### PR TITLE
Add much graphs/metrics to mackerel-plugin-mysql

### DIFF
--- a/mackerel-plugin-mysql/README.md
+++ b/mackerel-plugin-mysql/README.md
@@ -6,7 +6,7 @@ MySQL custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-mysql [-host=<host>] [-port=<port>] [-username=<username>] [-password=<password>] [-tempfile=<tempfile>] [-disable_innodb=true]
+mackerel-plugin-mysql [-host=<host>] [-port=<port>] [-username=<username>] [-password=<password>] [-tempfile=<tempfile>] [-disable_innodb=true] [-enable_extended=true]
 ```
 
 ## Example of mackerel-agent.conf

--- a/mackerel-plugin-mysql/mysql.go
+++ b/mackerel-plugin-mysql/mysql.go
@@ -458,6 +458,15 @@ func (m MySQLPlugin) addExtendedGraphdef(graphdef map[string](mp.Graphs)) map[st
 			mp.Metrics{Name: "Qcache_free_blocks", Label: "Qcache Free Blocks", Diff: false, Stacked: false, Type: "uint64"},
 		},
 	}
+	graphdef["temporary_objects"] = mp.Graphs{
+		Label: prefix + ".temporary Objects",
+		Unit:  "float",
+		Metrics: [](mp.Metrics){
+			mp.Metrics{Name: "Created_tmp_tables", Label: "Created Tmp Tables", Diff: true, Stacked: false, Type: "uint64"},
+			mp.Metrics{Name: "Created_tmp_disk_tables", Label: "Created Tmp Disk Tables", Diff: true, Stacked: false, Type: "uint64"},
+			mp.Metrics{Name: "Created_tmp_files", Label: "Created Tmp Files", Diff: true, Stacked: false, Type: "uint64"},
+		},
+	}
 	return graphdef
 }
 

--- a/mackerel-plugin-mysql/mysql_test.go
+++ b/mackerel-plugin-mysql/mysql_test.go
@@ -25,6 +25,27 @@ func TestGraphDefinition(t *testing.T) {
 	}
 }
 
+func TestGraphDefinition_DisableInnoDB_EnableExtended(t *testing.T) {
+	var mysql MySQLPlugin
+
+	mysql.DisableInnoDB = true
+	mysql.EnableExtended = true
+	graphdef := mysql.GraphDefinition()
+	if len(graphdef) != 10 {
+		t.Errorf("GetTempfilename: %d should be 28", len(graphdef))
+	}
+}
+
+func TestGraphDefinition_EnableExtended(t *testing.T) {
+	var mysql MySQLPlugin
+
+	mysql.EnableExtended = true
+	graphdef := mysql.GraphDefinition()
+	if len(graphdef) != 31 {
+		t.Errorf("GetTempfilename: %d should be 28", len(graphdef))
+	}
+}
+
 func TestParseProcStat56(t *testing.T) {
 	stub := `=====================================
 2015-03-09 20:11:22 7f6c0c845700 INNODB MONITOR OUTPUT

--- a/mackerel-plugin-mysql/mysql_test.go
+++ b/mackerel-plugin-mysql/mysql_test.go
@@ -31,8 +31,8 @@ func TestGraphDefinition_DisableInnoDB_EnableExtended(t *testing.T) {
 	mysql.DisableInnoDB = true
 	mysql.EnableExtended = true
 	graphdef := mysql.GraphDefinition()
-	if len(graphdef) != 11 {
-		t.Errorf("GetTempfilename: %d should be 28", len(graphdef))
+	if len(graphdef) != 14 {
+		t.Errorf("GetTempfilename: %d should be 14", len(graphdef))
 	}
 }
 
@@ -41,8 +41,8 @@ func TestGraphDefinition_EnableExtended(t *testing.T) {
 
 	mysql.EnableExtended = true
 	graphdef := mysql.GraphDefinition()
-	if len(graphdef) != 32 {
-		t.Errorf("GetTempfilename: %d should be 28", len(graphdef))
+	if len(graphdef) != 35 {
+		t.Errorf("GetTempfilename: %d should be 35", len(graphdef))
 	}
 }
 

--- a/mackerel-plugin-mysql/mysql_test.go
+++ b/mackerel-plugin-mysql/mysql_test.go
@@ -31,7 +31,7 @@ func TestGraphDefinition_DisableInnoDB_EnableExtended(t *testing.T) {
 	mysql.DisableInnoDB = true
 	mysql.EnableExtended = true
 	graphdef := mysql.GraphDefinition()
-	if len(graphdef) != 10 {
+	if len(graphdef) != 11 {
 		t.Errorf("GetTempfilename: %d should be 28", len(graphdef))
 	}
 }
@@ -41,7 +41,7 @@ func TestGraphDefinition_EnableExtended(t *testing.T) {
 
 	mysql.EnableExtended = true
 	graphdef := mysql.GraphDefinition()
-	if len(graphdef) != 31 {
+	if len(graphdef) != 32 {
 		t.Errorf("GetTempfilename: %d should be 28", len(graphdef))
 	}
 }

--- a/mackerel-plugin-mysql/mysql_test.go
+++ b/mackerel-plugin-mysql/mysql_test.go
@@ -1023,3 +1023,140 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["uncheckpointed_bytes"], 9)
 
 }
+
+func TestParseProcesslist1(t *testing.T) {
+	stat := make(map[string]float64)
+	pattern := []string{"NULL"}
+
+	for _, val := range pattern {
+		parseProcesslist(val, &stat)
+	}
+	assert.EqualValues(t, 0, stat["State_closing_tables"])
+	assert.EqualValues(t, 0, stat["State_copying_to_tmp_table"])
+	assert.EqualValues(t, 0, stat["State_end"])
+	assert.EqualValues(t, 0, stat["State_freeing_items"])
+	assert.EqualValues(t, 0, stat["State_init"])
+	assert.EqualValues(t, 0, stat["State_locked"])
+	assert.EqualValues(t, 0, stat["State_login"])
+	assert.EqualValues(t, 0, stat["State_preparing"])
+	assert.EqualValues(t, 0, stat["State_reading_from_net"])
+	assert.EqualValues(t, 0, stat["State_sending_data"])
+	assert.EqualValues(t, 0, stat["State_sorting_result"])
+	assert.EqualValues(t, 0, stat["State_statistics"])
+	assert.EqualValues(t, 0, stat["State_updating"])
+	assert.EqualValues(t, 0, stat["State_writing_to_net"])
+	assert.EqualValues(t, 0, stat["State_none"])
+	assert.EqualValues(t, 1, stat["State_other"])
+}
+
+func TestParseProcesslist2(t *testing.T) {
+	stat := make(map[string]float64)
+
+	// https://dev.mysql.com/doc/refman/5.6/en/general-thread-states.html
+	pattern := []string{
+		"",
+		"After create",
+		"altering table",
+		"Analyzing",
+		"checking permissions",
+		"Checking table",
+		"cleaning up",
+		"closing tables",
+		"committing alter table to storage engine",
+		"converting HEAP to MyISAM",
+		"MEMORY",
+		"MyISAM",
+		"copy to tmp table",
+		"Copying to group table",
+		"GROUP BY",
+		"Copying to tmp table",
+		"Copying to tmp table on disk",
+		"Creating index",
+		"Creating sort index",
+		"creating table",
+		"Creating tmp table",
+		"deleting from main table",
+		"deleting from reference tables",
+		"discard_or_import_tablespace",
+		"end",
+		"executing",
+		"Execution of init_command",
+		"freeing items",
+		"FULLTEXT initialization",
+		"init",
+		"Killed",
+		"logging slow query",
+		"login",
+		"manage keys",
+		"NULL",
+		"Opening tables",
+		"Opening table",
+		"optimizing",
+		"preparing",
+		"preparing for alter table",
+		"Purging old relay logs",
+		"query end",
+		"Reading from net",
+		"Removing duplicates",
+		"removing tmp table",
+		"rename",
+		"rename result table",
+		"Reopen tables",
+		"Repair by sorting",
+		"Repair done",
+		"Repair with keycache",
+		"Rolling back",
+		"Saving state",
+		"Searching rows for update",
+		"Sending data",
+		"setup",
+		"Sorting for group",
+		"Sorting for order",
+		"Sorting index",
+		"Sorting result",
+		"statistics",
+		"System lock",
+		"update",
+		"Updating",
+		"updating main table",
+		"updating reference tables",
+		"User lock",
+		"User sleep",
+		"Waiting for commit lock",
+		"Waiting for global read lock",
+		"Waiting for tables",
+		"Waiting for table flush",
+		"Waiting for lock_type lock",
+		"Waiting for table level lock",
+		"Waiting for event metadata lock",
+		"Waiting for global read lock",
+		"Waiting for schema metadat lock",
+		"Waiting for stored function metadata  lock",
+		"Waiting for stored procedure metadata lock",
+		"Waiting for table metadata lock",
+		"Waiting for trigger metadata lock",
+		"Waiting on cond",
+		"Writing to net",
+		"Table lock",
+	}
+
+	for _, val := range pattern {
+		parseProcesslist(val, &stat)
+	}
+	assert.EqualValues(t, 1, stat["State_closing_tables"])
+	assert.EqualValues(t, 1, stat["State_copying_to_tmp_table"])
+	assert.EqualValues(t, 1, stat["State_end"])
+	assert.EqualValues(t, 1, stat["State_freeing_items"])
+	assert.EqualValues(t, 1, stat["State_init"])
+	assert.EqualValues(t, 12, stat["State_locked"])
+	assert.EqualValues(t, 1, stat["State_login"])
+	assert.EqualValues(t, 1, stat["State_preparing"])
+	assert.EqualValues(t, 1, stat["State_reading_from_net"])
+	assert.EqualValues(t, 1, stat["State_sending_data"])
+	assert.EqualValues(t, 1, stat["State_sorting_result"])
+	assert.EqualValues(t, 1, stat["State_statistics"])
+	assert.EqualValues(t, 1, stat["State_updating"])
+	assert.EqualValues(t, 1, stat["State_writing_to_net"])
+	assert.EqualValues(t, 1, stat["State_none"])
+	assert.EqualValues(t, 58, stat["State_other"])
+}


### PR DESCRIPTION
We need more metrics with MySQL plugin, so add below graphs/metrics.

I think [Percona Monitoring Plugins](https://github.com/percona/percona-monitoring-plugins) is very useful to monitoring/collecting metric for MySQL . So I refer to there code/definitions.

To enable below graphs/metrics, add command-line option `-enable_extended` . 
Default behavior is NOT change.

- MySQL Query Cache
    - Qcache Queries In Cache
    - Qcache Hits
    - Qcache Inserts
    - Qcache Not Cached
    - Qcache Lowmem Prunes
- MySQL Query Cache Memory
    - Query Cache Size
    - Qcache Free Memory
    - Qcache Total Blocks
    - Qcache Free Blocks
- MySQL Sorts
    - Sort Rows
    - Sort Range
    - Sort Merge Passes
    - Sort Scan
- MySQL Temporary Objects
    - Created Tmp Tables
    - Created Tmp Disk Tables
    - Created Tmp Files
- MySQL Files and Tables
    - Table Cache
    - Open Tables
    - Open Files
    - Opened Tables
- MySQL Processlist
    - State Closing Tables
    - State Copying To Tmp Table
    - State End
    - State Freeing Items
    - State Init
    - State Locked
    - State Login
    - State Preparing
    - State Reading From Net
    - State Sending Data
    - State Sorting Result
    - State Statistics
    - State Updating
    - State Writing To Net
    - State None
    - State Other
