### PR TITLE
Don't specify default tempfile path

### DIFF
--- a/mackerel-plugin-apache2/apache2.go
+++ b/mackerel-plugin-apache2/apache2.go
@@ -14,67 +14,78 @@ import (
 	"github.com/urfave/cli"
 )
 
-// metric value structure
-var graphdef = map[string](mp.Graphs){
-	"apache2.workers": mp.Graphs{
-		Label: "Apache Workers",
-		Unit:  "integer",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "busy_workers", Label: "Busy Workers", Diff: false, Stacked: true},
-			mp.Metrics{Name: "idle_workers", Label: "Idle Workers", Diff: false, Stacked: true},
-		},
-	},
-	"apache2.bytes": mp.Graphs{
-		Label: "Apache Bytes",
-		Unit:  "bytes",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "bytes_sent", Label: "Bytes Sent", Diff: true, Type: "uint64"},
-		},
-	},
-	"apache2.cpu": mp.Graphs{
-		Label: "Apache CPU Load",
-		Unit:  "float",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "cpu_load", Label: "CPU Load", Diff: false},
-		},
-	},
-	"apache2.req": mp.Graphs{
-		Label: "Apache Requests",
-		Unit:  "integer",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "requests", Label: "Requests", Diff: true, Type: "uint64"},
-		},
-	},
-	"apache2.scoreboard": mp.Graphs{
-		Label: "Apache Scoreboard",
-		Unit:  "integer",
-		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "score-_", Label: "Waiting for connection", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-S", Label: "Starting up", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-R", Label: "Reading request", Diff: false, Stacked: true},
-			mp.Metrics{Name: "scpre-W", Label: "Sending reply", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-K", Label: "Keepalive", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-D", Label: "DNS lookup", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-C", Label: "Closing connection", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-L", Label: "Logging", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-G", Label: "Gracefully finishing", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-I", Label: "Idle cleanup", Diff: false, Stacked: true},
-			mp.Metrics{Name: "score-.", Label: "Open slot", Diff: false, Stacked: true},
-		},
-	},
-}
-
 // Apache2Plugin for fetching metrics
 type Apache2Plugin struct {
-	Host     string
-	Port     uint16
-	Path     string
-	Header   []string
-	Tempfile string
+	Host        string
+	Port        uint16
+	Path        string
+	Header      []string
+	Tempfile    string
+	Prefix      string
+	LabelPrefix string
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (c Apache2Plugin) MetricKeyPrefix() string {
+	if c.Prefix == "" {
+		c.Prefix = "apache2"
+	}
+	return c.Prefix
 }
 
 // GraphDefinition Graph definition
 func (c Apache2Plugin) GraphDefinition() map[string](mp.Graphs) {
+	labelPrefix := c.LabelPrefix
+
+	// metric value structure
+	var graphdef = map[string](mp.Graphs){
+		"workers": mp.Graphs{
+			Label: (labelPrefix + " Workers"),
+			Unit:  "integer",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "busy_workers", Label: "Busy Workers", Diff: false, Stacked: true},
+				mp.Metrics{Name: "idle_workers", Label: "Idle Workers", Diff: false, Stacked: true},
+			},
+		},
+		"bytes": mp.Graphs{
+			Label: (labelPrefix + " Bytes"),
+			Unit:  "bytes",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "bytes_sent", Label: "Bytes Sent", Diff: true, Type: "uint64"},
+			},
+		},
+		"cpu": mp.Graphs{
+			Label: (labelPrefix + " CPU Load"),
+			Unit:  "float",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "cpu_load", Label: "CPU Load", Diff: false},
+			},
+		},
+		"req": mp.Graphs{
+			Label: (labelPrefix + " Requests"),
+			Unit:  "integer",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "requests", Label: "Requests", Diff: true, Type: "uint64"},
+			},
+		},
+		"scoreboard": mp.Graphs{
+			Label: (labelPrefix + " Scoreboard"),
+			Unit:  "integer",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "score-_", Label: "Waiting for connection", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-S", Label: "Starting up", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-R", Label: "Reading request", Diff: false, Stacked: true},
+				mp.Metrics{Name: "scpre-W", Label: "Sending reply", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-K", Label: "Keepalive", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-D", Label: "DNS lookup", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-C", Label: "Closing connection", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-L", Label: "Logging", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-G", Label: "Gracefully finishing", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-I", Label: "Idle cleanup", Diff: false, Stacked: true},
+				mp.Metrics{Name: "score-.", Label: "Open slot", Diff: false, Stacked: true},
+			},
+		},
+	}
 	return graphdef
 }
 
@@ -87,6 +98,8 @@ func doMain(c *cli.Context) error {
 	apache2.Port = uint16(c.Int("http_port"))
 	apache2.Path = c.String("status_page")
 	apache2.Header = c.StringSlice("header")
+	apache2.Prefix = c.String("metric-key-prefix")
+	apache2.LabelPrefix = c.String("label-prefix")
 
 	helper := mp.NewMackerelPlugin(apache2)
 	helper.Tempfile = c.String("tempfile")

--- a/mackerel-plugin-apache2/flags.go
+++ b/mackerel-plugin-apache2/flags.go
@@ -10,6 +10,8 @@ var flags = []cli.Flag{
 	cliHeader,
 	cliStatusPage,
 	cliTempFile,
+	cliMetricKerPrefix,
+	cliLabelPrefix,
 }
 
 var cliHTTPHost = cli.StringFlag{
@@ -42,7 +44,18 @@ var cliStatusPage = cli.StringFlag{
 
 var cliTempFile = cli.StringFlag{
 	Name:   "tempfile, t",
-	Value:  "/tmp/mackerel-plugin-apache2",
 	Usage:  "Set temporary file path.",
 	EnvVar: "ENVVAR_TEMPFILE",
+}
+
+var cliMetricKerPrefix = cli.StringFlag{
+	Name:  "metric-key-prefix, m",
+	Value: "apache2",
+	Usage: "Set metric key prefix.",
+}
+
+var cliLabelPrefix = cli.StringFlag{
+	Name:  "label-prefix, l",
+	Value: "Apache",
+	Usage: "Set metric label prefix.",
 }

--- a/mackerel-plugin-aws-cloudfront/README.md
+++ b/mackerel-plugin-aws-cloudfront/README.md
@@ -6,7 +6,7 @@ AWS CloudFront custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-cloudfront -identifier=<cloudfront-distribution-id> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-cloudfront -identifier=<cloudfront-distribution-id> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>] [-metric-key-prefix=<cloudfront>] [-metric-label-prefix=<CloudFront>]
 ```
 
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`

--- a/mackerel-plugin-aws-ec2-ebs/aws-ec2-ebs.go
+++ b/mackerel-plugin-aws-ec2-ebs/aws-ec2-ebs.go
@@ -95,7 +95,7 @@ var cloudwatchdefs = map[string](cloudWatchSetting){
 }
 
 var graphdef = map[string](mp.Graphs){
-	"ec2.ebs.bandwidth.#": mp.Graphs{
+	"ebs.bandwidth.#": mp.Graphs{
 		Label: "EBS Bandwidth",
 		Unit:  "bytes/sec",
 		Metrics: [](mp.Metrics){
@@ -103,7 +103,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "write", Label: "Write", Diff: false},
 		},
 	},
-	"ec2.ebs.throughput.#": mp.Graphs{
+	"ebs.throughput.#": mp.Graphs{
 		Label: "EBS Throughput (op/s)",
 		Unit:  "iops",
 		Metrics: [](mp.Metrics){
@@ -111,7 +111,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "write", Label: "Write", Diff: false},
 		},
 	},
-	"ec2.ebs.size_per_op.#": mp.Graphs{
+	"ebs.size_per_op.#": mp.Graphs{
 		Label: "EBS Avg Op Size (Bytes/op)",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
@@ -119,7 +119,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "write", Label: "Write", Diff: false},
 		},
 	},
-	"ec2.ebs.latency.#": mp.Graphs{
+	"ebs.latency.#": mp.Graphs{
 		Label: "EBS Avg Latency (ms/op)",
 		Unit:  "float",
 		Metrics: [](mp.Metrics){
@@ -127,28 +127,28 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "write", Label: "Write", Diff: false},
 		},
 	},
-	"ec2.ebs.queue_length.#": mp.Graphs{
+	"ebs.queue_length.#": mp.Graphs{
 		Label: "EBS Avg Queue Length (ops)",
 		Unit:  "float",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "queue_length", Label: "Queue Length", Diff: false},
 		},
 	},
-	"ec2.ebs.idle_time.#": mp.Graphs{
+	"ebs.idle_time.#": mp.Graphs{
 		Label: "EBS Time Spent Idle",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "idle_time", Label: "Idle Time", Diff: false},
 		},
 	},
-	"ec2.ebs.throughput_delivered.#": mp.Graphs{
+	"ebs.throughput_delivered.#": mp.Graphs{
 		Label: "EBS Throughput of Provisioned IOPS",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "throughput_delivered", Label: "Throughput", Diff: false},
 		},
 	},
-	"ec2.ebs.consumed_ops.#": mp.Graphs{
+	"ebs.consumed_ops.#": mp.Graphs{
 		Label: "EBS Consumed Ops of Provisioned IOPS",
 		Unit:  "float",
 		Metrics: [](mp.Metrics){
@@ -169,6 +169,11 @@ type EBSPlugin struct {
 	EC2             *ec2.EC2
 	CloudWatch      *cloudwatch.CloudWatch
 	Volumes         []*ec2.Volume
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (p EBSPlugin) MetricKeyPrefix() string {
+	return "ec2"
 }
 
 func (p *EBSPlugin) prepare() error {
@@ -330,11 +335,7 @@ func main() {
 	}
 
 	helper := mp.NewMackerelPlugin(ebs)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-ebs"
-	}
+	helper.Tempfile = *optTempfile
 
 	helper.Run()
 }

--- a/mackerel-plugin-aws-elasticache/aws-elasticache.go
+++ b/mackerel-plugin-aws-elasticache/aws-elasticache.go
@@ -3,14 +3,13 @@ package main
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"time"
 
 	"github.com/crowdmob/goamz/aws"
 	"github.com/crowdmob/goamz/cloudwatch"
-	mp "github.com/mackerelio/go-mackerel-plugin"
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 )
 
 var metricsdefMemcached = []string{
@@ -33,28 +32,28 @@ var metricsdefRedis = []string{
 }
 
 var graphdefMemcached = map[string](mp.Graphs){
-	"ecache.CPUUtilization": mp.Graphs{
+	"CPUUtilization": mp.Graphs{
 		Label: "ECache CPU Utilization",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
 		},
 	},
-	"ecache.SwapUsage": mp.Graphs{
+	"SwapUsage": mp.Graphs{
 		Label: "ECache Swap Usage",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "SwapUsage", Label: "SwapUsage"},
 		},
 	},
-	"ecache.FreeableMemory": mp.Graphs{
+	"FreeableMemory": mp.Graphs{
 		Label: "ECache Freeable Memory",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "FreeableMemory", Label: "FreeableMemory"},
 		},
 	},
-	"ecache.NetworkTraffic": mp.Graphs{
+	"NetworkTraffic": mp.Graphs{
 		Label: "ECache Network Traffic",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
@@ -62,7 +61,7 @@ var graphdefMemcached = map[string](mp.Graphs){
 			mp.Metrics{Name: "NetworkBytesOut", Label: "NetworkBytesOut"},
 		},
 	},
-	"ecache.Command": mp.Graphs{
+	"Command": mp.Graphs{
 		Label: "ECache Command",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -74,7 +73,7 @@ var graphdefMemcached = map[string](mp.Graphs){
 			mp.Metrics{Name: "CmdConfigSet", Label: "CmdConfigSet"},
 		},
 	},
-	"ecache.CacheHitAndMiss": mp.Graphs{
+	"CacheHitAndMiss": mp.Graphs{
 		Label: "ECache Hits/Misses",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -93,14 +92,14 @@ var graphdefMemcached = map[string](mp.Graphs){
 			mp.Metrics{Name: "TouchMisses", Label: "TouchMisses"},
 		},
 	},
-	"ecache.Evictions": mp.Graphs{
+	"Evictions": mp.Graphs{
 		Label: "ECache Evictions",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "Evictions", Label: "Evictions"},
 		},
 	},
-	"ecache.Unfetched": mp.Graphs{
+	"Unfetched": mp.Graphs{
 		Label: "ECache Unfetched",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -108,7 +107,7 @@ var graphdefMemcached = map[string](mp.Graphs){
 			mp.Metrics{Name: "ExpiredUnfetched", Label: "ExpiredUnfetched"},
 		},
 	},
-	"ecache.Bytes": mp.Graphs{
+	"Bytes": mp.Graphs{
 		Label: "ECache Traffics",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
@@ -116,7 +115,7 @@ var graphdefMemcached = map[string](mp.Graphs){
 			mp.Metrics{Name: "BytesWrittenOutFromMemcached", Label: "BytesWrittenOutFromMemcached"},
 		},
 	},
-	"ecache.Connections": mp.Graphs{
+	"Connections": mp.Graphs{
 		Label: "ECache Connections",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -124,7 +123,7 @@ var graphdefMemcached = map[string](mp.Graphs){
 			mp.Metrics{Name: "NewConnections", Label: "NewConnections"},
 		},
 	},
-	"ecache.Items": mp.Graphs{
+	"Items": mp.Graphs{
 		Label: "ECache Items",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -135,7 +134,7 @@ var graphdefMemcached = map[string](mp.Graphs){
 			mp.Metrics{Name: "SlabsMoved", Label: "SlabsMoved"},
 		},
 	},
-	"ecache.MemoryUsage": mp.Graphs{
+	"MemoryUsage": mp.Graphs{
 		Label: "ECache Memory Usage",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
@@ -147,28 +146,28 @@ var graphdefMemcached = map[string](mp.Graphs){
 }
 
 var graphdefRedis = map[string](mp.Graphs){
-	"ecache.CPUUtilization": mp.Graphs{
+	"CPUUtilization": mp.Graphs{
 		Label: "ECache CPU Utilization",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
 		},
 	},
-	"ecache.SwapUsage": mp.Graphs{
+	"SwapUsage": mp.Graphs{
 		Label: "ECache Swap Usage",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "SwapUsage", Label: "SwapUsage"},
 		},
 	},
-	"ecache.FreeableMemory": mp.Graphs{
+	"FreeableMemory": mp.Graphs{
 		Label: "ECache Freeable Memory",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "FreeableMemory", Label: "FreeableMemory"},
 		},
 	},
-	"ecache.NetworkTraffic": mp.Graphs{
+	"NetworkTraffic": mp.Graphs{
 		Label: "ECache Network Traffic",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
@@ -176,7 +175,7 @@ var graphdefRedis = map[string](mp.Graphs){
 			mp.Metrics{Name: "NetworkBytesOut", Label: "NetworkBytesOut"},
 		},
 	},
-	"ecache.Command": mp.Graphs{
+	"Command": mp.Graphs{
 		Label: "ECache Command",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -190,7 +189,7 @@ var graphdefRedis = map[string](mp.Graphs){
 			mp.Metrics{Name: "SortedSetBasedCmds", Label: "SortedSetBasedCmds"},
 		},
 	},
-	"ecache.CacheHitAndMiss": mp.Graphs{
+	"CacheHitAndMiss": mp.Graphs{
 		Label: "ECache Hits/Misses",
 		Unit:  "float",
 		Metrics: [](mp.Metrics){
@@ -198,21 +197,21 @@ var graphdefRedis = map[string](mp.Graphs){
 			mp.Metrics{Name: "CacheMisses", Label: "CacheMisses"},
 		},
 	},
-	"ecache.Evictions": mp.Graphs{
+	"Evictions": mp.Graphs{
 		Label: "ECache Evictions",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "Evictions", Label: "Evictions"},
 		},
 	},
-	"ecache.Bytes": mp.Graphs{
+	"Bytes": mp.Graphs{
 		Label: "ECache Traffics",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "BytesUsedForCache", Label: "BytesUsedForCache"},
 		},
 	},
-	"ecache.Connections": mp.Graphs{
+	"Connections": mp.Graphs{
 		Label: "ECache Connections",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -220,7 +219,7 @@ var graphdefRedis = map[string](mp.Graphs){
 			mp.Metrics{Name: "NewConnections", Label: "NewConnections"},
 		},
 	},
-	"ecache.Items": mp.Graphs{
+	"Items": mp.Graphs{
 		Label: "ECache Items",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -239,6 +238,11 @@ type ECachePlugin struct {
 	CacheNodeID     string
 	ElastiCacheType string
 	CacheMetrics    []string
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (p ECachePlugin) MetricKeyPrefix() string {
+	return "ecache"
 }
 
 func getLastPoint(cloudWatch *cloudwatch.CloudWatch, dimensions *[]cloudwatch.Dimension, metricName string) (float64, error) {
@@ -277,7 +281,7 @@ func getLastPoint(cloudWatch *cloudwatch.CloudWatch, dimensions *[]cloudwatch.Di
 }
 
 // FetchMetrics fetch elasticache values
-func (p ECachePlugin) FetchMetrics() (map[string]float64, error) {
+func (p ECachePlugin) FetchMetrics() (map[string]interface{}, error) {
 	auth, err := aws.GetAuth(p.AccessKeyID, p.SecretAccessKey, "", time.Now())
 	if err != nil {
 		return nil, err
@@ -288,7 +292,7 @@ func (p ECachePlugin) FetchMetrics() (map[string]float64, error) {
 		return nil, err
 	}
 
-	stat := make(map[string]float64)
+	stat := make(map[string]interface{})
 
 	perInstances := &[]cloudwatch.Dimension{
 		{
@@ -332,7 +336,7 @@ func main() {
 	optSecretAccessKey := flag.String("secret-access-key", "", "AWS Secret Access Key")
 	optCacheClusterID := flag.String("cache-cluster-id", "", "Cache Cluster Id")
 	optCacheNodeID := flag.String("cache-node-id", "0001", "Cache Node Id")
-	optElastiCacheType := flag.String("elasticache-type", "", "ElastiCache type")
+	optElastiCacheType := flag.String("elasticache-type", "", "ElastiCache type ('memcached' or 'redis')")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
 
@@ -360,15 +364,6 @@ func main() {
 	}
 
 	helper := mp.NewMackerelPlugin(ecache)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-aws-elasticache-%s-%s", *optCacheClusterID, *optCacheNodeID)
-	}
-
-	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
-		helper.OutputDefinitions()
-	} else {
-		helper.OutputValues()
-	}
+	helper.Tempfile = *optTempfile
+	helper.Run()
 }

--- a/mackerel-plugin-aws-elasticsearch/aws-elasticsearch.go
+++ b/mackerel-plugin-aws-elasticsearch/aws-elasticsearch.go
@@ -4,58 +4,57 @@ import (
 	"errors"
 	"flag"
 	"log"
-	"os"
 	"time"
 
 	"github.com/crowdmob/goamz/aws"
 	"github.com/crowdmob/goamz/cloudwatch"
-	mp "github.com/mackerelio/go-mackerel-plugin"
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 )
 
 var graphdef = map[string](mp.Graphs){
-	"es.Nodes": mp.Graphs{
+	"Nodes": mp.Graphs{
 		Label: "AWS ES Nodes",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "Nodes", Label: "Nodes"},
 		},
 	},
-	"es.CPUUtilization": mp.Graphs{
+	"CPUUtilization": mp.Graphs{
 		Label: "AWS ES CPU Utilization",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "CPUUtilization", Label: "CPUUtilization"},
 		},
 	},
-	"es.JVMMemoryPressure": mp.Graphs{
+	"JVMMemoryPressure": mp.Graphs{
 		Label: "AWS ES JVMMemoryPressure",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "JVMMemoryPressure", Label: "JVMMemoryPressure"},
 		},
 	},
-	"es.FreeStorageSpace": mp.Graphs{
+	"FreeStorageSpace": mp.Graphs{
 		Label: "AWS ES Free Storage Space",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "FreeStorageSpace", Label: "FreeStorageSpace"},
 		},
 	},
-	"es.SearchableDocuments": mp.Graphs{
+	"SearchableDocuments": mp.Graphs{
 		Label: "AWS ES SearchableDocuments",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "SearchableDocuments", Label: "SearchableDocuments"},
 		},
 	},
-	"es.DeletedDocuments": mp.Graphs{
+	"DeletedDocuments": mp.Graphs{
 		Label: "AWS ES DeletedDocuments",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "DeletedDocuments", Label: "DeletedDocuments"},
 		},
 	},
-	"es.IOPS": mp.Graphs{
+	"IOPS": mp.Graphs{
 		Label: "AWS ES IOPS",
 		Unit:  "iops",
 		Metrics: [](mp.Metrics){
@@ -63,7 +62,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "WriteIOPS", Label: "WriteIOPS"},
 		},
 	},
-	"es.Throughput": mp.Graphs{
+	"Throughput": mp.Graphs{
 		Label: "AWS ES Throughput",
 		Unit:  "bytes/sec",
 		Metrics: [](mp.Metrics){
@@ -71,28 +70,28 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "WriteThroughput", Label: "WriteThroughput"},
 		},
 	},
-	"es.DiskQueueDepth": mp.Graphs{
+	"DiskQueueDepth": mp.Graphs{
 		Label: "AWS ES DiskQueueDepth",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "DiskQueueDepth", Label: "DiskQueueDepth"},
 		},
 	},
-	"es.AutomatedSnapshotFailure": mp.Graphs{
+	"AutomatedSnapshotFailure": mp.Graphs{
 		Label: "AWS ES AutomatedSnapshotFailure",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "AutomatedSnapshotFailure", Label: "AutomatedSnapshotFailure"},
 		},
 	},
-	"es.MasterCPUUtilization": mp.Graphs{
+	"MasterCPUUtilization": mp.Graphs{
 		Label: "AWS ES MasterCPUUtilization",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "MasterCPUUtilization", Label: "MasterCPUUtilization"},
 		},
 	},
-	"es.Latency": mp.Graphs{
+	"Latency": mp.Graphs{
 		Label: "AWS ES Latency",
 		Unit:  "float",
 		Metrics: [](mp.Metrics){
@@ -100,21 +99,21 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "WriteLatency", Label: "WriteLatency"},
 		},
 	},
-	"es.MasterJVMMemoryPressure": mp.Graphs{
+	"MasterJVMMemoryPressure": mp.Graphs{
 		Label: "AWS ES MasterJVMMemoryPressure",
 		Unit:  "percentage",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "MasterJVMMemoryPressure", Label: "MasterJVMMemoryPressure"},
 		},
 	},
-	"es.MasterFreeStorageSpace": mp.Graphs{
+	"MasterFreeStorageSpace": mp.Graphs{
 		Label: "AWS ES MasterFreeStorageSpace",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
 			mp.Metrics{Name: "MasterFreeStorageSpace", Label: "MasterFreeStorageSpace"},
 		},
 	},
-	"es.ClusterStatus": mp.Graphs{
+	"ClusterStatus": mp.Graphs{
 		Label: "AWS ES ClusterStatus",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -136,6 +135,11 @@ type ESPlugin struct {
 }
 
 const esNameSpace = "AWS/ES"
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (p ESPlugin) MetricKeyPrefix() string {
+	return "es"
+}
 
 func (p *ESPlugin) prepare() error {
 	auth, err := aws.GetAuth(p.AccessKeyID, p.SecretAccessKey, "", time.Now())
@@ -187,7 +191,7 @@ func (p ESPlugin) getLastPoint(dimensions *[]cloudwatch.Dimension, metricName st
 }
 
 // FetchMetrics interface for mackerelplugin
-func (p ESPlugin) FetchMetrics() (map[string]float64, error) {
+func (p ESPlugin) FetchMetrics() (map[string]interface{}, error) {
 	dimensions := []cloudwatch.Dimension{
 		{
 			Name:  "DomainName",
@@ -207,7 +211,7 @@ func (p ESPlugin) FetchMetrics() (map[string]float64, error) {
 		log.Printf("%s", err)
 	}
 
-	stat := make(map[string]float64)
+	stat := make(map[string]interface{})
 
 	for _, met := range ret.ListMetricsResult.Metrics {
 		v, err := p.getLastPoint(&dimensions, met.MetricName)
@@ -258,15 +262,6 @@ func main() {
 	}
 
 	helper := mp.NewMackerelPlugin(es)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-aws-elasticsearch"
-	}
-
-	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
-		helper.OutputDefinitions()
-	} else {
-		helper.OutputValues()
-	}
+	helper.Tempfile = *optTempfile
+	helper.Run()
 }

--- a/mackerel-plugin-conntrack/README.md
+++ b/mackerel-plugin-conntrack/README.md
@@ -14,7 +14,7 @@ mackerel-plugin-conntrack [-tempfile=<tempfile>] [-version]
 $ mackerel-plugin-conntrack -h
 Usage of mackerel-plugin-conntrack:
   -tempfile string
-        Temp file name (default "/tmp/mackerel-plugin-conntrack")
+        Temp file name
   -version
         Print version information and quit.
 ```

--- a/mackerel-plugin-conntrack/cli.go
+++ b/mackerel-plugin-conntrack/cli.go
@@ -21,7 +21,7 @@ type ConntrackPlugin struct{}
 func (c ConntrackPlugin) GraphDefinition() map[string](mp.Graphs) {
 	// graphdef is Graph definition for mackerelplugin.
 	var graphdef = map[string](mp.Graphs){
-		"conntrack.count": mp.Graphs{
+		"count": mp.Graphs{
 			Label: "Conntrack Count",
 			Unit:  "integer",
 			Metrics: [](mp.Metrics){
@@ -31,6 +31,11 @@ func (c ConntrackPlugin) GraphDefinition() map[string](mp.Graphs) {
 	}
 
 	return graphdef
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (c ConntrackPlugin) MetricKeyPrefix() string {
+	return "conntrack"
 }
 
 // FetchMetrics interface for mackerelplugin.
@@ -68,7 +73,7 @@ func (c *CLI) Run(args []string) int {
 	// Define option flag parse
 	flags := flag.NewFlagSet(Name, flag.ContinueOnError)
 	flags.BoolVar(&version, "version", false, "Print version information and quit.")
-	flags.StringVar(&tempfile, "tempfile", "/tmp/mackerel-plugin-conntrack", "Temp file name")
+	flags.StringVar(&tempfile, "tempfile", "", "Temp file name")
 
 	// Parse commandline flag
 	if err := flags.Parse(args[1:]); err != nil {

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -18,7 +18,7 @@ import (
 )
 
 var graphdef = map[string](mp.Graphs){
-	"docker.cpuacct.#": mp.Graphs{
+	"cpuacct.#": mp.Graphs{
 		Label: "Docker CPU",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -26,7 +26,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "system", Label: "System", Diff: true, Stacked: true, Type: "uint64"},
 		},
 	},
-	"docker.memory.#": mp.Graphs{
+	"memory.#": mp.Graphs{
 		Label: "Docker Memory",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -34,7 +34,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "rss", Label: "RSS", Diff: false, Stacked: true},
 		},
 	},
-	"docker.blkio.io_queued.#": mp.Graphs{
+	"blkio.io_queued.#": mp.Graphs{
 		Label: "Docker BlkIO Queued",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -44,7 +44,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "async", Label: "Async", Diff: false, Stacked: true},
 		},
 	},
-	"docker.blkio.io_serviced.#": mp.Graphs{
+	"blkio.io_serviced.#": mp.Graphs{
 		Label: "Docker BlkIO IOPS",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -54,7 +54,7 @@ var graphdef = map[string](mp.Graphs){
 			mp.Metrics{Name: "async", Label: "Async", Diff: true, Stacked: true, Type: "uint64"},
 		},
 	},
-	"docker.blkio.io_service_bytes.#": mp.Graphs{
+	"blkio.io_service_bytes.#": mp.Graphs{
 		Label: "Docker BlkIO Bytes",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
@@ -75,6 +75,11 @@ type DockerPlugin struct {
 	NameFormat    string
 	Label         string
 	pathBuilder   *pathBuilder
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (m DockerPlugin) MetricKeyPrefix() string {
+	return "docker"
 }
 
 func getFile(path string) (string, error) {
@@ -465,16 +470,6 @@ func main() {
 	}
 
 	helper := mp.NewMackerelPlugin(docker)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-docker-%s", normalizeMetricName(*optHost))
-	}
-
-	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
-		helper.OutputDefinitions()
-	} else {
-		helper.OutputValues()
-	}
+	helper.Tempfile = *optTempfile
+	helper.Run()
 }


### PR DESCRIPTION
ref: https://github.com/mackerelio/mackerel-agent/pull/277 / https://github.com/mackerelio/go-mackerel-plugin-helper/pull/21

With above changes about `MACKEREL_PLUGIN_WORKDIR`, plugins should place their tempfile under `MACKEREL_PLUGIN_WORKDIR`.
The fastest way to achieve it is to change plugins to implement `mp.PluginWithPrefix` interface and stopped to specify default tempfile. For `mp.PluginWithPrefix` without `tempfile` parameter, `mp` will automatically decide tempfile path under `MACKEREL_PLUGIN_WORKDIR`.

I'm sorry that I don't change all of plugins, because there are SO many! (maybe about 30 plugins are left unchanged...)
If this p-r approved, I'll change rest of them.