### PR TITLE
Release version 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.21.1 (2016-06-28)
+
+* fix to use config.json to list up plugins for packaging #240 (stanaka)
+* build with go 1.6.2 #241 (Songmu)
+
+
 ## 0.21.0 (2016-06-23)
 
 * Add PHP-FPM plugin #226 (ariarijp)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.21.1 (2016-06-28)
 
-* fix to use config.json to list up plugins for packaging #240 (stanaka)
 * build with go 1.6.2 #241 (Songmu)
 
 

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-agent-plugins (0.21.1-1) stable; urgency=low
+
+  * fix to use config.json to list up plugins for packaging (by stanaka)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/240>
+  * build with go 1.6.2 (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/241>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 28 Jun 2016 09:23:23 +0000
+
 mackerel-agent-plugins (0.21.0-1) stable; urgency=low
 
   * Add PHP-FPM plugin (by ariarijp)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,7 +1,5 @@
 mackerel-agent-plugins (0.21.1-1) stable; urgency=low
 
-  * fix to use config.json to list up plugins for packaging (by stanaka)
-    <https://github.com/mackerelio/mackerel-agent-plugins/pull/240>
   * build with go 1.6.2 (by Songmu)
     <https://github.com/mackerelio/mackerel-agent-plugins/pull/241>
 

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,10 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Tue Jun 28 2016 <mackerel-developers@hatena.ne.jp> - 0.21.1-1
+- fix to use config.json to list up plugins for packaging (by stanaka)
+- build with go 1.6.2 (by Songmu)
+
 * Thu Jun 23 2016 <mackerel-developers@hatena.ne.jp> - 0.21.0-1
 - Add PHP-FPM plugin (by ariarijp)
 - Support password authentication of Redis (by hico-horiuchi)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -50,7 +50,6 @@ done
 
 %changelog
 * Tue Jun 28 2016 <mackerel-developers@hatena.ne.jp> - 0.21.1-1
-- fix to use config.json to list up plugins for packaging (by stanaka)
 - build with go 1.6.2 (by Songmu)
 
 * Thu Jun 23 2016 <mackerel-developers@hatena.ne.jp> - 0.21.0-1


### PR DESCRIPTION
- fix to use config.json to list up plugins for packaging #240
- build with go 1.6.2 #241