### PR TITLE
Release version 0.13.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ deploy:
   api_key:
     secure: c2pLKkM2leWMIzakVisNf3kAK6TBYslDM8SFEVrTTHpHnTI/6jUFnDLuL9cKuq9c76QcgYfqdLDn/hP+uFHf5WdtdJR00R+bX8cCx6NfOe7Kk9GlqGinUcXKAVs0kQHaYtQrN/rCOIG92kYFdbRHMD8uMrADJVRySePTMMhMX9o=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.13.1-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.13.1-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.13.2-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.13.2-1_all.deb"
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent-plugins

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent-plugins (0.13.2-1) stable; urgency=low
+
+  * reduce binary size (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/120>
+  * remove Config field from FluentPluginMetrics (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/121>
+  * support coreos and amazon linux for docker plugin (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/122>
+  * Add Key prefix option for AWS RDS plugin (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/124>
+
+ -- itchyny <itchyny@hatena.ne.jp>  Thu, 15 Oct 2015 12:24:35 +0900
+
 mackerel-agent-plugins (0.13.1-1) stable; urgency=low
 
   * [docker] resolve cgroup path in systemd environment (by Songmu)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -41,6 +41,12 @@ done
 %{__targetdir}
 
 %changelog
+* Thu Oct 15 2015 <itchyny@hatena.ne.jp> - 0.13.2
+- reduce binary size (by Songmu)
+- remove Config field from FluentPluginMetrics (by Songmu)
+- support coreos and amazon linux for docker plugin (by stanaka)
+- Add Key prefix option for AWS RDS plugin (by stanaka)
+
 * Fri Sep 25 2015 <y.songmu@gmail.com> - 0.13.1
 - [docker] resolve cgroup path in systemd environment (by Songmu)
 

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -8,7 +8,7 @@
 
 Summary: Monitoring program plugins for Mackerel
 Name: mackerel-agent-plugins
-Version: 0.13.1
+Version: 0.13.2
 Release: %{revision}
 License: Apache-2
 Group: Applications/System


### PR DESCRIPTION
- reduce binary size #120
- remove Config field from FluentPluginMetrics #121
- support coreos and amazon linux for docker plugin #122
- Add Key prefix option for AWS RDS plugin #124