### PR TITLE
jvm plugin -pidfile option jstat failed

### DIFF
--- a/mackerel-plugin-jvm/jvm.go
+++ b/mackerel-plugin-jvm/jvm.go
@@ -210,7 +210,7 @@ func main() {
 			logger.Errorf("Failed to load pid. %s", err)
 			os.Exit(1)
 		}
-		jvm.Lvmid = string(pid)
+		jvm.Lvmid = strings.Replace(string(pid), "\n", "", 1)
 	}
 
 	jvm.JavaName = *optJavaName


### PR DESCRIPTION
![2015-02-18 10 02 17](https://cloud.githubusercontent.com/assets/4530978/6240968/592834f8-b759-11e4-8f49-412e0a4b7302.png)

```
pid, err := ioutil.ReadFile(*optPidFile)
// pid : 20745\n
// pid_length : 6
```
use ReadFile case, pid contain "\n".
it replace to "" -> succeeded