### PR TITLE
Do not send fluentd metrics of other than the output plugin

### DIFF
--- a/mackerel-plugin-fluentd/fluentd.go
+++ b/mackerel-plugin-fluentd/fluentd.go
@@ -57,6 +57,9 @@ func (f *FluentdMetrics) parseStats(body []byte) (map[string]interface{}, error)
 
 	metrics := make(map[string]interface{})
 	for _, p := range f.plugins {
+		if p.PluginCategory != "output" {
+			continue
+		}
 		pid := p.getNormalizedPluginID()
 		metrics["fluentd.retry_count."+pid] = float64(p.RetryCount)
 		metrics["fluentd.buffer_queue_length."+pid] = float64(p.BufferQueueLength)

--- a/mackerel-plugin-fluentd/fluentd_test.go
+++ b/mackerel-plugin-fluentd/fluentd_test.go
@@ -31,7 +31,7 @@ func TestNormalizePluginID(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	var fluentd FluentdMetrics
-	stub := `{"plugins":[{"plugin_id":"object:3feb368cfad0","plugin_category":"output","type":"mackerel","config":{"type":"mackerel","api_key":"aaa","service":"foo","metrics_name":"${[1]}-bar.${out_key}","remove_prefix":"","out_keys":"Latency","localtime":true},"output_plugin":true,"buffer_queue_length":0,"buffer_total_queued_size":53,"retry_count":0}]}`
+	stub := `{"plugins":[{"plugin_id":"object:3feb368cfad0","plugin_category":"output","type":"mackerel","config":{"type":"mackerel","api_key":"aaa","service":"foo","metrics_name":"${[1]}-bar.${out_key}","remove_prefix":"","out_keys":"Latency","localtime":true},"output_plugin":true,"buffer_queue_length":0,"buffer_total_queued_size":53,"retry_count":0},{"plugin_id":"object:155633c","plugin_category":"input","type":"monitor_agent","config":{"type":"monitor_agent","bind":"0.0.0.0","port":"24220"},"output_plugin":false,"retry_count":null}]}`
 
 	fluentdStats := []byte(stub)
 
@@ -40,4 +40,7 @@ func TestParse(t *testing.T) {
 	// Fluentd Stats
 	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.object_3feb368cfad0"]).String(), "float64")
 	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.object_3feb368cfad0"].(float64), 53)
+	if _, ok := stat["fluentd.buffer_total_queued_size.object_155633c"]; ok {
+		t.Errorf("parseStats: stats of other than the output plugin should not exist")
+	}
 }


### PR DESCRIPTION
Metrics fetched by `mackerel-plugin-fluentd` is updated only output plugin. So, metric other than the output plugins were so as not to send.