### PR TITLE
fix README.md of mackerel-plugin-jvm

### DIFF
--- a/mackerel-plugin-jvm/README.md
+++ b/mackerel-plugin-jvm/README.md
@@ -17,7 +17,7 @@ mackerel-plugin-jvm -javaname=<javaname> [-pidfile=</path/to/pidfile>] [-jstatpa
 
 ```
 [plugin.metrics.jvm]
-command = "/path/to/mackerel-plugin-jvm -javaname=NettyServer -jstatpath=/usr/bin/jstat -jpspath=/usr/bin/jps -jinfo=/usr/bin/jinfo"
+command = "/path/to/mackerel-plugin-jvm -javaname=NettyServer -jstatpath=/usr/bin/jstat -jpspath=/usr/bin/jps -jinfopath=/usr/bin/jinfo"
 ```
 
 ## About javaname


### PR DESCRIPTION
I fix README.md of mackerel-plugin-jvm, change command line option from "-jinfo" to "-jinfopath."