### PR TITLE
additional help for nginx SSL sites

### DIFF
--- a/mackerel-plugin-nginx/README.md
+++ b/mackerel-plugin-nginx/README.md
@@ -6,7 +6,7 @@ Nginx custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-nginx [-host=<host>] [-port=<port>] [-path=<path>] [-tempfile=<tempfile>]
+mackerel-plugin-nginx [-scheme=<'http'|'https'>] [-host=<host>] [-port=<port>] [-path=<path>] [-tempfile=<tempfile>]
 ```
 
 ## Requirements


### PR DESCRIPTION
If "scheme" flag is working, which I think is, it should be mentioned in the readme.  Users may end up only setting the port and give up.