### PR TITLE
use new helper

### DIFF
--- a/mackerel-plugin-memcached/memcached_test.go
+++ b/mackerel-plugin-memcached/memcached_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphDefinition(t *testing.T) {
+	var memcached MemcachedPlugin
+
+	graphdef := memcached.GraphDefinition()
+	if len(graphdef) != 7 {
+		t.Errorf("GetTempfilename: %d should be 3", len(graphdef))
+	}
+}
+
+func TestParse(t *testing.T) {
+	var memcached MemcachedPlugin
+	stub := `STAT pid 1994
+STAT uptime 92066123
+STAT time 1436890963
+STAT version 1.4.0
+STAT pointer_size 64
+STAT rusage_user 1393.803107
+STAT rusage_system 2947.180187
+STAT curr_connections 1003
+STAT total_connections 965032539
+STAT connection_structures 16388
+STAT cmd_get 4306259844
+STAT cmd_set 2423543841
+STAT cmd_flush 0
+STAT get_hits 2769383483
+STAT get_misses 1536876361
+STAT delete_misses 244469885
+STAT delete_hits 14456835
+STAT incr_misses 0
+STAT incr_hits 0
+STAT decr_misses 0
+STAT decr_hits 0
+STAT cas_misses 0
+STAT cas_hits 0
+STAT cas_badval 0
+STAT bytes_read 8328670869009
+STAT bytes_written 9151962263382
+STAT limit_maxbytes 2147483648
+STAT accepting_conns 1
+STAT listen_disabled_num 0
+STAT threads 5
+STAT conn_yields 1487476
+STAT bytes 621371972
+STAT curr_items 955652
+STAT total_items 2423543841
+STAT evictions 236677775
+END
+`
+
+	memcachedStats := bytes.NewBufferString(stub)
+
+	stat, err := memcached.ParseStats(memcachedStats)
+	fmt.Println(stat)
+	assert.Nil(t, err)
+	// Memcached Stats
+	assert.EqualValues(t, reflect.TypeOf(stat["get_hits"]).String(), "string")
+	assert.EqualValues(t, stat["get_hits"].(string), "2769383483")
+}

--- a/mackerel-plugin-mysql/mysql.go
+++ b/mackerel-plugin-mysql/mysql.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	mp "github.com/mackerelio/go-mackerel-plugin"
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 	"github.com/ziutek/mymysql/mysql"
 	_ "github.com/ziutek/mymysql/native"
 )
@@ -18,16 +18,16 @@ var graphdef map[string](mp.Graphs) = map[string](mp.Graphs){
 		Label: "MySQL Command",
 		Unit:  "float",
 		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "Com_insert", Label: "Insert", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Com_select", Label: "Select", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Com_update", Label: "Update", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Com_update_multi", Label: "Update Multi", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Com_delete", Label: "Delete", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Com_delete_multi", Label: "Delete Multi", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Com_replace", Label: "Replace", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Com_set_option", Label: "Set Option", Diff: true, Stacked: true},
-			mp.Metrics{Name: "Qcache_hits", Label: "Query Cache Hits", Diff: true, Stacked: false},
-			mp.Metrics{Name: "Questions", Label: "Questions", Diff: true, Stacked: false},
+			mp.Metrics{Name: "Com_insert", Label: "Insert", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Com_select", Label: "Select", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Com_update", Label: "Update", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Com_update_multi", Label: "Update Multi", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Com_delete", Label: "Delete", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Com_delete_multi", Label: "Delete Multi", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Com_replace", Label: "Replace", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Com_set_option", Label: "Set Option", Diff: true, Stacked: true, Type: "uint64"},
+			mp.Metrics{Name: "Qcache_hits", Label: "Query Cache Hits", Diff: true, Stacked: false, Type: "uint64"},
+			mp.Metrics{Name: "Questions", Label: "Questions", Diff: true, Stacked: false, Type: "uint64"},
 		},
 	},
 	"mysql.join": mp.Graphs{
@@ -168,7 +168,7 @@ func (m MySQLPlugin) FetchShowSlaveStatus(db mysql.Conn, stat map[string]float64
 	return nil
 }
 
-func (m MySQLPlugin) FetchMetrics() (map[string]float64, error) {
+func (m MySQLPlugin) FetchMetrics() (map[string]interface{}, error) {
 	db := mysql.New("tcp", "", m.Target, m.Username, m.Password, "")
 	err := db.Connect()
 	if err != nil {
@@ -187,7 +187,12 @@ func (m MySQLPlugin) FetchMetrics() (map[string]float64, error) {
 
 	m.FetchShowSlaveStatus(db, stat)
 
-	return stat, err
+	statRet := make(map[string]interface{})
+	for key, value := range stat {
+		statRet[key] = value
+	}
+
+	return statRet, err
 }
 
 func (m MySQLPlugin) GraphDefinition() map[string](mp.Graphs) {

--- a/mackerel-plugin-nginx/nginx.go
+++ b/mackerel-plugin-nginx/nginx.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	mp "github.com/mackerelio/go-mackerel-plugin"
+	"io"
+
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 	//"io/ioutil"
 	"errors"
 	"net/http"
@@ -64,7 +66,7 @@ type NginxPlugin struct {
 //  1693613501 1693613501 7996986318
 // Reading: 66 Writing: 16 Waiting: 41
 
-func (n NginxPlugin) FetchMetrics() (map[string]float64, error) {
+func (n NginxPlugin) FetchMetrics() (map[string]interface{}, error) {
 	req, err := http.NewRequest("GET", n.Uri, nil)
 	if err != nil {
 		return nil, err
@@ -88,9 +90,13 @@ func (n NginxPlugin) FetchMetrics() (map[string]float64, error) {
 	}
 	defer resp.Body.Close()
 
-	stat := make(map[string]float64)
+	return n.ParseStats(resp.Body)
+}
 
-	r := bufio.NewReader(resp.Body)
+func (n NginxPlugin) ParseStats(body io.Reader) (map[string]interface{}, error) {
+	stat := make(map[string]interface{})
+
+	r := bufio.NewReader(body)
 	line, _, err := r.ReadLine()
 	if err != nil {
 		return nil, errors.New("cannot get values")

--- a/mackerel-plugin-nginx/nginx_test.go
+++ b/mackerel-plugin-nginx/nginx_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphDefinition(t *testing.T) {
+	var nginx NginxPlugin
+
+	graphdef := nginx.GraphDefinition()
+	if len(graphdef) != 3 {
+		t.Errorf("GetTempfilename: %d should be 3", len(graphdef))
+	}
+}
+
+func TestParse(t *testing.T) {
+	var nginx NginxPlugin
+	stub := `Active connections: 123
+server accepts handled requests
+ 1693613501 1693613501 7996986318
+Reading: 66 Writing: 16 Waiting: 41
+`
+
+	nginxStats := bytes.NewBufferString(stub)
+
+	stat, err := nginx.ParseStats(nginxStats)
+	fmt.Println(stat)
+	assert.Nil(t, err)
+	assert.EqualValues(t, reflect.TypeOf(stat["writing"]).String(), "float64")
+	assert.EqualValues(t, stat["writing"], 16)
+	assert.EqualValues(t, reflect.TypeOf(stat["accepts"]).String(), "float64")
+	assert.EqualValues(t, stat["accepts"], 1693613501)
+}

--- a/mackerel-plugin-plack/plack.go
+++ b/mackerel-plugin-plack/plack.go
@@ -123,12 +123,12 @@ func (p PlackPlugin) ParseStats(body io.Reader) (map[string]interface{}, error) 
 		return nil, errors.New("cannot get values")
 	}
 
-	stat["requests"], err = strconv.ParseFloat(s.TotalAccesses, 64)
+	stat["requests"], err = strconv.ParseUint(s.TotalAccesses, 10, 64)
 	if err != nil {
 		return nil, errors.New("cannot get values")
 	}
 
-	stat["bytes_sent"], err = strconv.ParseFloat(s.TotalKbytes, 64)
+	stat["bytes_sent"], err = strconv.ParseUint(s.TotalKbytes, 10, 64)
 	if err != nil {
 		return nil, errors.New("cannot get values")
 	}

--- a/mackerel-plugin-plack/plack.go
+++ b/mackerel-plugin-plack/plack.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -99,11 +100,15 @@ func (p PlackPlugin) FetchMetrics() (map[string]interface{}, error) {
 	}
 	defer resp.Body.Close()
 
+	return p.ParseStats(resp.Body)
+}
+
+func (p PlackPlugin) ParseStats(body io.Reader) (map[string]interface{}, error) {
 	stat := make(map[string]interface{})
-	decoder := json.NewDecoder(resp.Body)
+	decoder := json.NewDecoder(body)
 
 	var s PlackServerStatus
-	err = decoder.Decode(&s)
+	err := decoder.Decode(&s)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-plack/plack_test.go
+++ b/mackerel-plugin-plack/plack_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphDefinition(t *testing.T) {
+	var plack PlackPlugin
+
+	graphdef := plack.GraphDefinition()
+	if len(graphdef) != 3 {
+		t.Errorf("GetTempfilename: %d should be 3", len(graphdef))
+	}
+}
+
+func TestParse(t *testing.T) {
+	var plack PlackPlugin
+	stub := `{
+  "Uptime": "1410520211",
+  "TotalAccesses": "2",
+  "IdleWorkers": "2",
+  "TotalKbytes": "5",
+  "BusyWorkers": "1",
+  "stats": [
+    {
+      "pid": 11062,
+      "method": "GET",
+      "ss": 51,
+      "remote_addr": "127.0.0.1",
+      "host": "localhost:8000",
+      "protocol": "HTTP/1.1",
+      "status": "_",
+      "uri": "/server-status?json"
+    },
+    {
+      "ss": 41,
+      "remote_addr": "127.0.0.1",
+      "host": "localhost:8000",
+      "protocol": "HTTP/1.1",
+      "pid": 11063,
+      "method": "GET",
+      "status": "_",
+      "uri": "/server-status?json"
+    },
+    {
+      "ss": 0,
+      "remote_addr": "127.0.0.1",
+      "host": "localhost:8000",
+      "protocol": "HTTP/1.1",
+      "pid": 11064,
+      "method": "GET",
+      "status": "A",
+      "uri": "/server-status?json"
+    }
+  ]
+}
+`
+
+	plackStats := bytes.NewBufferString(stub)
+
+	stat, err := plack.ParseStats(plackStats)
+	fmt.Println(stat)
+	assert.Nil(t, err)
+	assert.EqualValues(t, reflect.TypeOf(stat["requests"]).String(), "float64")
+	assert.EqualValues(t, stat["requests"], 2.0)
+	assert.EqualValues(t, reflect.TypeOf(stat["bytes_sent"]).String(), "float64")
+	assert.EqualValues(t, stat["bytes_sent"], 5.0)
+}

--- a/mackerel-plugin-plack/plack_test.go
+++ b/mackerel-plugin-plack/plack_test.go
@@ -66,8 +66,8 @@ func TestParse(t *testing.T) {
 	stat, err := plack.ParseStats(plackStats)
 	fmt.Println(stat)
 	assert.Nil(t, err)
-	assert.EqualValues(t, reflect.TypeOf(stat["requests"]).String(), "float64")
-	assert.EqualValues(t, stat["requests"], 2.0)
-	assert.EqualValues(t, reflect.TypeOf(stat["bytes_sent"]).String(), "float64")
-	assert.EqualValues(t, stat["bytes_sent"], 5.0)
+	assert.EqualValues(t, reflect.TypeOf(stat["requests"]).String(), "uint64")
+	assert.EqualValues(t, stat["requests"], 2)
+	assert.EqualValues(t, reflect.TypeOf(stat["bytes_sent"]).String(), "uint64")
+	assert.EqualValues(t, stat["bytes_sent"], 5)
 }


### PR DESCRIPTION
The new helper https://github.com/mackerelio/go-mackerel-plugin-helper works well with uint64 counter especially in the case of counter overflow and counter reset.
With this pull request, plugins prevent to post a negative value for uint64 counter, 