### PR TITLE
Release version 0.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ deploy:
   api_key:
     secure: c2pLKkM2leWMIzakVisNf3kAK6TBYslDM8SFEVrTTHpHnTI/6jUFnDLuL9cKuq9c76QcgYfqdLDn/hP+uFHf5WdtdJR00R+bX8cCx6NfOe7Kk9GlqGinUcXKAVs0kQHaYtQrN/rCOIG92kYFdbRHMD8uMrADJVRySePTMMhMX9o=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.9.2-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.9.2-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.9.3-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.9.3-1_all.deb"
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent-plugins

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Detailed specification of plugin can be shown at [mackerel-agent specification](
 Document of each plugin is located under each sub directory.
 
 * [mackerel-plugin-apache2](./mackerel-plugin-apache2/README.md)
+* [mackerel-plugin-aws-cloudfront](./mackerel-plugin-aws-cloudfront/README.md)
 * [mackerel-plugin-aws-ec2-cpucredit](./mackerel-plugin-aws-ec2-cpucredit/README.md)
 * [mackerel-plugin-aws-elasticache](./mackerel-plugin-aws-elasticache/README.md)
 * [mackerel-plugin-aws-elb](./mackerel-plugin-aws-elb/README.md)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent-plugins (0.9.3-1) stable; urgency=low
+
+  * Can specify database name option when postgresql does not has a database with the same name as the user name. (by azusa)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/97>
+  * Add mackerel-plugin-aws-cloudfront (by najeira)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/98>
+
+ -- Tomohiro Nishimura <tomohiro68@gmail.com>  Wed, 08 Jul 2015 11:27:00 +0900
+
 mackerel-agent-plugins (0.9.2-1) stable; urgency=low
 
   * elasticsearch: add memory size used by lucene segments, which were exposed in Elasticsearch 1.4 (by yshh)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -8,7 +8,7 @@
 
 Summary: Monitoring program plugins for Mackerel
 Name: mackerel-agent-plugins
-Version: 0.9.2
+Version: 0.9.3
 Release: %{revision}
 License: Apache-2
 Group: Applications/System

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -41,6 +41,10 @@ done
 %{__targetdir}
 
 %changelog
+* Wed Jul 08 2015 <tomohiro68@gmail.com> - 0.9.3
+- Can specify database name option when postgresql does not has a database with the same name as the user name. (by azusa)
+- Add mackerel-plugin-aws-cloudfront (by najeira)
+
 * Wed Jun 17 2015 <tomohiro68@gmail.com> - 0.9.2
 - elasticsearch: add memory size used by lucene segments, which were exposed in Elasticsearch 1.4 (by yshh)
 - mysql: better error handling (by stanaka)


### PR DESCRIPTION
- Can specify database name option when postgresql does not has a database with the same name as the user name. #97
- Add mackerel-plugin-aws-cloudfront #98