### PR TITLE
support coreos and amazon linux for docker plugin

### DIFF
--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -205,8 +205,7 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 	for id, name := range dockerStats {
 		for metric, stats := range metrics {
-			ret, err := exists(pb.build(id, metric, "stat"))
-			if ret == false {
+			if ok, err := exists(pb.build(id, metric, "stat")); !ok || err != nil {
 				continue
 			}
 			data, err := getFile(pb.build(id, metric, "stat"))
@@ -224,8 +223,7 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 		// blkio statistics
 		for _, blkioType := range []string{"io_queued", "io_serviced", "io_service_bytes"} {
-			ret, err := exists(pb.build(id, "blkio", blkioType))
-			if ret == false {
+			if ok, err := exists(pb.build(id, "blkio", blkioType)); !ok || err != nil {
 				continue
 			}
 			data, err := getFile(pb.build(id, "blkio", blkioType))

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -231,7 +231,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 			}
 			data, err := getFile(pb.build(id, "blkio", blkioType))
 			if err != nil {
-				fmt.Println(err)
 				return nil, err
 			}
 			for _, stat := range []string{"Read", "Write", "Sync", "Async"} {

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -111,7 +111,7 @@ func (m DockerPlugin) getDockerPs() (string, error) {
 }
 
 func findPrefixPath() (string, error) {
-	pathCandidate := []string{"/host/sys/fs/cgroup", "/sys/fs/cgroup"}
+	pathCandidate := []string{"/host/cgroup/", "/cgroup", "/host/sys/fs/cgroup", "/sys/fs/cgroup"}
 	for _, path := range pathCandidate {
 		result, err := exists(path)
 		if err != nil {
@@ -205,6 +205,11 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 	for id, name := range dockerStats {
 		for metric, stats := range metrics {
+			//fmt.Println(pb.build(id, metric, "stat"))
+			ret, err := exists(pb.build(id, metric, "stat"))
+			if ret == false {
+				continue
+			}
 			data, err := getFile(pb.build(id, metric, "stat"))
 			if err != nil {
 				return nil, err
@@ -220,8 +225,13 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 		// blkio statistics
 		for _, blkioType := range []string{"io_queued", "io_serviced", "io_service_bytes"} {
+			ret, err := exists(pb.build(id, "blkio", blkioType))
+			if ret == false {
+				continue
+			}
 			data, err := getFile(pb.build(id, "blkio", blkioType))
 			if err != nil {
+				fmt.Println(err)
 				return nil, err
 			}
 			for _, stat := range []string{"Read", "Write", "Sync", "Async"} {

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -205,7 +205,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 	for id, name := range dockerStats {
 		for metric, stats := range metrics {
-			//fmt.Println(pb.build(id, metric, "stat"))
 			ret, err := exists(pb.build(id, metric, "stat"))
 			if ret == false {
 				continue
@@ -240,7 +239,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 				for _, m := range matchs {
 					if m != nil {
 						ret, _ := strconv.ParseFloat(m[1], 64)
-						//fmt.Println(ret)
 						v += ret
 					}
 				}
@@ -249,7 +247,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 		}
 
 	}
-	//fmt.Println(res)
 
 	return res, nil
 }


### PR DESCRIPTION
In Amazon Linux, the path of cgroups statistics should be `/cgroup`, and some blkio metrics do not exist.
In CoreOS, some blkio metrics are also missing.

This pull request add a path candidate for Amazon Linux and error handling of missing metrics.