### PR TITLE
Add metric key and label prefix option to Elasticsearch plugin

### DIFF
--- a/mackerel-plugin-elasticsearch/README.md
+++ b/mackerel-plugin-elasticsearch/README.md
@@ -6,7 +6,7 @@ Elasticsearch custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-elasticsearch [-scheme=<'http'|'https'>] [-host=<host>] [-port=<manage_port>] [-tempfile=<tempfile>]
+mackerel-plugin-elasticsearch [-scheme=<'http'|'https'>] [-host=<host>] [-port=<manage_port>] [-tempfile=<tempfile>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<label-prefix>]
 ```
 
 ## Example of mackerel-agent.conf

--- a/mackerel-plugin-elasticsearch/elasticsearch_test.go
+++ b/mackerel-plugin-elasticsearch/elasticsearch_test.go
@@ -20,7 +20,10 @@ var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) 
 })
 
 func TestGraphDefinition(t *testing.T) {
-	var elasticsearch ElasticsearchPlugin
+	elasticsearch := ElasticsearchPlugin{
+		Prefix:      "elasticsearch",
+		LabelPrefix: "Elasticsearch",
+	}
 	graphdef := elasticsearch.GraphDefinition()
 
 	assert.EqualValues(t, "Elasticsearch HTTP", graphdef["elasticsearch.http"].Label)


### PR DESCRIPTION
Add metric key and label prefix option to Elasticsearch plugin.

This enables us to get metrics from multiple Elasticsearch servers which cannot run mackerel-agent (e.g. hosted Elasticsearch services).