### PR TITLE
Can specify database name option when postgresql does not has a database with the same name as the user name.

### DIFF
--- a/mackerel-plugin-postgres/README.md
+++ b/mackerel-plugin-postgres/README.md
@@ -6,14 +6,15 @@ PostgreSQL custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-postgres -user=<username> -password=<password>
+mackerel-plugin-postgres -user=<username> -password=<password> -database=<databasename>
 ```
+`-database` is optional.
 
 ## Example of mackerel-agent.conf
 
 ```
 [plugin.metrics.postgres]
-command = "/path/to/mackerel-plugin-postgres -user=test -password=secret"
+command = "/path/to/mackerel-plugin-postgres -user=test -password=secret -database=databasename"
 ```
 
 ## References

--- a/mackerel-plugin-postgres/postgres.go
+++ b/mackerel-plugin-postgres/postgres.go
@@ -88,6 +88,7 @@ type PostgresPlugin struct {
 	SSLmode  string
 	Timeout  int
 	Tempfile string
+        Option   string
 }
 
 func FetchStatDatabase(db *sql.DB) (map[string]float64, error) {
@@ -186,7 +187,7 @@ func mergeStat(dst, src map[string]float64) {
 }
 
 func (p PostgresPlugin) FetchMetrics() (map[string]float64, error) {
-	db, err := sql.Open("postgres", fmt.Sprintf("user=%s password=%s host=%s port=%s sslmode=%s connect_timeout=%d", p.Username, p.Password, p.Host, p.Port, p.SSLmode, p.Timeout))
+	db, err := sql.Open("postgres", fmt.Sprintf("user=%s password=%s host=%s port=%s sslmode=%s connect_timeout=%d %s", p.Username, p.Password, p.Host, p.Port, p.SSLmode, p.Timeout, p.Option))
 	if err != nil {
 		logger.Errorf("FetchMetrics: ", err)
 		return nil, err
@@ -222,6 +223,7 @@ func main() {
 	optHost := flag.String("hostname", "localhost", "Hostname to login to")
 	optPort := flag.String("port", "5432", "Database port")
 	optUser := flag.String("user", "", "Postgres User")
+        optDatabase := flag.String("database", "", "Database name")
 	optPass := flag.String("password", "", "Postgres Password")
 	optSSLmode := flag.String("sslmode", "disable", "Whether or not to use SSL")
 	optConnectTimeout := flag.Int("connect_timeout", 5, "Maximum wait for connection, in seconds.")
@@ -238,6 +240,10 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
+        option := ""
+        if *optDatabase != "" {
+		option = fmt.Sprintf("dbname=%s", *optDatabase)
+        }
 
 	var postgres PostgresPlugin
 	postgres.Host = *optHost
@@ -246,6 +252,8 @@ func main() {
 	postgres.Password = *optPass
 	postgres.SSLmode = *optSSLmode
 	postgres.Timeout = *optConnectTimeout
+	postgres.Option = option
+
 
 	helper := mp.NewMackerelPlugin(postgres)
 


### PR DESCRIPTION
lib/pq uses username for database name when connect to database if database name does not specify.
So mackerel-plugin-postgres cannnot connect to database  if Postgresql does not has a database with the same name as the user name, As the following error.

```
$ /usr/local/bin/mackerel-plugin-postgres -password=*** -user=+++++
2015/06/25 16:04:30 ERROR <metrics.plugin.postgres> Failed to select pg_stat_database. pq: database "+++++" does not exist
2015/06/25 16:04:30 OutputValues:  pq: database "+++++" does not exist
```
I added a argument option for specfy database, then this plugin became able to connect a database.

thanks



