### PR TITLE
Release version 0.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ deploy:
   api_key:
     secure: c2pLKkM2leWMIzakVisNf3kAK6TBYslDM8SFEVrTTHpHnTI/6jUFnDLuL9cKuq9c76QcgYfqdLDn/hP+uFHf5WdtdJR00R+bX8cCx6NfOe7Kk9GlqGinUcXKAVs0kQHaYtQrN/rCOIG92kYFdbRHMD8uMrADJVRySePTMMhMX9o=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.13.2-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.13.2-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.14.0-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.14.0-1_all.deb"
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent-plugins

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Documentation for each plugin is located in its respective sub directory.
 * [mackerel-plugin-snmp](./mackerel-plugin-snmp/README.md)
 * [mackerel-plugin-squid](./mackerel-plugin-squid/README.md)
 * [mackerel-plugin-td-table-count](./mackerel-plugin-td-table-count/README.md)
+* [mackerel-plugin-trafficserver](./mackerel-plugin-trafficserver/README.md)
 * [mackerel-plugin-varnish](./mackerel-plugin-varnish/README.md)
 * [mackerel-plugin-xentop](./mackerel-plugin-xentop/README.md)
 

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent-plugins (0.14.0-1) stable; urgency=low
+
+  * Apache Traffic Server Plugin (by naokibtn)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/126>
+  * added plugin for AWS Elasticsearch Service (by hiroakis)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/127>
+  * use wildcard definition & normalize xen names (by naokibtn)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/128>
+  * add graph definition for java8 metaspace (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/129>
+  * add plugins (aws-elasticsearch and trafficserver) into package (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/132>
+
+ -- daiksy <daiksy@hatena.ne.jp>  Mon, 26 Oct 2015 15:30:26 +0900
+
 mackerel-agent-plugins (0.13.2-1) stable; urgency=low
 
   * reduce binary size (by Songmu)

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -8,7 +8,7 @@ package=mackerel-agent-plugins
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/tmp/usr/local/bin
-	for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elb aws-rds aws-ses elasticsearch haproxy jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres redis snmp squid td-table-count varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker;do \
+	for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elasticsearch aws-elb aws-rds aws-ses elasticsearch haproxy jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres redis snmp squid td-table-count trafficserver varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker;do \
 	    install -m755 debian/mackerel-plugin-$$i debian/tmp/usr/local/bin; \
 	done
 

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -41,6 +41,13 @@ done
 %{__targetdir}
 
 %changelog
+* Mon Oct 26 2015 <daiksy@hatena.ne.jp> - 0.14.0
+- Apache Traffic Server Plugin (by naokibtn)
+- added plugin for AWS Elasticsearch Service (by hiroakis)
+- use wildcard definition & normalize xen names (by naokibtn)
+- add graph definition for java8 metaspace (by Songmu)
+- add plugins (aws-elasticsearch and trafficserver) into package (by Songmu)
+
 * Thu Oct 15 2015 <itchyny@hatena.ne.jp> - 0.13.2
 - reduce binary size (by Songmu)
 - remove Config field from FluentPluginMetrics (by Songmu)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -8,7 +8,7 @@
 
 Summary: Monitoring program plugins for Mackerel
 Name: mackerel-agent-plugins
-Version: 0.13.2
+Version: 0.14.0
 Release: %{revision}
 License: Apache-2
 Group: Applications/System
@@ -29,7 +29,7 @@ This package provides plugins for Mackerel.
 
 %{__mkdir} -p %{buildroot}%{__targetdir}
 
-for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elb aws-rds aws-ses elasticsearch haproxy jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres redis snmp squid td-table-count varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker;do \
+for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elasticsearch aws-elb aws-rds aws-ses elasticsearch haproxy jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres redis snmp squid td-table-count trafficserver varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker;do \
     %{__install} -m0755 %{_sourcedir}/build/mackerel-plugin-$i %{buildroot}%{__targetdir}/; \
 done
 


### PR DESCRIPTION
- Apache Traffic Server Plugin #126
- added plugin for AWS Elasticsearch Service #127
- use wildcard definition & normalize xen names #128
- add graph definition for java8 metaspace #129
- add plugins (aws-elasticsearch and trafficserver) into package #132