### PR TITLE
Release version 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.21.0 (2016-06-23)
+
+* Add PHP-FPM plugin #226 (ariarijp)
+* Support password authentication of Redis #232 (hico-horiuchi)
+* Add an option to specify type and id pattern to fluentd plugin #233 (waniji)
+* Fix bug:aws-ses #234 (tjinjin)
+* fix help link #235 (daiksy)
+* xentop: get CPU %, not CPU time/min #236 (hagihala)
+* add mackerel-plugin-php-fpm into package #238 (Songmu)
+
+
 ## 0.20.2 (2016-06-09)
 
 * aws-ec2-ebs: Use wildcard in the graph definitions #230 (itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,22 @@
+mackerel-agent-plugins (0.21.0-1) stable; urgency=low
+
+  * Add PHP-FPM plugin (by ariarijp)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/226>
+  * Support password authentication of Redis (by hico-horiuchi)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/232>
+  * Add an option to specify type and id pattern to fluentd plugin (by waniji)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/233>
+  * Fix bug:aws-ses (by tjinjin)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/234>
+  * fix help link (by daiksy)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/235>
+  * xentop: get CPU %, not CPU time/min (by hagihala)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/236>
+  * add mackerel-plugin-php-fpm into package (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/238>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 23 Jun 2016 05:58:01 +0000
+
 mackerel-agent-plugins (0.20.2-1) stable; urgency=low
 
   * aws-ec2-ebs: Use wildcard in the graph definitions (by itchyny)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,15 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Thu Jun 23 2016 <mackerel-developers@hatena.ne.jp> - 0.21.0-1
+- Add PHP-FPM plugin (by ariarijp)
+- Support password authentication of Redis (by hico-horiuchi)
+- Add an option to specify type and id pattern to fluentd plugin (by waniji)
+- Fix bug:aws-ses (by tjinjin)
+- fix help link (by daiksy)
+- xentop: get CPU %, not CPU time/min (by hagihala)
+- add mackerel-plugin-php-fpm into package (by Songmu)
+
 * Thu Jun 09 2016 <mackerel-developers@hatena.ne.jp> - 0.20.2-1
 - aws-ec2-ebs: Use wildcard in the graph definitions (by itchyny)
 


### PR DESCRIPTION
- Add PHP-FPM plugin #226
- Support password authentication of Redis #232
- Add an option to specify type and id pattern to fluentd plugin #233
- Fix bug:aws-ses #234
- fix help link #235
- xentop: get CPU %, not CPU time/min #236
- add mackerel-plugin-php-fpm into package #238