### PR TITLE
mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics

### DIFF
--- a/mackerel-plugin-linux/flags.go
+++ b/mackerel-plugin-linux/flags.go
@@ -16,9 +16,9 @@ var cliTempFile = cli.StringFlag{
 	EnvVar: "ENVVAR_TEMPFILE",
 }
 
-var cliType = cli.StringFlag{
+var cliType = cli.StringSliceFlag{
 	Name:   "type, p",
-	Value:  "all",
-	Usage:  "Select metrics: all, swap, netstat, diskstats, proc_stat, users",
+	Value:  &cli.StringSlice{},
+	Usage:  "Select metrics type(s) to fetch: all, swap, netstat, diskstats, proc_stat, users",
 	EnvVar: "ENVVAR_TYPE",
 }

--- a/mackerel-plugin-linux/linux.go
+++ b/mackerel-plugin-linux/linux.go
@@ -26,7 +26,7 @@ var graphdef = map[string](mp.Graphs){}
 // LinuxPlugin mackerel plugin for linux
 type LinuxPlugin struct {
 	Tempfile string
-	Type     string
+	Typemap  map[string]bool
 }
 
 // GraphDefinition interface for mackerelplugin
@@ -35,35 +35,35 @@ func (c LinuxPlugin) GraphDefinition() map[string](mp.Graphs) {
 
 	p := make(map[string]interface{})
 
-	if c.Type == "all" || c.Type == "swap" {
+	if c.Typemap["all"] || c.Typemap["swap"] {
 		err = collectProcVmstat(pathVmstat, &p)
 		if err != nil {
 			return nil
 		}
 	}
 
-	if c.Type == "all" || c.Type == "netstat" {
+	if c.Typemap["all"] || c.Typemap["netstat"] {
 		err = collectSs(&p)
 		if err != nil {
 			return nil
 		}
 	}
 
-	if c.Type == "all" || c.Type == "diskstats" {
+	if c.Typemap["all"] || c.Typemap["diskstats"] {
 		err = collectProcDiskstats(pathDiskstats, &p)
 		if err != nil {
 			return nil
 		}
 	}
 
-	if c.Type == "all" || c.Type == "proc_stat" {
+	if c.Typemap["all"] || c.Typemap["proc_stat"] {
 		err = collectProcStat(pathStat, &p)
 		if err != nil {
 			return nil
 		}
 	}
 
-	if c.Type == "all" || c.Type == "users" {
+	if c.Typemap["all"] || c.Typemap["users"] {
 		err = collectWho(&p)
 		if err != nil {
 			return nil
@@ -77,7 +77,17 @@ func (c LinuxPlugin) GraphDefinition() map[string](mp.Graphs) {
 func doMain(c *cli.Context) error {
 	var linux LinuxPlugin
 
-	linux.Type = c.String("type")
+	typemap := map[string]bool{}
+	types := c.StringSlice("type")
+	// If no `type` is specified, fetch all metrics
+	if len(types) == 0 {
+		typemap["all"] = true
+	} else {
+		for _, t := range types {
+			typemap[t] = true
+		}
+	}
+	linux.Typemap = typemap
 	helper := mp.NewMackerelPlugin(linux)
 	helper.Tempfile = c.String("tempfile")
 
@@ -91,35 +101,35 @@ func (c LinuxPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 	p := make(map[string]interface{})
 
-	if c.Type == "all" || c.Type == "swap" {
+	if c.Typemap["all"] || c.Typemap["swap"] {
 		err = collectProcVmstat(pathVmstat, &p)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if c.Type == "all" || c.Type == "netstat" {
+	if c.Typemap["all"] || c.Typemap["netstat"] {
 		err = collectSs(&p)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if c.Type == "all" || c.Type == "diskstats" {
+	if c.Typemap["all"] || c.Typemap["diskstats"] {
 		err = collectProcDiskstats(pathDiskstats, &p)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if c.Type == "all" || c.Type == "proc_stat" {
+	if c.Typemap["all"] || c.Typemap["proc_stat"] {
 		err = collectProcStat(pathStat, &p)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if c.Type == "all" || c.Type == "users" {
+	if c.Typemap["all"] || c.Typemap["users"] {
 		err = collectWho(&p)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently, `mackerel-plugin-linux` fetches all supported sets of metrics, or a specified set of metrics.
With this patch, `mackerel-plugin-linux` can fetch multiple, but not all sets of metrics, by specifying `--type` option multiple times.

Example:
```
[~] # ./mackerel-plugin-linux -p swap -p diskstats -p proc_stat
linux.swap.pswpin	0.000000	1467130047
linux.swap.pswpout	0.000000	1467130047
linux.disk.elapsed.iotime_sda	3000.000000	1467130047
linux.disk.elapsed.iotime_weighted_sda	3000.000000	1467130047
linux.disk.rwtime.tsreading_sda	0.000000	1467130047
linux.disk.rwtime.tswriting_sda	3000.000000	1467130047
linux.interrupts.interrupts	6255.000000	1467130047
linux.context_switches.context_switches	15810.000000	1467130047
linux.forks.forks	180.000000	1467130047
```

# Breaking change

Currently, `mackerel-plugin-linux -p A -p B` fetches only metrics set `B`.  This patch changes this behavior to fetch both `A` and `B`, but current behavior is not documented, and I thinks it is meaningless.