### PR TITLE
Do not use 'mysql' database

### DIFF
--- a/mackerel-plugin-mysql/mysql.go
+++ b/mackerel-plugin-mysql/mysql.go
@@ -116,7 +116,7 @@ type MySQLPlugin struct {
 }
 
 func (m MySQLPlugin) FetchMetrics() (map[string]float64, error) {
-	db := mysql.New("tcp", "", m.Target, m.Username, m.Password, "mysql")
+	db := mysql.New("tcp", "", m.Target, m.Username, m.Password, "")
 	err := db.Connect()
 	if err != nil {
 		log.Fatalln("FetchMetrics: ", err)


### PR DESCRIPTION
This plugin works without privileges on 'mysql' database.
