### PR TITLE
Release version 0.19.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,6 @@ deploy:
   on:
     all_branches: true
     condition: "$TRAVIS_BRANCH =~ ^bump-version-.*$"
+notifications:
+  slack:
+    secure: cPeJRg+ouTlemEV5UM4muhDwtIM0dktcs3mnfB73oZ2MGOimv/DFpL+VTRLlkWau8l0dT4ngLlGPcveLrXQXwps2LsJMr+gS6Az/CAQCIl21oj4bnjs5uGYTG8hM8ymVzGINPNnj5Fnn5DUMunA2sow30qxfuCnSUMGot2nFRKw=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
 # Changelog
 
+## 0.19.3 (2016-04-14)
+
+* Revert "Revert "use /usr/bin/mackerel-plugin-*"" #208 (Songmu)
+* fix: redis plugin panics when redis-server is not installed. #209 (stanaka)
+* fix: rpm should not include dir #210 (stanaka)
+* [nginx] fix typo #215 (y-kuno)
+* Refactoring the release process #217 (stanaka)
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.19.3 (2016-04-14)
 
+* [redis] skip to calculate capacity when CONFIG command failed (#214) (Songmu)
 * Revert "Revert "use /usr/bin/mackerel-plugin-*"" #208 (Songmu)
 * fix: redis plugin panics when redis-server is not installed. #209 (stanaka)
 * fix: rpm should not include dir #210 (stanaka)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent-plugins (0.19.3-1) stable; urgency=low
+
+  * Revert "Revert "use /usr/bin/mackerel-plugin-*"" (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/208>
+  * fix: redis plugin panics when redis-server is not installed. (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/209>
+  * fix: rpm should not include dir (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/210>
+  * [nginx] fix typo (by y-kuno)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/215>
+  * Refactoring the release process (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/217>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 14 Apr 2016 08:19:38 +0000
+
 mackerel-agent-plugins (0.19.2-1) stable; urgency=low
 
   * Revert "use /usr/bin/mackerel-plugin-*" (by Songmu)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,5 +1,7 @@
 mackerel-agent-plugins (0.19.3-1) stable; urgency=low
 
+  * [redis] skip to calculate capacity when CONFIG command failed (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/214>
   * Revert "Revert "use /usr/bin/mackerel-plugin-*"" (by Songmu)
     <https://github.com/mackerelio/mackerel-agent-plugins/pull/208>
   * fix: redis plugin panics when redis-server is not installed. (by stanaka)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,13 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Thu Apr 14 2016 <mackerel-developers@hatena.ne.jp> - 0.19.3-1
+- Revert "Revert "use /usr/bin/mackerel-plugin-*"" (by Songmu)
+- fix: redis plugin panics when redis-server is not installed. (by stanaka)
+- fix: rpm should not include dir (by stanaka)
+- [nginx] fix typo (by y-kuno)
+- Refactoring the release process (by stanaka)
+
 * Fri Mar 25 2016 <y.songmu@gmail.com> - 0.19.2
 - Revert "use /usr/bin/mackerel-plugin-*" (by Songmu)
 

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -50,6 +50,7 @@ done
 
 %changelog
 * Thu Apr 14 2016 <mackerel-developers@hatena.ne.jp> - 0.19.3-1
+- [redis] skip to calculate capacity when CONFIG command failed (by Songmu)
 - Revert "Revert "use /usr/bin/mackerel-plugin-*"" (by Songmu)
 - fix: redis plugin panics when redis-server is not installed. (by stanaka)
 - fix: rpm should not include dir (by stanaka)

--- a/tool/releng
+++ b/tool/releng
@@ -418,10 +418,10 @@ sub create_pull_request {
         infof "skip to update changelogs because no merged pull request is found after the last release.\n"
     }
     if($ret || git_with_exit_code qw/diff --exit-code/){
-        git qw/commit -am/, "update changelogs";
-        git qw/config --global push.default matching/;
         git qw/config user.email/, 'mackerel-developers@hatena.ne.jp';
         git qw/config user.name/, 'mackerel';
+        git qw/commit -am/, "update changelogs";
+        git qw/config --global push.default matching/;
         git qw/push -u/, "https://$ENV{GITHUB_TOKEN}\@github.com/$REPO_NAME.git";
         infof "Difference is pushed to GitHub.\n";
     }


### PR DESCRIPTION
- Revert "Revert "use /usr/bin/mackerel-plugin-*"" #208
- fix: redis plugin panics when redis-server is not installed. #209
- fix: rpm should not include dir #210
- [nginx] fix typo #215
- Refactoring the release process #217