### PR TITLE
Feature/key prefix for rds plugin

### DIFF
--- a/mackerel-plugin-aws-rds/README.md
+++ b/mackerel-plugin-aws-rds/README.md
@@ -6,10 +6,11 @@ AWS RDS custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-rds -identifier=<db-instance-identifer> [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-rds -identifier=<db-instance-identifer> [-use-identifier-as-prefix] [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
 * if you run on an ec2-instance, you probably don't have to specify `-region`
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`
+* With `-use-identifier-as-prefix`, identifier is used as key prefix. ex: rds.<db-instance-identifer>.Latency.ReadLatency
 
 ## AWS IAM Policy
 the credential provided manually or fetched automatically by IAM Role should have the policy that includes an action, 'cloudwatch:GetMetricStatistics'

--- a/mackerel-plugin-aws-rds/aws-rds.go
+++ b/mackerel-plugin-aws-rds/aws-rds.go
@@ -3,97 +3,22 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"time"
 
-	"github.com/crowdmob/goamz/aws"
-	"github.com/crowdmob/goamz/cloudwatch"
+	"github.com/AdRoll/goamz/aws"
+	"github.com/AdRoll/goamz/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
-
-var graphdef map[string](mp.Graphs) = map[string](mp.Graphs){
-	"rds.CPUUtilization": mp.Graphs{
-		Label: "RDS CPU Utilization",
-		Unit:  "percentage",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
-		},
-	},
-	"rds.DatabaseConnections": mp.Graphs{
-		Label: "RDS Database Connections",
-		Unit:  "float",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "DatabaseConnections", Label: "DatabaseConnections"},
-		},
-	},
-	"rds.FreeableMemory": mp.Graphs{
-		Label: "RDS Freeable Memory",
-		Unit:  "bytes",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "FreeableMemory", Label: "FreeableMemory"},
-		},
-	},
-	"rds.FreeStorageSpace": mp.Graphs{
-		Label: "RDS Free Storage Space",
-		Unit:  "bytes",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "FreeStorageSpace", Label: "FreeStorageSpace"},
-		},
-	},
-	"rds.ReplicaLag": mp.Graphs{
-		Label: "RDS Replica Lag",
-		Unit:  "float",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReplicaLag", Label: "ReplicaLag"},
-		},
-	},
-	"rds.SwapUsage": mp.Graphs{
-		Label: "RDS Swap Usage",
-		Unit:  "bytes",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "SwapUsage", Label: "SwapUsage"},
-		},
-	},
-	"rds.IOPS": mp.Graphs{
-		Label: "RDS IOPS",
-		Unit:  "iops",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReadIOPS", Label: "Read"},
-			mp.Metrics{Name: "WriteIOPS", Label: "Write"},
-		},
-	},
-	"rds.Latency": mp.Graphs{
-		Label: "RDS Latency in second",
-		Unit:  "float",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReadLatency", Label: "Read"},
-			mp.Metrics{Name: "WriteLatency", Label: "Write"},
-		},
-	},
-	"rds.Throughput": mp.Graphs{
-		Label: "RDS Throughput",
-		Unit:  "bytes/sec",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReadThroughput", Label: "Read"},
-			mp.Metrics{Name: "WriteThroughput", Label: "Write"},
-		},
-	},
-	"rds.NetworkThroughput": mp.Graphs{
-		Label: "RDS Network Throughput",
-		Unit:  "bytes/sec",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "NetworkTransmitThroughput", Label: "Transmit"},
-			mp.Metrics{Name: "NetworkReceiveThroughput", Label: "Receive"},
-		},
-	},
-}
 
 type RDSPlugin struct {
 	Region          string
 	AccessKeyId     string
 	SecretAccessKey string
 	Identifier      string
+	KeyPrefix       string
 }
 
 func GetLastPoint(cloudWatch *cloudwatch.CloudWatch, dimension *cloudwatch.Dimension, metricName string) (float64, error) {
@@ -166,14 +91,90 @@ func (p RDSPlugin) FetchMetrics() (map[string]float64, error) {
 }
 
 func (p RDSPlugin) GraphDefinition() map[string](mp.Graphs) {
-	return graphdef
+	return map[string](mp.Graphs){
+		fmt.Sprintf("%s.CPUUtilization", p.KeyPrefix): mp.Graphs{
+			Label: "RDS CPU Utilization",
+			Unit:  "percentage",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
+			},
+		},
+		fmt.Sprintf("%s.DatabaseConnections", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Database Connections",
+			Unit:  "float",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "DatabaseConnections", Label: "DatabaseConnections"},
+			},
+		},
+		fmt.Sprintf("%s.FreeableMemory", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Freeable Memory",
+			Unit:  "bytes",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "FreeableMemory", Label: "FreeableMemory"},
+			},
+		},
+		fmt.Sprintf("%s.FreeStorageSpace", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Free Storage Space",
+			Unit:  "bytes",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "FreeStorageSpace", Label: "FreeStorageSpace"},
+			},
+		},
+		fmt.Sprintf("%s.ReplicaLag", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Replica Lag",
+			Unit:  "float",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReplicaLag", Label: "ReplicaLag"},
+			},
+		},
+		fmt.Sprintf("%s.SwapUsage", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Swap Usage",
+			Unit:  "bytes",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "SwapUsage", Label: "SwapUsage"},
+			},
+		},
+		fmt.Sprintf("%s.IOPS", p.KeyPrefix): mp.Graphs{
+			Label: "RDS IOPS",
+			Unit:  "iops",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReadIOPS", Label: "Read"},
+				mp.Metrics{Name: "WriteIOPS", Label: "Write"},
+			},
+		},
+		fmt.Sprintf("%s.Latency", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Latency in second",
+			Unit:  "float",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReadLatency", Label: "Read"},
+				mp.Metrics{Name: "WriteLatency", Label: "Write"},
+			},
+		},
+		fmt.Sprintf("%s.Throughput", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Throughput",
+			Unit:  "bytes/sec",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReadThroughput", Label: "Read"},
+				mp.Metrics{Name: "WriteThroughput", Label: "Write"},
+			},
+		},
+		fmt.Sprintf("%s.NetworkThroughput", p.KeyPrefix): mp.Graphs{
+			Label: "RDS Network Throughput",
+			Unit:  "bytes/sec",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "NetworkTransmitThroughput", Label: "Transmit"},
+				mp.Metrics{Name: "NetworkReceiveThroughput", Label: "Receive"},
+			},
+		},
+	}
 }
 
 func main() {
 	optRegion := flag.String("region", "", "AWS Region")
 	optAccessKeyId := flag.String("access-key-id", "", "AWS Access Key ID")
 	optSecretAccessKey := flag.String("secret-access-key", "", "AWS Secret Access Key")
-	optIdentifier := flag.String("identifier", "", "DB Instance Identifier")
+	optIdentifier := flag.String("identifier", "", "Prefix name (default: rds)")
+	optKeyPrefix := flag.Bool("use-identifier-as-prefix", false, "Use Identifier as key prefix (default: false)")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
 
@@ -188,6 +189,11 @@ func main() {
 	rds.Identifier = *optIdentifier
 	rds.AccessKeyId = *optAccessKeyId
 	rds.SecretAccessKey = *optSecretAccessKey
+	if *optKeyPrefix {
+		rds.KeyPrefix = "rds." + rds.Identifier
+	} else {
+		rds.KeyPrefix = "rds"
+	}
 
 	helper := mp.NewMackerelPlugin(rds)
 	if *optTempfile != "" {

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -205,8 +205,7 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 	for id, name := range dockerStats {
 		for metric, stats := range metrics {
-			ret, err := exists(pb.build(id, metric, "stat"))
-			if ret == false {
+			if ok, err := exists(pb.build(id, metric, "stat")); !ok || err != nil {
 				continue
 			}
 			data, err := getFile(pb.build(id, metric, "stat"))
@@ -224,8 +223,7 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 		// blkio statistics
 		for _, blkioType := range []string{"io_queued", "io_serviced", "io_service_bytes"} {
-			ret, err := exists(pb.build(id, "blkio", blkioType))
-			if ret == false {
+			if ok, err := exists(pb.build(id, "blkio", blkioType)); !ok || err != nil {
 				continue
 			}
 			data, err := getFile(pb.build(id, "blkio", blkioType))

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -231,7 +231,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 			}
 			data, err := getFile(pb.build(id, "blkio", blkioType))
 			if err != nil {
-				fmt.Println(err)
 				return nil, err
 			}
 			for _, stat := range []string{"Read", "Write", "Sync", "Async"} {

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -111,7 +111,7 @@ func (m DockerPlugin) getDockerPs() (string, error) {
 }
 
 func findPrefixPath() (string, error) {
-	pathCandidate := []string{"/host/sys/fs/cgroup", "/sys/fs/cgroup"}
+	pathCandidate := []string{"/host/cgroup/", "/cgroup", "/host/sys/fs/cgroup", "/sys/fs/cgroup"}
 	for _, path := range pathCandidate {
 		result, err := exists(path)
 		if err != nil {
@@ -205,6 +205,11 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 	for id, name := range dockerStats {
 		for metric, stats := range metrics {
+			//fmt.Println(pb.build(id, metric, "stat"))
+			ret, err := exists(pb.build(id, metric, "stat"))
+			if ret == false {
+				continue
+			}
 			data, err := getFile(pb.build(id, metric, "stat"))
 			if err != nil {
 				return nil, err
@@ -220,8 +225,13 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 		// blkio statistics
 		for _, blkioType := range []string{"io_queued", "io_serviced", "io_service_bytes"} {
+			ret, err := exists(pb.build(id, "blkio", blkioType))
+			if ret == false {
+				continue
+			}
 			data, err := getFile(pb.build(id, "blkio", blkioType))
 			if err != nil {
+				fmt.Println(err)
 				return nil, err
 			}
 			for _, stat := range []string{"Read", "Write", "Sync", "Async"} {

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -205,7 +205,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 	res := map[string]interface{}{}
 	for id, name := range dockerStats {
 		for metric, stats := range metrics {
-			//fmt.Println(pb.build(id, metric, "stat"))
 			ret, err := exists(pb.build(id, metric, "stat"))
 			if ret == false {
 				continue
@@ -240,7 +239,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 				for _, m := range matchs {
 					if m != nil {
 						ret, _ := strconv.ParseFloat(m[1], 64)
-						//fmt.Println(ret)
 						v += ret
 					}
 				}
@@ -249,7 +247,6 @@ func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 		}
 
 	}
-	//fmt.Println(res)
 
 	return res, nil
 }


### PR DESCRIPTION
With `-use-identifier-as-prefix`, identifier is used as key prefix.

ex: `rds.<db-instance-identifer>.Latency.ReadLatency`