### PR TITLE
When Seconds_Behind_Master is NULL, agent-plugin doesn't send the Seconds_Behind_Master metric.

### DIFF
--- a/mackerel-plugin-mysql/mysql.go
+++ b/mackerel-plugin-mysql/mysql.go
@@ -161,8 +161,13 @@ func (m MySQLPlugin) fetchShowSlaveStatus(db mysql.Conn, stat map[string]float64
 
 	for _, row := range rows {
 		idx := res.Map("Seconds_Behind_Master")
-		Value := row.Int(idx)
-		stat["Seconds_Behind_Master"] = float64(Value)
+		switch row[idx].(type) {
+		case nil:
+			// nop
+		default:
+			Value := row.Int(idx)
+			stat["Seconds_Behind_Master"] = float64(Value)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
mackerel-plugin-mysql use https://github.com/ziutek/mymysql.
row.Int method is "Get the nn-th value and return it as int (0 if NULL). Panic if conversion is".

It can’t tell the difference between "Seconds_Behind_Master=NULL" and "Seconds_Behind_Master=0".

When Seconds_Behind_Master is NULL, agent-plugin doesn't send the Seconds_Behind_Master metric.