### PR TITLE
Release version 0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ deploy:
   api_key:
     secure: c2pLKkM2leWMIzakVisNf3kAK6TBYslDM8SFEVrTTHpHnTI/6jUFnDLuL9cKuq9c76QcgYfqdLDn/hP+uFHf5WdtdJR00R+bX8cCx6NfOe7Kk9GlqGinUcXKAVs0kQHaYtQrN/rCOIG92kYFdbRHMD8uMrADJVRySePTMMhMX9o=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.16.0-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.16.0-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.17.0-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.17.0-1_all.deb"
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent-plugins

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Documentation for each plugin is located in its respective sub directory.
 * [mackerel-plugin-aws-elb](./mackerel-plugin-aws-elb/README.md)
 * [mackerel-plugin-aws-rds](./mackerel-plugin-aws-rds/README.md)
 * [mackerel-plugin-aws-ses](./mackerel-plugin-aws-ses/README.md)
+* [mackerel-plugin-conntrack](./mackerel-plugin-conntrack/README.md)
 * [mackerel-plugin-docker](./mackerel-plugin-docker/README.md)
 * [mackerel-plugin-elasticsearch](./mackerel-plugin-elasticsearch/README.md)
 * [mackerel-plugin-fluentd](./mackerel-plugin-fluentd/README.md)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,22 @@
+mackerel-agent-plugins (0.17.0-1) stable; urgency=low
+
+  * Add mackerel-plugin-rabbitmq (by haramaki)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/165>
+  * Add metric key and label prefix option to Elasticsearch plugin (by yano3)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/173>
+  * Add jmx jolokia plugin (by y-kuno)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/174>
+  * Add nf(ip)_conntrack plugin (by hfm)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/175>
+  * [memcached] support unix socket (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/176>
+  * use plugin-helper for mackerel-plugin-apache2 (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/177>
+  * add conntrack, jmx-jolokia, rabbitmq into package (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/178>
+
+ -- Stefan Utamaru <stefafafan@hatena.ne.jp>  Thu, 18 Feb 2016 17:08:55 +0900
+
 mackerel-agent-plugins (0.16.0-1) stable; urgency=low
 
   * Add couple of metrics to Elasticsearch plugin (by ariarijp)

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -8,7 +8,7 @@ package=mackerel-agent-plugins
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/tmp/usr/local/bin
-	for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elasticsearch aws-elb aws-rds aws-ses elasticsearch gostats haproxy jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres redis snmp squid td-table-count trafficserver varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker unicorn inode;do \
+	for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elasticsearch aws-elb aws-rds aws-ses conntrack elasticsearch gostats haproxy jmx-jolokia jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres rabbitmq redis snmp squid td-table-count trafficserver varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker unicorn inode;do \
 	    install -m755 debian/mackerel-plugin-$$i debian/tmp/usr/local/bin; \
 	done
 

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -41,6 +41,15 @@ done
 %{__targetdir}
 
 %changelog
+* Thu Feb 18 2016 <stefafafan@hatena.ne.jp> - 0.17.0
+- Add mackerel-plugin-rabbitmq (by haramaki)
+- Add metric key and label prefix option to Elasticsearch plugin (by yano3)
+- Add jmx jolokia plugin (by y-kuno)
+- Add nf(ip)_conntrack plugin (by hfm)
+- [memcached] support unix socket (by Songmu)
+- use plugin-helper for mackerel-plugin-apache2 (by stanaka)
+- add conntrack, jmx-jolokia, rabbitmq into package (by Songmu)
+
 * Thu Feb 04 2016 <y.songmu@gmail.com> - 0.16.0
 - Add couple of metrics to Elasticsearch plugin (by ariarijp)
 - [jvm] Add confirmation to error message (by tom--bo)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -8,7 +8,7 @@
 
 Summary: Monitoring program plugins for Mackerel
 Name: mackerel-agent-plugins
-Version: 0.16.0
+Version: 0.17.0
 Release: %{revision}
 License: Apache-2
 Group: Applications/System
@@ -29,7 +29,7 @@ This package provides plugins for Mackerel.
 
 %{__mkdir} -p %{buildroot}%{__targetdir}
 
-for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elasticsearch aws-elb aws-rds aws-ses elasticsearch gostats haproxy jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres redis snmp squid td-table-count trafficserver varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker unicorn inode;do \
+for i in apache2 aws-ec2-cpucredit aws-elasticache aws-elasticsearch aws-elb aws-rds aws-ses conntrack elasticsearch gostats haproxy jmx-jolokia jvm linux memcached mongodb munin mysql nginx php-apc php-opcache plack postgres rabbitmq redis snmp squid td-table-count trafficserver varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker unicorn inode;do \
     %{__install} -m0755 %{_sourcedir}/build/mackerel-plugin-$i %{buildroot}%{__targetdir}/; \
 done
 


### PR DESCRIPTION
- Add mackerel-plugin-rabbitmq #165
- Add metric key and label prefix option to Elasticsearch plugin #173
- Add jmx jolokia plugin #174
- Add nf(ip)_conntrack plugin #175
- [memcached] support unix socket #176
- use plugin-helper for mackerel-plugin-apache2 #177
- add conntrack, jmx-jolokia, rabbitmq into package #178