### PR TITLE
[docker] fix build error "too few values in struct initializer"

### DIFF
--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -294,7 +294,9 @@ func (m DockerPlugin) FetchMetricsWithAPI(containers []docker.APIContainers) (ma
 		statsC := make(chan *docker.Stats)
 		done := make(chan bool)
 		go func() {
-			errC <- client.Stats(docker.StatsOptions{name, statsC, false, done, 0})
+			// errC <- client.Stats(docker.StatsOptions{name, statsC, false, done, 0})
+			errC <- client.Stats(docker.StatsOptions{ID: name, Stats: statsC, Stream: false, Done: done, Timeout: 0})
+
 			close(errC)
 		}()
 		var resultStats []*docker.Stats

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -294,7 +294,6 @@ func (m DockerPlugin) FetchMetricsWithAPI(containers []docker.APIContainers) (ma
 		statsC := make(chan *docker.Stats)
 		done := make(chan bool)
 		go func() {
-			// errC <- client.Stats(docker.StatsOptions{name, statsC, false, done, 0})
 			errC <- client.Stats(docker.StatsOptions{ID: name, Stats: statsC, Stream: false, Done: done, Timeout: 0})
 
 			close(errC)


### PR DESCRIPTION
fix build error

```
-->     linux/amd64: github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker

1 errors occurred:
--> linux/amd64 error: exit status 2
Stderr: # github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker
mackerel-plugin-docker/docker.go:297: too few values in struct initializer
```