### PR TITLE
apache2: Add a 'header' parameter to cli flags

### DIFF
--- a/mackerel-plugin-apache2/apache2_test.go
+++ b/mackerel-plugin-apache2/apache2_test.go
@@ -77,7 +77,7 @@ Scoreboard: W_.__...........................`
 	host := found[2]
 	port, _ := strconv.Atoi(found[3])
 	path := found[4]
-	header := []string{"x-text-header: test"}
+	header := []string{fmt.Sprintf("Host: %s", found[2]), "X-Text-Header: test"}
 
 	ret, err := getApache2Metrics(host, uint16(port), path, header)
 	assert.Nil(t, err)

--- a/mackerel-plugin-apache2/apache2_test.go
+++ b/mackerel-plugin-apache2/apache2_test.go
@@ -77,8 +77,9 @@ Scoreboard: W_.__...........................`
 	host := found[2]
 	port, _ := strconv.Atoi(found[3])
 	path := found[4]
+	header := []string{"x-text-header: test"}
 
-	ret, err := getApache2Metrics(host, uint16(port), path)
+	ret, err := getApache2Metrics(host, uint16(port), path, header)
 	assert.Nil(t, err)
 	assert.NotNil(t, ret)
 	assert.NotEmpty(t, ret)

--- a/mackerel-plugin-apache2/flags.go
+++ b/mackerel-plugin-apache2/flags.go
@@ -7,6 +7,7 @@ import (
 var Flags = []cli.Flag{
 	cliHttpHost,
 	cliHttpPort,
+	cliHeader,
 	cliStatusPage,
 	cliTempFile,
 }
@@ -23,6 +24,13 @@ var cliHttpPort = cli.IntFlag{
 	Value:  80,
 	Usage:  "Set apache2 listeing port.",
 	EnvVar: "ENVVAR_HTTP_PORT",
+}
+
+var cliHeader = cli.StringSliceFlag{
+	Name:  "header, H",
+	Value: &cli.StringSlice{},
+	Usage: "Set http header. (e.g. \"Host: servername\")",
+	EnvVar: "ENVVAR_HEADER",
 }
 
 var cliStatusPage = cli.StringFlag{


### PR DESCRIPTION
I have changed the mackerel-plugin-apache2, to be able to set the any header at HTTP request.