### PR TITLE
Add td-table-count plugin

### DIFF
--- a/mackerel-plugin-td-table-count/README.md
+++ b/mackerel-plugin-td-table-count/README.md
@@ -1,0 +1,21 @@
+mackerel-plugin-td-table-count
+=====================
+
+Treasure Data Table Count custom metrics plugin for mackerel-agent.
+
+## Usage
+
+```shell
+mackerel-plugin-td-table-count -api-key=<Master API Key> -database=<Database Name>
+```
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.td-table-count]
+command = "/path/to/mackerel-plugin-td-table-count -api-key=<Master API Key> -database=<Database Name>"
+```
+
+## Author
+
+[Takuya Arita](https://github.com/ariarijp)

--- a/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
+++ b/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+
+	mp "github.com/mackerelio/go-mackerel-plugin"
+	"github.com/mackerelio/mackerel-agent/logging"
+	td "github.com/mattn/go-treasuredata"
+)
+
+var logger = logging.GetLogger("metrics.plugin.td-table")
+
+var tableNames = []string{}
+
+type TDTablePlugin struct {
+	ApiKey           string
+	Database         string
+	IgnoreTableNames []string
+	Tempfile         string
+}
+
+func (m TDTablePlugin) FetchMetrics() (map[string]float64, error) {
+	stat := make(map[string]float64)
+	cli := td.NewClient(m.ApiKey)
+
+	tables, err := cli.TableList(m.Database)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, table := range tables {
+		ignore := false
+		for _, ignoreTableName := range m.IgnoreTableNames {
+			if table.Name == ignoreTableName {
+				ignore = true
+			}
+		}
+
+		if ignore == false {
+			stat[table.Name] = float64(table.Count)
+			tableNames = append(tableNames, table.Name)
+		}
+	}
+
+	return stat, nil
+}
+
+func (m TDTablePlugin) GraphDefinition() map[string](mp.Graphs) {
+	metrics := []mp.Metrics{}
+	for _, tableName := range tableNames {
+		metrics = append(metrics, mp.Metrics{
+			Name: tableName,
+			Diff: false,
+		})
+	}
+
+	return map[string](mp.Graphs){
+		"td.count": mp.Graphs{
+			Label:   "TD Number of rows",
+			Unit:    "float",
+			Metrics: metrics,
+		},
+	}
+}
+
+func main() {
+	optApiKey := flag.String("api-key", "", "API Key")
+	optDatabase := flag.String("database", "", "Database name")
+	optIgnoreTableNames := flag.String("ignore-table", "", "Ignore Table name (Can be Comma-Separated)")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	flag.Parse()
+
+	var plugin TDTablePlugin
+	plugin.ApiKey = *optApiKey
+	plugin.Database = *optDatabase
+
+	ignoreTableNames := []string{}
+	if *optIgnoreTableNames != "" {
+		ignoreTableNames = strings.Split(*optIgnoreTableNames, ",")
+	}
+	plugin.IgnoreTableNames = ignoreTableNames
+
+	helper := mp.NewMackerelPlugin(plugin)
+
+	if *optTempfile != "" {
+		helper.Tempfile = *optTempfile
+	} else {
+		helper.Tempfile = "/tmp/mackerel-plugin-td-table"
+	}
+
+	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
+		helper.OutputDefinitions()
+	} else {
+		helper.OutputValues()
+	}
+}

--- a/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
+++ b/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
@@ -79,7 +79,7 @@ func (m TDTablePlugin) GraphDefinition() map[string](mp.Graphs) {
 	}
 
 	graphdef := map[string](mp.Graphs){
-		fmt.Sprintf("td.count_%s", m.Database): graph,
+		fmt.Sprintf("td-table.%s", m.Database): graph,
 	}
 
 	return graphdef

--- a/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
+++ b/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 
@@ -72,13 +73,13 @@ func (m TDTablePlugin) GraphDefinition() map[string](mp.Graphs) {
 	}
 
 	graph := mp.Graphs{
-		Label:   "TD Number of rows",
+		Label:   fmt.Sprintf("TD %s Database Number of rows", m.Database),
 		Unit:    "integer",
 		Metrics: metrics,
 	}
 
 	graphdef := map[string](mp.Graphs){
-		"td.count": graph,
+		fmt.Sprintf("td.count_%s", m.Database): graph,
 	}
 
 	return graphdef


### PR DESCRIPTION
I'm afraid, I didn't write its tests.

Here is the output of this plugin.

```
./mackerel-plugin-td-table-count  -api-key="APIKEY" -database=DATABASE
td-table.[DATABASE].[TABLE]	122398	1429198003
td-table.[DATABASE].[TABLE]	105620	1429198003
td-table.[DATABASE].[TABLE]	216821	1429198003
td-table.[DATABASE].[TABLE]	127983	1429198003
td-table.[DATABASE].[TABLE]	187870	1429198003
td-table.[DATABASE].[TABLE]	21901	1429198003
td-table.[DATABASE].[TABLE]	23555	1429198003
td-table.[DATABASE].[TABLE]	23765	1429198003
td-table.[DATABASE].[TABLE]	12597	1429198003
```