### PR TITLE
remove Config field from FluentPluginMetrics

### DIFF
--- a/mackerel-plugin-fluentd/fluentd.go
+++ b/mackerel-plugin-fluentd/fluentd.go
@@ -20,14 +20,13 @@ type FluentdMetrics struct {
 }
 
 type FluentdPluginMetrics struct {
-	RetryCount            uint64            `json:"retry_count"`
-	BufferQueueLength     uint64            `json:"buffer_queue_length"`
-	BufferTotalQueuedSize uint64            `json:"buffer_total_queued_size"`
-	OutputPlugin          bool              `json:"output_plugin"`
-	Config                map[string]string `json:"config"`
-	Type                  string            `json:"type"`
-	PluginCategory        string            `json:"plugin_category"`
-	PluginID              string            `json:"plugin_id"`
+	RetryCount            uint64 `json:"retry_count"`
+	BufferQueueLength     uint64 `json:"buffer_queue_length"`
+	BufferTotalQueuedSize uint64 `json:"buffer_total_queued_size"`
+	OutputPlugin          bool   `json:"output_plugin"`
+	Type                  string `json:"type"`
+	PluginCategory        string `json:"plugin_category"`
+	PluginID              string `json:"plugin_id"`
 	PluginIDModified      string
 }
 

--- a/mackerel-plugin-fluentd/fluentd_test.go
+++ b/mackerel-plugin-fluentd/fluentd_test.go
@@ -31,7 +31,7 @@ func TestNormalizePluginID(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	var fluentd FluentdMetrics
-	stub := `{"plugins":[{"plugin_id":"object:3feb368cfad0","plugin_category":"output","type":"mackerel","config":{"type":"mackerel","api_key":"aaa","service":"foo","metrics_name":"${[1]}-bar.${out_key}","remove_prefix":"","out_keys":"Latency"},"output_plugin":true,"buffer_queue_length":0,"buffer_total_queued_size":53,"retry_count":0}]}`
+	stub := `{"plugins":[{"plugin_id":"object:3feb368cfad0","plugin_category":"output","type":"mackerel","config":{"type":"mackerel","api_key":"aaa","service":"foo","metrics_name":"${[1]}-bar.${out_key}","remove_prefix":"","out_keys":"Latency","localtime":true},"output_plugin":true,"buffer_queue_length":0,"buffer_total_queued_size":53,"retry_count":0}]}`
 
 	fluentdStats := []byte(stub)
 


### PR DESCRIPTION
The value of fluentd config is not always string. So I remove `Config` field from FluentPluginMetrics. This plugin works without `Config` field.

## e.g.

```javascript
"config": {
  "@type": "buffered_slack",
  "@id": "twitter_slack_output",
  "webhook_url": "https://hooks.slack.com/services/xxxxxxxxxxxxxxxxxxxx",
  "channel": "mackerel_social",
  "message": "%s: %s https://twitter.com/%s/status/%s",
  "message_keys": "user_screen_name,text,user_screen_name,id_str",
  "flush_interval": "1m",
  "time_format": "%H:%M:%S",
  "localtime": true, // <- here!
},
```

## error

```
$ mackerel-plugin-fluentd
2015/10/05 01:13:47 OutputValues:  json: cannot unmarshal bool into Go value of type string
```