### PR TITLE
Add mackerel plugin rack stats

### DIFF
--- a/mackerel-plugin-rack-stats/README.md
+++ b/mackerel-plugin-rack-stats/README.md
@@ -1,0 +1,40 @@
+# mackerel-plugin-rack-stats
+Rack servers metrics plugin for mackerel.io agent.  
+Only work on Linux.  
+
+## Synopsis
+
+```shell
+mackerel-plugin-rack-stats [-address=<url or unix domain socket>] [-path=<path>] [-metric-key=<metric-key>]  [-tempfile=<tempfile>]
+```
+
+```shell
+$ ./mackerel-plugin-rack-stats --help
+Usage of ./mackerel-plugin-rack-stats:
+  -address string
+        URL or Unix Domain Socket (default "http://localhost:8080")
+  -metric-key string
+        Metric Key
+  -path string
+        Path (default "/_raindrops")
+  -tempfile string
+        Temp file name
+  -version
+        Version
+```
+
+## Requirements
+
+- [raindrops](https://rubygems.org/gems/raindrops)
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.rack_stats]
+command = "/path/to/mackerel-plugin-rack-stats -address=unix:/path/to/unicorn.sock"
+```
+
+```
+[plugin.metrics.rack_stats]
+command = "/path/to/mackerel-plugin-rack-stats -address=http://localhost:8080"
+```

--- a/mackerel-plugin-rack-stats/rack.go
+++ b/mackerel-plugin-rack-stats/rack.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+)
+
+var sock string
+
+func parseAddress(uri string) (scheme, path, port string, err error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return scheme, path, port, err
+	}
+
+	scheme = u.Scheme
+	path = u.Path
+	if path == "" {
+		path = u.Host
+	}
+
+	host := strings.Split(u.Host, ":")
+	if len(host) == 1 {
+		port = "80"
+	} else {
+		port = host[1]
+	}
+
+	return scheme, path, port, err
+}
+
+func parseBody(r io.Reader, index string) (stats map[string]interface{}, err error) {
+	scanner := bufio.NewScanner(r)
+	stats = make(map[string]interface{})
+	for scanner.Scan() {
+		p := strings.Split(scanner.Text(), " ")
+		if len(p) == 2 {
+			stats[strings.Trim(p[0], ":")], err = strconv.ParseFloat(p[1], 64)
+		} else {
+			re := regexp.MustCompile(fmt.Sprintf("%s$", index))
+			if ok := re.Match([]byte(p[0])); ok && err == nil {
+				stats[strings.Trim(p[len(p)-2], ":")], err = strconv.ParseFloat(p[len(p)-1], 64)
+			}
+		}
+	}
+	stats["active"] = stats["active"].(float64) - 1
+
+	return stats, err
+}
+
+func parseBodyHTTP(uri, port string) (stats map[string]interface{}, err error) {
+	var req *http.Request
+	req, err = http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return stats, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return stats, err
+	}
+	defer resp.Body.Close()
+
+	stats, err = parseBody(resp.Body, ":"+port)
+
+	return stats, err
+}
+
+func fakeDial(proto, addr string) (conn net.Conn, err error) {
+	return net.Dial("unix", sock)
+}
+
+func parseBodyUnix(path string) (stats map[string]interface{}, err error) {
+	tr := &http.Transport{
+		Dial: fakeDial,
+	}
+
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(fmt.Sprintf("http://dummy/%s", strings.TrimLeft(path, "/")))
+
+	if err != nil {
+		return stats, err
+	}
+	defer resp.Body.Close()
+
+	stats, err = parseBody(resp.Body, sock)
+
+	return stats, err
+}
+
+// RackStatsPlugin mackerel plugin for Rack servers
+type RackStatsPlugin struct {
+	Address   string
+	Path      string
+	MetricKey string
+}
+
+// FetchMetrics interface for mackerelplugin
+func (u RackStatsPlugin) FetchMetrics() (stats map[string]interface{}, err error) {
+	stats, err = u.parseStats()
+	return stats, err
+}
+
+func (u RackStatsPlugin) parseStats() (stats map[string]interface{}, err error) {
+	scheme, path, port, err := parseAddress(u.Address)
+
+	switch scheme {
+	case "http":
+		stats, err = parseBodyHTTP(fmt.Sprintf("%s/%s", u.Address, strings.TrimLeft(u.Path, "/")), port)
+	case "unix":
+		sock = path
+		stats, err = parseBodyUnix(u.Path)
+	}
+
+	return stats, err
+}
+
+// GraphDefinition interface for mackerelplugin
+func (u RackStatsPlugin) GraphDefinition() map[string](mp.Graphs) {
+	scheme, path, port, err := parseAddress(u.Address)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var label string
+	if u.MetricKey == "" {
+		switch scheme {
+		case "http":
+			u.MetricKey = port
+			label = fmt.Sprintf("Rack Port %s Stats", port)
+		case "unix":
+			u.MetricKey = strings.Replace(strings.Replace(path, "/", "_", -1), ".", "_", -1)
+			label = fmt.Sprintf("Rack %s Stats", path)
+		}
+	} else {
+		label = fmt.Sprintf("Rack %s Stats", u.MetricKey)
+	}
+
+	return map[string](mp.Graphs){
+<<<<<<< HEAD
+		fmt.Sprintf("%s.rack.stats", u.MetricKey): mp.Graphs{
+=======
+		fmt.Sprintf("rack.%s.stats", u.MetricKey): mp.Graphs{
+>>>>>>> Add mackerel-plugin-rack-stats
+			Label: label,
+			Unit:  "integer",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "queued", Label: "Queued", Diff: false},
+				mp.Metrics{Name: "active", Label: "Active", Diff: false},
+				mp.Metrics{Name: "writing", Label: "Writing", Diff: false},
+				mp.Metrics{Name: "calling", Label: "Calling", Diff: false},
+			},
+		},
+	}
+}
+
+func main() {
+	optAddress := flag.String("address", "http://localhost:8080", "URL or Unix Domain Socket")
+	optPath := flag.String("path", "/_raindrops", "Path")
+<<<<<<< HEAD
+	optMetricKey := flag.String("metric-key", "", "Metric Key")
+=======
+	optMetricKey := flag.String("metric-key-prefix", "", "Metric Key Prefix")
+>>>>>>> Add mackerel-plugin-rack-stats
+	optVersion := flag.Bool("version", false, "Version")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	flag.Parse()
+
+	if *optVersion {
+		fmt.Println("0.3")
+		os.Exit(0)
+	}
+
+	var rack RackStatsPlugin
+	rack.Address = *optAddress
+	rack.Path = *optPath
+	rack.MetricKey = *optMetricKey
+
+	helper := mp.NewMackerelPlugin(rack)
+	if *optTempfile != "" {
+		helper.Tempfile = *optTempfile
+	} else {
+		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-rack-stats")
+	}
+
+	helper.Run()
+}

--- a/mackerel-plugin-rack-stats/rack.go
+++ b/mackerel-plugin-rack-stats/rack.go
@@ -148,11 +148,7 @@ func (u RackStatsPlugin) GraphDefinition() map[string](mp.Graphs) {
 	}
 
 	return map[string](mp.Graphs){
-<<<<<<< HEAD
-		fmt.Sprintf("%s.rack.stats", u.MetricKey): mp.Graphs{
-=======
 		fmt.Sprintf("rack.%s.stats", u.MetricKey): mp.Graphs{
->>>>>>> Add mackerel-plugin-rack-stats
 			Label: label,
 			Unit:  "integer",
 			Metrics: [](mp.Metrics){
@@ -168,11 +164,7 @@ func (u RackStatsPlugin) GraphDefinition() map[string](mp.Graphs) {
 func main() {
 	optAddress := flag.String("address", "http://localhost:8080", "URL or Unix Domain Socket")
 	optPath := flag.String("path", "/_raindrops", "Path")
-<<<<<<< HEAD
-	optMetricKey := flag.String("metric-key", "", "Metric Key")
-=======
 	optMetricKey := flag.String("metric-key-prefix", "", "Metric Key Prefix")
->>>>>>> Add mackerel-plugin-rack-stats
 	optVersion := flag.Bool("version", false, "Version")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()

--- a/mackerel-plugin-rack-stats/rack_test.go
+++ b/mackerel-plugin-rack-stats/rack_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphDefinition(t *testing.T) {
+	var rack RackStatsPlugin
+
+	graphdef := rack.GraphDefinition()
+	if len(graphdef) != 1 {
+		t.Errorf("GetTempfilename: %d should be 1", len(graphdef))
+	}
+}
+
+var testPort string
+var testSock string
+
+func requestHandlerHTTP(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(200)
+	w.Header().Set("Content-Type", "text/plain")
+	fmt.Fprintln(w, "calling: 10")
+	fmt.Fprintln(w, "writing: 20")
+	fmt.Fprintln(w, fmt.Sprintf("0.0.0.0:%s active: 31", testPort))
+	fmt.Fprintln(w, fmt.Sprintf("0.0.0.0:%s queued: 40", testPort))
+	fmt.Fprintln(w, fmt.Sprintf("0.0.0.0:%s0 active: 50", testPort))
+	fmt.Fprintln(w, fmt.Sprintf("0.0.0.0:%s0 queued: 60", testPort))
+	fmt.Fprintln(w, "/path/to/unicorn.sock active: 70")
+	fmt.Fprintln(w, "/path/to/unicorn.sock queued: 80")
+	fmt.Fprintln(w, "/path/to/unicorn2.sock active: 90")
+	fmt.Fprintln(w, "/path/to/unicorn2.sock queued: 100")
+}
+
+func requestHandlerUnix(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(200)
+	w.Header().Set("Content-Type", "text/plain")
+	fmt.Fprintln(w, "calling: 10")
+	fmt.Fprintln(w, "writing: 20")
+	fmt.Fprintln(w, "0.0.0.0:8080 active: 50")
+	fmt.Fprintln(w, "0.0.0.0:8080 queued: 60")
+	fmt.Fprintln(w, fmt.Sprintf("%s active: 71", testSock))
+	fmt.Fprintln(w, fmt.Sprintf("%s queued: 80", testSock))
+	fmt.Fprintln(w, "/path/to/unicorn2.sock active: 90")
+	fmt.Fprintln(w, "/path/to/unicorn2.sock queued: 100")
+}
+
+func TestParseHttp(t *testing.T) {
+	var rack RackStatsPlugin
+
+	ts := httptest.NewServer(http.HandlerFunc(requestHandlerHTTP))
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+
+	var host string
+	host, testPort, _ = net.SplitHostPort(u.Host)
+
+	rack.Address = fmt.Sprintf("http://%s:%s", host, testPort)
+	rack.Path = "/_raindrops"
+
+	stats, err := rack.parseStats()
+	assert.Nil(t, err)
+	assert.EqualValues(t, reflect.TypeOf(stats["calling"]).String(), "float64")
+	assert.EqualValues(t, stats["calling"], 10)
+	assert.EqualValues(t, reflect.TypeOf(stats["writing"]).String(), "float64")
+	assert.EqualValues(t, stats["writing"], 20)
+	assert.EqualValues(t, reflect.TypeOf(stats["active"]).String(), "float64")
+	assert.EqualValues(t, stats["active"], 30)
+	assert.EqualValues(t, reflect.TypeOf(stats["queued"]).String(), "float64")
+	assert.EqualValues(t, stats["queued"], 40)
+}
+
+func TestParseUnix(t *testing.T) {
+	var rack RackStatsPlugin
+
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir)
+
+	testSock = fmt.Sprintf("%s/unicorn.sock", dir)
+
+	l, err := net.Listen("unix", testSock)
+	if err != nil {
+		t.Error(err)
+	}
+
+	rack.Address = fmt.Sprintf("unix:%s", testSock)
+	rack.Path = "/_raindrops"
+
+	var mux = http.NewServeMux()
+	mux.Handle(rack.Path, http.HandlerFunc(requestHandlerUnix))
+
+	go http.Serve(l, mux)
+
+	stats, err := rack.parseStats()
+	assert.Nil(t, err)
+	assert.EqualValues(t, reflect.TypeOf(stats["calling"]).String(), "float64")
+	assert.EqualValues(t, stats["calling"], 10)
+	assert.EqualValues(t, reflect.TypeOf(stats["writing"]).String(), "float64")
+	assert.EqualValues(t, stats["writing"], 20)
+	assert.EqualValues(t, reflect.TypeOf(stats["active"]).String(), "float64")
+	assert.EqualValues(t, stats["active"], 70)
+	assert.EqualValues(t, reflect.TypeOf(stats["queued"]).String(), "float64")
+	assert.EqualValues(t, stats["queued"], 80)
+}


### PR DESCRIPTION
A mackerel plugin for Rack servers.

```
$ ./mackerel-plugin-rack-stats
rack.8080.stats.queued  0.000000        1458798067
rack.8080.stats.active  0.000000        1458798067
rack.8080.stats.writing 0.000000        1458798067
rack.8080.stats.calling 0.000000        1458798067
```

```
$ ./mackerel-plugin-rack-stats -address=unix:/home/ec2-user/unicorn.sock
rack._home_ec2-user_unicorn_sock.stats.queued      0.000000        1458798089
rack._home_ec2-user_unicorn_sock.stats.active      0.000000        1458798089
rack._home_ec2-user_unicorn_sock.stats.writing     0.000000        1458798089
rack._home_ec2-user_unicorn_sock.stats.calling     0.000000        1458798089
```