### PR TITLE
Release version 0.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ deploy:
   api_key:
     secure: c2pLKkM2leWMIzakVisNf3kAK6TBYslDM8SFEVrTTHpHnTI/6jUFnDLuL9cKuq9c76QcgYfqdLDn/hP+uFHf5WdtdJR00R+bX8cCx6NfOe7Kk9GlqGinUcXKAVs0kQHaYtQrN/rCOIG92kYFdbRHMD8uMrADJVRySePTMMhMX9o=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.17.0-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.17.0-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-agent-plugins-0.18.0-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/mackerel-agent-plugins/packaging/mackerel-agent-plugins_0.18.0-1_all.deb"
   skip_cleanup: true
   on:
     repo: mackerelio/mackerel-agent-plugins

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Documentation for each plugin is located in its respective sub directory.
 * [mackerel-plugin-td-table-count](./mackerel-plugin-td-table-count/README.md)
 * [mackerel-plugin-trafficserver](./mackerel-plugin-trafficserver/README.md)
 * [mackerel-plugin-unicorn](./mackerel-plugin-unicorn/README.md)
+* [mackerel-plugin-uptime](./mackerel-plugin-uptime/README.md)
 * [mackerel-plugin-varnish](./mackerel-plugin-varnish/README.md)
 * [mackerel-plugin-xentop](./mackerel-plugin-xentop/README.md)
 

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,16 @@
+mackerel-agent-plugins (0.18.0-1) stable; urgency=low
+
+  * [mysql] care innodb_buffer_pool_instances (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/182>
+  * Add uptime plugin (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/183>
+  * [inode] use `df -iP` on linux (care line break) (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/185>
+  * [mysql] support unix socket (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/186>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 02 Mar 2016 15:15:19 +0900
+
 mackerel-agent-plugins (0.17.0-1) stable; urgency=low
 
   * Add mackerel-plugin-rabbitmq (by haramaki)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -8,7 +8,7 @@
 
 Summary: Monitoring program plugins for Mackerel
 Name: mackerel-agent-plugins
-Version: 0.17.0
+Version: 0.18.0
 Release: %{revision}
 License: Apache-2
 Group: Applications/System

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -41,6 +41,12 @@ done
 %{__targetdir}
 
 %changelog
+* Wed Mar 02 2016 <y.songmu@gmail.com> - 0.18.0
+- [mysql] care innodb_buffer_pool_instances (by Songmu)
+- Add uptime plugin (by Songmu)
+- [inode] use `df -iP` on linux (care line break) (by Songmu)
+- [mysql] support unix socket (by Songmu)
+
 * Thu Feb 18 2016 <stefafafan@hatena.ne.jp> - 0.17.0
 - Add mackerel-plugin-rabbitmq (by haramaki)
 - Add metric key and label prefix option to Elasticsearch plugin (by yano3)


### PR DESCRIPTION
- [mysql] care innodb_buffer_pool_instances #182
- Add uptime plugin #183
- [inode] use `df -iP` on linux (care line break) #185
- [mysql] support unix socket #186