### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ yum install mackerel-agent-plugins
 apt-get install mackerel-agent-plugins
 ```
 
-mackerel-agent-plugins will be installed to ```/usr/local/bin/mackerel-plugin-*```.
+mackerel-agent-plugins will be installed to ```/usr/bin/mackerel-plugin-*```.
 
 Caution
 =======


### PR DESCRIPTION
# What is this

I fixed `README.md` because default path of plugins was changed to `/usr/bin` since `v0.19.4` via https://github.com/mackerelio/mackerel-agent-plugins/pull/208 .
Ofcource, some plugins are still remaining at `/usr/local/bin` .
So, the current description is a little confused, 

Thank you 🙇 