### PR TITLE
[Plack] Adopt Plack::Middleware::ServerStatus::Lite 0.35's response

### DIFF
--- a/mackerel-plugin-plack/plack.go
+++ b/mackerel-plugin-plack/plack.go
@@ -68,7 +68,7 @@ type PlackRequest struct{}
 
 // PlackServerStatus sturct for server-status's json
 type PlackServerStatus struct {
-	// Uptime        string         `json:"Uptime"`
+	Uptime        interface{}    `json:"Uptime"` // Plack::Middleware::ServerStatus::Lite 0.35 outputs Uptime as a JSON number, though pre-0.35 outputs it as a JSON string.
 	TotalAccesses string         `json:"TotalAccesses"`
 	TotalKbytes   string         `json:"TotalKbytes"`
 	BusyWorkers   string         `json:"BusyWorkers"`

--- a/mackerel-plugin-plack/plack.go
+++ b/mackerel-plugin-plack/plack.go
@@ -68,7 +68,7 @@ type PlackRequest struct{}
 
 // PlackServerStatus sturct for server-status's json
 type PlackServerStatus struct {
-	Uptime        string         `json:"Uptime"`
+	// Uptime        string         `json:"Uptime"`
 	TotalAccesses string         `json:"TotalAccesses"`
 	TotalKbytes   string         `json:"TotalKbytes"`
 	BusyWorkers   string         `json:"BusyWorkers"`

--- a/mackerel-plugin-plack/plack_test.go
+++ b/mackerel-plugin-plack/plack_test.go
@@ -70,4 +70,14 @@ func TestParse(t *testing.T) {
 	assert.EqualValues(t, stat["requests"], 2)
 	assert.EqualValues(t, reflect.TypeOf(stat["bytes_sent"]).String(), "uint64")
 	assert.EqualValues(t, stat["bytes_sent"], 5)
+
+	stubWithIntUptime := `
+{"TotalKbytes":"36","IdleWorkers":"0","BusyWorkers":"0","TotalAccesses":"670","stats":[],"Uptime":1474047568}
+`
+
+	plackStatsWithIntUptime := bytes.NewBufferString(stubWithIntUptime)
+
+	statWithIntUptime, err := plack.parseStats(plackStatsWithIntUptime)
+	fmt.Println(statWithIntUptime)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
Related: https://github.com/kazeburo/Plack-Middleware-ServerStatus-Lite/pull/20

In response from Plack::Middleware::ServerStatus::Lite < 0.35, `Uptime` was a JSON string. But at its 0.35, `Uptime` became (maybe unexpectedly) a JSON number.
Because of this change, mackerel-plugin-plack became unable to parse a response from Plack::Middleware::ServerStatus::Lite 0.35.