### PR TITLE
fix tiny typo

### DIFF
--- a/mackerel-plugin-redis/README.md
+++ b/mackerel-plugin-redis/README.md
@@ -6,7 +6,7 @@ Redis custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-redis [-hostname=<hostname>] [-port=<port>] [-timeout=<time>]
+mackerel-plugin-redis [-host=<hostname>] [-port=<port>] [-timeout=<time>]
 ```
 
 ## Example of mackerel-agent.conf


### PR DESCRIPTION
This is a tiny fix for README.md of Redis plugin. According to following line, you write `-host` option. However you write `-hostname` in README.md. `-host` is correct description.

https://github.com/mackerelio/mackerel-agent-plugins/blob/master/mackerel-plugin-redis/redis.go#L152