### PR TITLE
[AWS-*] Fix typo s/secret-access-key==/secret-access-key=/

### DIFF
--- a/mackerel-plugin-aws-cloudfront/README.md
+++ b/mackerel-plugin-aws-cloudfront/README.md
@@ -6,7 +6,7 @@ AWS CloudFront custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-cloudfront -identifier=<cloudfront-distribution-id> [-access-key-id=<id>] [-secret-access-key==<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-cloudfront -identifier=<cloudfront-distribution-id> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
 
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`

--- a/mackerel-plugin-aws-ec2-cpucredit/README.md
+++ b/mackerel-plugin-aws-ec2-cpucredit/README.md
@@ -6,7 +6,7 @@ AWS EC2 CPU-Credit custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-ec2-cpucredit [-instance-id=<id>] [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key==<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-ec2-cpucredit [-instance-id=<id>] [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
 * if you run on an ec2-instance, you probably don't have to specify `-instance-id` & `-region`
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`

--- a/mackerel-plugin-aws-elb/README.md
+++ b/mackerel-plugin-aws-elb/README.md
@@ -7,7 +7,7 @@ As it stands, this can fetch only across-all-LBs metrics.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-elb [-lbname=<aws-load-blancer-name>] [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key==<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-elb [-lbname=<aws-load-blancer-name>] [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
 * if you run on an ec2-instance, you probably don't have to specify `-region`
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`

--- a/mackerel-plugin-aws-rds/README.md
+++ b/mackerel-plugin-aws-rds/README.md
@@ -6,7 +6,7 @@ AWS RDS custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-rds -identifier=<db-instance-identifer> [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key==<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-rds -identifier=<db-instance-identifer> [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
 * if you run on an ec2-instance, you probably don't have to specify `-region`
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`

--- a/mackerel-plugin-aws-ses/README.md
+++ b/mackerel-plugin-aws-ses/README.md
@@ -6,7 +6,7 @@ AWS SES custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-ses -endpoint=<SES Endpoint URL> [-access-key-id=<id>] [-secret-access-key==<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-ses -endpoint=<SES Endpoint URL> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
 * SES Endpoint URL should be like "https://email.#{AWS_REGION}.amazonaws.com" (starting with "https://"). see "API (HTTPS) endpoint" column of http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`


### PR DESCRIPTION
I found unnecessary `=` of `secret-access-key==` in aws-* plugin's README.
I removed those `=` by the following.

```sh
$ pt -l --nogroup --nocolor "==<" | xargs sed -i '' 's/==</=</g'
```