### PR TITLE
Release version 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ deploy:
   api_key:
     secure: c2pLKkM2leWMIzakVisNf3kAK6TBYslDM8SFEVrTTHpHnTI/6jUFnDLuL9cKuq9c76QcgYfqdLDn/hP+uFHf5WdtdJR00R+bX8cCx6NfOe7Kk9GlqGinUcXKAVs0kQHaYtQrN/rCOIG92kYFdbRHMD8uMrADJVRySePTMMhMX9o=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.10.0-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.10.0-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.11.0-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.11.0-1_all.deb"
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent-plugins

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent-plugins (0.11.0-1) stable; urgency=low
+
+  * [redis] support multiple redis instances on one server by using -metric-key-prefix option (by xorphitus)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/96>
+  * [Redis] fix tiny documentation typo (by hiroakis)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/101>
+  * [memcached/mysql/nginx/plack] care counter overflow and reset by using new helper. (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/102>
+  * [MySQL] Fix typo of metric name s/Thread_created/Threads_created/ (by yuuki1)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/103>
+  * [Redis] Support -socket option to specify unix socket (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/104>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 29 Jul 2015 14:39:16 +0900
+
 mackerel-agent-plugins (0.10.0-1) stable; urgency=low
 
   * Can specify database name option when postgresql does not has a database with the same name as the user name. (by azusa)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -41,6 +41,13 @@ done
 %{__targetdir}
 
 %changelog
+* Wed Jul 29 2015 <y.songmu@gmail.com> - 0.11.0
+- [redis] support multiple redis instances on one server by using -metric-key-prefix option (by xorphitus)
+- [Redis] fix tiny documentation typo (by hiroakis)
+- [memcached/mysql/nginx/plack] care counter overflow and reset by using new helper. (by stanaka)
+- [MySQL] Fix typo of metric name s/Thread_created/Threads_created/ (by yuuki1)
+- [Redis] Support -socket option to specify unix socket (by Songmu)
+
 * Wed Jul 08 2015 <tomohiro68@gmail.com> - 0.10.0
 - Can specify database name option when postgresql does not has a database with the same name as the user name. (by azusa)
 - Add mackerel-plugin-aws-cloudfront (by najeira)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -8,7 +8,7 @@
 
 Summary: Monitoring program plugins for Mackerel
 Name: mackerel-agent-plugins
-Version: 0.10.0
+Version: 0.11.0
 Release: %{revision}
 License: Apache-2
 Group: Applications/System


### PR DESCRIPTION
- [redis] support multiple redis instances on one server by using -metric-key-prefix option #96
- [Redis] fix tiny documentation typo #101
- [memcached/mysql/nginx/plack] care counter overflow and reset by using new helper. #102
- [MySQL] Fix typo of metric name s/Thread_created/Threads_created/ #103
- [Redis] Support -socket option to specify unix socket #104