### PR TITLE
Fix helper.Tempfile in mysql.go

### DIFF
--- a/mackerel-plugin-mysql/mysql.go
+++ b/mackerel-plugin-mysql/mysql.go
@@ -784,7 +784,7 @@ func main() {
 	mysql.DisableInnoDB = *optInnoDB
 	helper := mp.NewMackerelPlugin(mysql)
 	helper.Tempfile = *optTempfile
-	if helper.Tempfile != "" {
+	if helper.Tempfile == "" {
 		if mysql.isUnixSocket {
 			helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-mysql-%s", fmt.Sprintf("%x", md5.Sum([]byte(mysql.Target))))
 		} else {


### PR DESCRIPTION
If `helper.Tempfile` is empty, it seems correct to set the path to the tempfile.