### PR TITLE
Release version 0.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ deploy:
   api_key:
     secure: c2pLKkM2leWMIzakVisNf3kAK6TBYslDM8SFEVrTTHpHnTI/6jUFnDLuL9cKuq9c76QcgYfqdLDn/hP+uFHf5WdtdJR00R+bX8cCx6NfOe7Kk9GlqGinUcXKAVs0kQHaYtQrN/rCOIG92kYFdbRHMD8uMrADJVRySePTMMhMX9o=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.14.1-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.14.1-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.14.2-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.14.2-1_all.deb"
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent-plugins

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent-plugins (0.14.2-1) stable; urgency=low
+
+  * Fix document (by tkuchiki)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/137>
+  * Get memory usage percentage and CMSInitiatingOccupancyFraction when CMS GC is running (by tom--bo)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/138>
+  * follow latest aws-sdk-go (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/139>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 25 Nov 2015 19:06:34 +0900
+
 mackerel-agent-plugins (0.14.1-1) stable; urgency=low
 
   * fix index bug in plugin-xentop (by Songmu)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -8,7 +8,7 @@
 
 Summary: Monitoring program plugins for Mackerel
 Name: mackerel-agent-plugins
-Version: 0.14.1
+Version: 0.14.2
 Release: %{revision}
 License: Apache-2
 Group: Applications/System

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -41,6 +41,11 @@ done
 %{__targetdir}
 
 %changelog
+* Wed Nov 25 2015 <y.songmu@gmail.com> - 0.14.2
+- Fix document (by tkuchiki)
+- Get memory usage percentage and CMSInitiatingOccupancyFraction when CMS GC is running (by tom--bo)
+- follow latest aws-sdk-go (by Songmu)
+
 * Mon Oct 26 2015 <y.songmu@gmail.com> - 0.14.1
 - fix index bug in plugin-xentop (by Songmu)
 


### PR DESCRIPTION
- Fix document #137
- Get memory usage percentage and CMSInitiatingOccupancyFraction when CMS GC is running #138
- follow latest aws-sdk-go #139