### PR TITLE
Add Key prefix option for AWS RDS plugin

### DIFF
--- a/mackerel-plugin-aws-rds/README.md
+++ b/mackerel-plugin-aws-rds/README.md
@@ -6,7 +6,7 @@ AWS RDS custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-rds -identifier=<db-instance-identifer> [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-rds -identifier=<db-instance-identifer> [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<label-prefix>]
 ```
 * if you run on an ec2-instance, you probably don't have to specify `-region`
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`

--- a/mackerel-plugin-aws-rds/aws-rds.go
+++ b/mackerel-plugin-aws-rds/aws-rds.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/crowdmob/goamz/aws"
@@ -12,88 +13,13 @@ import (
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
-var graphdef map[string](mp.Graphs) = map[string](mp.Graphs){
-	"rds.CPUUtilization": mp.Graphs{
-		Label: "RDS CPU Utilization",
-		Unit:  "percentage",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
-		},
-	},
-	"rds.DatabaseConnections": mp.Graphs{
-		Label: "RDS Database Connections",
-		Unit:  "float",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "DatabaseConnections", Label: "DatabaseConnections"},
-		},
-	},
-	"rds.FreeableMemory": mp.Graphs{
-		Label: "RDS Freeable Memory",
-		Unit:  "bytes",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "FreeableMemory", Label: "FreeableMemory"},
-		},
-	},
-	"rds.FreeStorageSpace": mp.Graphs{
-		Label: "RDS Free Storage Space",
-		Unit:  "bytes",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "FreeStorageSpace", Label: "FreeStorageSpace"},
-		},
-	},
-	"rds.ReplicaLag": mp.Graphs{
-		Label: "RDS Replica Lag",
-		Unit:  "float",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReplicaLag", Label: "ReplicaLag"},
-		},
-	},
-	"rds.SwapUsage": mp.Graphs{
-		Label: "RDS Swap Usage",
-		Unit:  "bytes",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "SwapUsage", Label: "SwapUsage"},
-		},
-	},
-	"rds.IOPS": mp.Graphs{
-		Label: "RDS IOPS",
-		Unit:  "iops",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReadIOPS", Label: "Read"},
-			mp.Metrics{Name: "WriteIOPS", Label: "Write"},
-		},
-	},
-	"rds.Latency": mp.Graphs{
-		Label: "RDS Latency in second",
-		Unit:  "float",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReadLatency", Label: "Read"},
-			mp.Metrics{Name: "WriteLatency", Label: "Write"},
-		},
-	},
-	"rds.Throughput": mp.Graphs{
-		Label: "RDS Throughput",
-		Unit:  "bytes/sec",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "ReadThroughput", Label: "Read"},
-			mp.Metrics{Name: "WriteThroughput", Label: "Write"},
-		},
-	},
-	"rds.NetworkThroughput": mp.Graphs{
-		Label: "RDS Network Throughput",
-		Unit:  "bytes/sec",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "NetworkTransmitThroughput", Label: "Transmit"},
-			mp.Metrics{Name: "NetworkReceiveThroughput", Label: "Receive"},
-		},
-	},
-}
-
 type RDSPlugin struct {
 	Region          string
 	AccessKeyId     string
 	SecretAccessKey string
 	Identifier      string
+	Prefix          string
+	LabelPrefix     string
 }
 
 func GetLastPoint(cloudWatch *cloudwatch.CloudWatch, dimension *cloudwatch.Dimension, metricName string) (float64, error) {
@@ -166,6 +92,83 @@ func (p RDSPlugin) FetchMetrics() (map[string]float64, error) {
 }
 
 func (p RDSPlugin) GraphDefinition() map[string](mp.Graphs) {
+	var graphdef map[string](mp.Graphs) = map[string](mp.Graphs){
+		p.Prefix + ".CPUUtilization": mp.Graphs{
+			Label: p.LabelPrefix + " CPU Utilization",
+			Unit:  "percentage",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
+			},
+		},
+		p.Prefix + ".DatabaseConnections": mp.Graphs{
+			Label: p.LabelPrefix + " Database Connections",
+			Unit:  "float",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "DatabaseConnections", Label: "DatabaseConnections"},
+			},
+		},
+		p.Prefix + ".FreeableMemory": mp.Graphs{
+			Label: p.LabelPrefix + " Freeable Memory",
+			Unit:  "bytes",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "FreeableMemory", Label: "FreeableMemory"},
+			},
+		},
+		p.Prefix + ".FreeStorageSpace": mp.Graphs{
+			Label: p.LabelPrefix + " Free Storage Space",
+			Unit:  "bytes",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "FreeStorageSpace", Label: "FreeStorageSpace"},
+			},
+		},
+		p.Prefix + ".ReplicaLag": mp.Graphs{
+			Label: p.LabelPrefix + " Replica Lag",
+			Unit:  "float",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReplicaLag", Label: "ReplicaLag"},
+			},
+		},
+		p.Prefix + ".SwapUsage": mp.Graphs{
+			Label: p.LabelPrefix + " Swap Usage",
+			Unit:  "bytes",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "SwapUsage", Label: "SwapUsage"},
+			},
+		},
+		p.Prefix + ".IOPS": mp.Graphs{
+			Label: p.LabelPrefix + " IOPS",
+			Unit:  "iops",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReadIOPS", Label: "Read"},
+				mp.Metrics{Name: "WriteIOPS", Label: "Write"},
+			},
+		},
+		p.Prefix + ".Latency": mp.Graphs{
+			Label: p.LabelPrefix + " Latency in second",
+			Unit:  "float",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReadLatency", Label: "Read"},
+				mp.Metrics{Name: "WriteLatency", Label: "Write"},
+			},
+		},
+		p.Prefix + ".Throughput": mp.Graphs{
+			Label: p.LabelPrefix + " Throughput",
+			Unit:  "bytes/sec",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "ReadThroughput", Label: "Read"},
+				mp.Metrics{Name: "WriteThroughput", Label: "Write"},
+			},
+		},
+		p.Prefix + ".NetworkThroughput": mp.Graphs{
+			Label: p.LabelPrefix + " Network Throughput",
+			Unit:  "bytes/sec",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "NetworkTransmitThroughput", Label: "Transmit"},
+				mp.Metrics{Name: "NetworkReceiveThroughput", Label: "Receive"},
+			},
+		},
+	}
+
 	return graphdef
 }
 
@@ -174,10 +177,23 @@ func main() {
 	optAccessKeyId := flag.String("access-key-id", "", "AWS Access Key ID")
 	optSecretAccessKey := flag.String("secret-access-key", "", "AWS Secret Access Key")
 	optIdentifier := flag.String("identifier", "", "DB Instance Identifier")
+	optPrefix := flag.String("metric-key-prefix", "rds", "Metric key prefix")
+	optLabelPrefix := flag.String("metric-label-prefix", "", "Metric Label prefix")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
 
-	var rds RDSPlugin
+	rds := RDSPlugin{
+		Prefix: *optPrefix,
+	}
+	if *optLabelPrefix == "" {
+		if *optPrefix == "rds" {
+			rds.LabelPrefix = "RDS"
+		} else {
+			rds.LabelPrefix = strings.Title(*optPrefix)
+		}
+	} else {
+		rds.LabelPrefix = *optLabelPrefix
+	}
 
 	if *optRegion == "" {
 		rds.Region = aws.InstanceRegion()


### PR DESCRIPTION
With `-metric-key-prefix` option, metric key prefix can be changed. The default value of key prefix is `rds`.

And `-metric-label-prefix` can be specified for label prefix.
Without `-metric-label-prefix`, `RDS` is used for key prefix `rds` or capitalized key prefix is used for other key prefix.

### Example
- Key: `<metric-key-prefix>.Latency.ReadLatency`
- Label: `<metric-label-prefix> Latency in second`