### PR TITLE
remove misleading expression 'manager_port'

### DIFF
--- a/mackerel-plugin-squid/README.md
+++ b/mackerel-plugin-squid/README.md
@@ -6,7 +6,7 @@ Squid custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-squid [-host=<host>] [-port=<manager_port>] [-tempfile=<tempfile>]
+mackerel-plugin-squid [-host=<host>] [-port=<squid_http_port>] [-tempfile=<tempfile>]
 ```
 
 ## Example of mackerel-agent.conf


### PR DESCRIPTION
squid probably doesn't have 'manager_port' concept.