### PR TITLE
Better installation testing library on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ env: PATH=/home/travis/gopath/bin:$PATH
 install:
 - go get github.com/mitchellh/gox
 - gox -build-toolchain -osarch=linux/386
-- go get github.com/stretchr/testify/assert
-- go get github.com/erikstmartin/go-testdb
-- go get -d -v ./... && go build -v ./...
+- go get -t -v ./... && go build -v ./...
 - sudo apt-get update
 - DEBIAN_FRONTEND=noninteractive sudo apt-get install -y rpm devscripts debhelper
 - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}


### PR DESCRIPTION
It is better way to use `go get -t` to install testing module.
