### PR TITLE
Fix bug:aws-ses

### DIFF
--- a/mackerel-plugin-aws-ses/aws-ses.go
+++ b/mackerel-plugin-aws-ses/aws-ses.go
@@ -33,8 +33,8 @@ var graphdef = map[string](mp.Graphs){
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "Complaints", Label: "Complaints"},
 			mp.Metrics{Name: "DeliveryAttempts", Label: "DeliveryAttempts"},
-			mp.Metrics{Name: "Bounces int", Label: "Bounces"},
-			mp.Metrics{Name: "Rejects int", Label: "Rejects"},
+			mp.Metrics{Name: "Bounces", Label: "Bounces"},
+			mp.Metrics{Name: "Rejects", Label: "Rejects"},
 		},
 	},
 }


### PR DESCRIPTION
I tried aws-ses plugin, but can't get Bounces and Rejects metrics.
So, check mackerel-agent.log, find parse error.

```
2016/06/17 03:32:02 WARNING <metrics.plugin> Failed to parse values: strconv.ParseFloat: parsing "int": invalid synt
ax
2016/06/17 03:32:02 WARNING <metrics.plugin> Failed to parse values: strconv.ParseFloat: parsing "int": invalid synt
ax
```



environments:
mackerel-agent v0.30.4
mackerel-agent-plugins 0.20.0