### PR TITLE
Make *some* plugins to support MACKEREL_PLUGIN_WORKDIR

### DIFF
--- a/mackerel-plugin-snmp/snmp.go
+++ b/mackerel-plugin-snmp/snmp.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/alouca/gosnmp"
-	mp "github.com/mackerelio/go-mackerel-plugin"
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 )
 
 // SNMPMetrics metrics
@@ -29,8 +29,8 @@ type SNMPPlugin struct {
 }
 
 // FetchMetrics interface for mackerelplugin
-func (m SNMPPlugin) FetchMetrics() (map[string]float64, error) {
-	stat := make(map[string]float64)
+func (m SNMPPlugin) FetchMetrics() (map[string]interface{}, error) {
+	stat := make(map[string]interface{})
 
 	s, err := gosnmp.NewGoSNMP(m.Host, m.Community, gosnmp.Version2c, 30)
 	if err != nil {
@@ -108,12 +108,7 @@ func main() {
 	snmp.SNMPMetricsSlice = sms
 
 	helper := mp.NewMackerelPlugin(snmp)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-snmp-%s-%s", *optHost, *optGraphName)
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-solr/solr.go
+++ b/mackerel-plugin-solr/solr.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	mp "github.com/mackerelio/go-mackerel-plugin"
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 	"github.com/mackerelio/mackerel-agent/logging"
 )
 
@@ -141,8 +141,8 @@ func escapeSlash(slashIncludedString string) (str string) {
 }
 
 // FetchMetrics interface for mackerelplugin
-func (s SolrPlugin) FetchMetrics() (map[string]float64, error) {
-	stat := make(map[string]float64)
+func (s SolrPlugin) FetchMetrics() (map[string]interface{}, error) {
+	stat := make(map[string]interface{})
 	for core, stats := range s.Stats {
 		for k, v := range stats {
 			stat[core+"_"+k] = v
@@ -237,12 +237,7 @@ func main() {
 	solr.loadStats()
 
 	helper := mp.NewMackerelPlugin(solr)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-%s-%s-%s", solr.Prefix, *optHost, *optPort)
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-squid/squid.go
+++ b/mackerel-plugin-squid/squid.go
@@ -92,12 +92,7 @@ func main() {
 	var squid SquidPlugin
 	squid.Target = fmt.Sprintf("%s:%s", *optHost, *optPort)
 	helper := mp.NewMackerelPlugin(squid)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-squid-%s-%s", *optHost, *optPort)
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
+++ b/mackerel-plugin-td-table-count/mackerel-plugin-td-table-count.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	mp "github.com/mackerelio/go-mackerel-plugin"
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 	"github.com/mackerelio/mackerel-agent/logging"
 	td "github.com/mattn/go-treasuredata"
 )
@@ -50,8 +50,8 @@ func getTables(m TDTablePlugin) ([]td.Table, error) {
 }
 
 // FetchMetrics interface for mackerelplugin
-func (m TDTablePlugin) FetchMetrics() (map[string]float64, error) {
-	stat := make(map[string]float64)
+func (m TDTablePlugin) FetchMetrics() (map[string]interface{}, error) {
+	stat := make(map[string]interface{})
 
 	tables, _ := getTables(m)
 	for _, table := range tables {
@@ -106,12 +106,7 @@ func main() {
 	plugin.IgnoreTableNames = ignoreTableNames
 
 	helper := mp.NewMackerelPlugin(plugin)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-td-table"
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-trafficserver/trafficserver.go
+++ b/mackerel-plugin-trafficserver/trafficserver.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -128,12 +127,7 @@ func main() {
 	var trafficserver TrafficserverPlugin
 
 	helper := mp.NewMackerelPlugin(trafficserver)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-trafficserver")
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-unicorn/unicorn.go
+++ b/mackerel-plugin-unicorn/unicorn.go
@@ -109,11 +109,7 @@ func main() {
 	unicorn.WorkerPids = workerPids
 
 	helper := mp.NewMackerelPlugin(unicorn)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-unicorn")
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-uptime/uptime.go
+++ b/mackerel-plugin-uptime/uptime.go
@@ -14,11 +14,19 @@ type UptimePlugin struct {
 	Prefix string
 }
 
+// MetricKeyPrefix interface for PluginWithPrefix
+func (u UptimePlugin) MetricKeyPrefix() string {
+	if u.Prefix == "" {
+		u.Prefix = "uptime"
+	}
+	return u.Prefix
+}
+
 // GraphDefinition interface for mackerelplugin
 func (u UptimePlugin) GraphDefinition() map[string](mp.Graphs) {
 	labelPrefix := strings.Title(u.Prefix)
 	return map[string](mp.Graphs){
-		u.Prefix: mp.Graphs{
+		"": mp.Graphs{
 			Label: labelPrefix,
 			Unit:  "float",
 			Metrics: [](mp.Metrics){
@@ -47,8 +55,5 @@ func main() {
 	}
 	helper := mp.NewMackerelPlugin(u)
 	helper.Tempfile = *optTempfile
-	if helper.Tempfile == "" {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-%s", *optPrefix)
-	}
 	helper.Run()
 }

--- a/mackerel-plugin-varnish/varnish.go
+++ b/mackerel-plugin-varnish/varnish.go
@@ -174,8 +174,6 @@ func main() {
 
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-varnish"
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-xentop/xentop.go
+++ b/mackerel-plugin-xentop/xentop.go
@@ -168,8 +168,6 @@ func main() {
 
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-xentop")
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {


### PR DESCRIPTION
ref: https://github.com/mackerelio/mackerel-agent-plugins/pull/260 / https://github.com/mackerelio/go-mackerel-plugin-helper/pull/21 / https://github.com/mackerelio/go-mackerel-plugin-helper/pull/22

With https://github.com/mackerelio/go-mackerel-plugin-helper/pull/22, all we have to modify plugins to support MACKEREL_PLUGIN_WORKDIR is simple:
- [MUST] Migrate to go-mackerel-plugin-helper if it still used go-mackerel-plugin
- [MUST] Don't specify default Tempfile name (should delegated to helper)

In this p-r, I modified 9 of plugins.
- `uptime`: since this plugin already supports `-metric-key-prefix`, so (only) this plugin implemented `PluginWithPrefix`
- `td-table-count` and `snmp`:  they still used go-mackerel-plugin, so they are migrated to go-mackerel-plugin-helper
- other 6 plugins: Just stopped specifying default tempfile
