### PR TITLE
Fixed flag comment of mackerel-plugin-fluentd

### DIFF
--- a/mackerel-plugin-fluentd/fluentd.go
+++ b/mackerel-plugin-fluentd/fluentd.go
@@ -127,7 +127,7 @@ func (f FluentdMetrics) GraphDefinition() map[string](mp.Graphs) {
 }
 
 func main() {
-	host := flag.String("host", "localhost", "fluentd monitor_agent port")
+	host := flag.String("host", "localhost", "fluentd monitor_agent host")
 	port := flag.String("port", "24220", "fluentd monitor_agent port")
 	pluginType := flag.String("plugin-type", "", "Gets the metric that matches this plugin type")
 	pluginIDPatternString := flag.String("plugin-id-pattern", "", "Gets the metric that matches this plugin id pattern")


### PR DESCRIPTION
I found that flag comment ( `-host` ) of mackerel-plugin-fluentd has nits typo. 🙇 

# Before

```
$ /usr/bin/mackerel-plugin-fluentd --help
Usage of /usr/bin/mackerel-plugin-fluentd:
  -host string
       	fluentd monitor_agent port (default "localhost")
  -plugin-id-pattern string
       	Gets the metric that matches this plugin id pattern
  -plugin-type string
       	Gets the metric that matches this plugin type
  -port string
       	fluentd monitor_agent port (default "24220")
  -tempfile string
       	Temp file name
```

Thank you. 👍 