### PR TITLE
Implement mackerel-plugin-aws-ec2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Documentation for each plugin is located in its respective sub directory.
 
 * [mackerel-plugin-apache2](./mackerel-plugin-apache2/README.md)
 * [mackerel-plugin-aws-cloudfront](./mackerel-plugin-aws-cloudfront/README.md)
+* [mackerel-plugin-aws-ec2](./mackerel-plugin-aws-ec2/README.md)
 * [mackerel-plugin-aws-ec2-cpucredit](./mackerel-plugin-aws-ec2-cpucredit/README.md)
 * [mackerel-plugin-aws-ec2-ebs](./mackerel-plugin-aws-ec2-ebs/README.md)
 * [mackerel-plugin-aws-elasticache](./mackerel-plugin-aws-elasticache/README.md)

--- a/mackerel-plugin-aws-ec2/README.md
+++ b/mackerel-plugin-aws-ec2/README.md
@@ -1,0 +1,22 @@
+mackerel-plugin-aws-ec2
+=======================
+
+AWS EC2 custom metrics plugin for mackerel.io agent.
+
+## Synopsis
+
+```shell
+mackerel-plugin-aws-ec2 [-instance-id=<id>] [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+```
+* if you run on an ec2-instance, you probably don't have to specify `-instance-id` & `-region`
+* if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`
+
+## AWS IAM Policy
+the credential provided manually or fetched automatically by IAM Role should have the policy that includes an action, 'cloudwatch:GetMetricStatistics'
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.aws-ec2]
+command = "/path/to/mackerel-plugin-aws-ec2"
+```

--- a/mackerel-plugin-aws-ec2/README.md
+++ b/mackerel-plugin-aws-ec2/README.md
@@ -8,8 +8,10 @@ AWS EC2 custom metrics plugin for mackerel.io agent.
 ```shell
 mackerel-plugin-aws-ec2 [-instance-id=<id>] [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
-* if you run on an ec2-instance, you probably don't have to specify `-instance-id` & `-region`
-* if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`
+* if you run on an ec2-instance, you don't have to specify `-instance-id` & `-region`
+* if you configure credentials (by using the `~/.aws/credentials` file or by setting the environment variables), you don't have to specify `-access-key-id` & `-secret-access-key`
+
+※ For more information about credentials, see the [AWS SDK for Go](https://github.com/aws/aws-sdk-go#configuring-credentials).
 
 ## AWS IAM Policy
 the credential provided manually or fetched automatically by IAM Role should have the policy that includes an action, 'cloudwatch:GetMetricStatistics'

--- a/mackerel-plugin-aws-ec2/aws-ec2.go
+++ b/mackerel-plugin-aws-ec2/aws-ec2.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+
+	mp "github.com/mackerelio/go-mackerel-plugin"
+)
+
+var graphdef = map[string](mp.Graphs){
+	"ec2.CPUUtilization": mp.Graphs{
+		Label: "CPU Utilization",
+		Unit:  "percentage",
+		Metrics: [](mp.Metrics){
+			mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
+		},
+	},
+	"ec2.DiskBytes": mp.Graphs{
+		Label: "Disk Bytes",
+		Unit:  "bytes",
+		Metrics: [](mp.Metrics){
+			mp.Metrics{Name: "DiskReadBytes", Label: "DiskReadBytes"},
+			mp.Metrics{Name: "DiskWriteBytes", Label: "DiskWriteBytes"},
+		},
+	},
+	"ec2.DiskOps": mp.Graphs{
+		Label: "Disk Ops",
+		Unit:  "float",
+		Metrics: [](mp.Metrics){
+			mp.Metrics{Name: "DiskReadOps", Label: "DiskReadOps"},
+			mp.Metrics{Name: "DiskWriteOps", Label: "DiskWriteOps"},
+		},
+	},
+	"ec2.Network": mp.Graphs{
+		Label: "Network",
+		Unit:  "bytes",
+		Metrics: [](mp.Metrics){
+			mp.Metrics{Name: "NetworkIn", Label: "NetworkIn"},
+			mp.Metrics{Name: "NetworkOut", Label: "NetworkOut"},
+		},
+	},
+	"ec2.NetworkPackets": mp.Graphs{
+		Label: "Network",
+		Unit:  "bytes",
+		Metrics: [](mp.Metrics){
+			mp.Metrics{Name: "NetworkPacketsIn", Label: "NetworkPacketsIn"},
+			mp.Metrics{Name: "NetworkPacketsOut", Label: "NetworkPacketsOut"},
+		},
+	},
+	"ec2.StatusCheckFailed": mp.Graphs{
+		Label: "StatusCheckFailed",
+		Unit:  "integer",
+		Metrics: [](mp.Metrics){
+			mp.Metrics{Name: "StatusCheckFailed", Label: "StatusCheckFailed"},
+			mp.Metrics{Name: "StatusCheckFailed_Instance", Label: "StatusCheckFailed_Instance"},
+			mp.Metrics{Name: "StatusCheckFailed_System", Label: "StatusCheckFailed_System"},
+		},
+	},
+}
+
+// EC2Plugin is a mackerel plugin for ec2
+type EC2Plugin struct {
+	Region      string
+	Credentials *credentials.Credentials
+	InstanceID  string
+	CloudWatch  *cloudwatch.CloudWatch
+}
+
+func getLastPoint(cloudWatch *cloudwatch.CloudWatch, dimension *cloudwatch.Dimension, metricName string) (float64, error) {
+	now := time.Now()
+	response, err := cloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsInput{
+		StartTime:  aws.Time(now.Add(time.Duration(600) * time.Second * -1)),
+		EndTime:    aws.Time(now),
+		Period:     aws.Int64(60),
+		Namespace:  aws.String("AWS/EC2"),
+		Dimensions: []*cloudwatch.Dimension{dimension},
+		MetricName: aws.String(metricName),
+		Statistics: []*string{aws.String("Average")},
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	datapoints := response.Datapoints
+	if len(datapoints) == 0 {
+		return 0, errors.New("fetched no datapoints")
+	}
+
+	latest := time.Unix(0, 0)
+	var latestVal float64
+	for _, dp := range datapoints {
+		if dp.Timestamp.Before(latest) {
+			continue
+		}
+
+		latest = *dp.Timestamp
+		latestVal = *dp.Average
+	}
+
+	return latestVal, nil
+}
+
+// FetchMetrics fetches metrics from CloudWatch
+func (p EC2Plugin) FetchMetrics() (map[string]float64, error) {
+	stat := make(map[string]float64)
+	p.CloudWatch = cloudwatch.New(session.New(&aws.Config{Credentials: p.Credentials, Region: &p.Region}))
+	dimension := &cloudwatch.Dimension{
+		Name:  aws.String("InstanceId"),
+		Value: aws.String(p.InstanceID),
+	}
+
+	for _, met := range [...]string{
+		"CPUUtilization",
+		"DiskReadBytes",
+		"DiskReadOps",
+		"DiskWriteBytes",
+		"DiskWriteOps",
+		"NetworkIn",
+		"NetworkOut",
+		"NetworkPacketsIn",
+		"NetworkPacketsOut",
+		"StatusCheckFailed",
+		"StatusCheckFailed_Instance",
+		"StatusCheckFailed_System",
+	} {
+		v, err := getLastPoint(p.CloudWatch, dimension, met)
+		if err == nil {
+			stat[met] = v
+		} else {
+			log.Printf("%s: %s", met, err)
+		}
+	}
+
+	return stat, nil
+}
+
+// GraphDefinition returns graphdef
+func (p EC2Plugin) GraphDefinition() map[string](mp.Graphs) {
+	return graphdef
+}
+
+func main() {
+	optAccessKeyID := flag.String("access-key-id", "", "AWS Access Key ID")
+	optSecretAccessKey := flag.String("secret-access-key", "", "AWS Secret Access Key")
+	optRegion := flag.String("region", "", "AWS Region")
+	optInstanceID := flag.String("instance-id", "", "Instance ID")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	flag.Parse()
+
+	var ec2 EC2Plugin
+
+	// use credentials from option
+	if *optAccessKeyID != "" && *optSecretAccessKey != "" {
+		ec2.Credentials = credentials.NewStaticCredentials(*optAccessKeyID, *optSecretAccessKey, "")
+	}
+
+	// get metadata in ec2 instance
+	ec2MC := ec2metadata.New(session.New())
+	ec2.Region = *optRegion
+	if *optRegion == "" {
+		ec2.Region, _ = ec2MC.Region()
+	}
+	ec2.InstanceID = *optInstanceID
+	if *optInstanceID == "" {
+		ec2.InstanceID, _ = ec2MC.GetMetadata("instance-id")
+	}
+
+	helper := mp.NewMackerelPlugin(ec2)
+	if *optTempfile != "" {
+		helper.Tempfile = *optTempfile
+	} else {
+		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-aws-ec2-%s", *optInstanceID)
+	}
+
+	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
+		helper.OutputDefinitions()
+	} else {
+		helper.OutputValues()
+	}
+}

--- a/mackerel-plugin-aws-ec2/aws-ec2_test.go
+++ b/mackerel-plugin-aws-ec2/aws-ec2_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGraphDefinition(t *testing.T) {
+	var ec2 EC2Plugin
+	graphdef := ec2.GraphDefinition()
+
+	expected := 6
+	if actual := len(graphdef); actual != expected {
+		t.Errorf("GraphDefinition(): %d should be %d", actual, expected)
+	}
+}


### PR DESCRIPTION
This plugin fetches ec2 data from Clowdwatch using [AWS SDK for Go](https://github.com/aws/aws-sdk-go).
please see [README](https://github.com/yyoshiki41/mackerel-agent-plugins/blob/aws-ec2-plugin/mackerel-plugin-aws-ec2/README.md).
### Example

``` bash
$ cd path/to/mackerel-plugin-aws-ec2
$ go run aws-ec2.go --instance-id=i-*** --region=***
ec2.DiskOps.DiskReadOps 0   1467540363
ec2.DiskOps.DiskWriteOps    0   1467540363
ec2.Network.NetworkIn   37769.800000    1467540363
ec2.Network.NetworkOut  12428.400000    1467540363
ec2.NetworkPackets.NetworkPacketsIn 51.600000   1467540363
ec2.NetworkPackets.NetworkPacketsOut    41  1467540363
ec2.StatusCheckFailed.StatusCheckFailed 0   1467540363
ec2.StatusCheckFailed.StatusCheckFailed_Instance    0   1467540363
ec2.StatusCheckFailed.StatusCheckFailed_System  0   1467540363
ec2.CPUUtilization.CPUUtilization   0.282000    1467540363
ec2.DiskBytes.DiskReadBytes 0   1467540363
ec2.DiskBytes.DiskWriteBytes    0   1467540363
```
