### PR TITLE
Release version 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.23.0 (2016-10-18)
+
+* mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics #243 (astj)
+* Fixed flag comment of mackerel-plugin-fluentd #257 (kakakakakku)
+* Fix postgres.iotime.{blk_read_time,blk_write_time} #259 (mechairoi)
+* [Plack] Adopt Plack::Middleware::ServerStatus::Lite 0.35's response #261 (astj)
+* build with Go 1.7 #262 (astj)
+* Add much graphs/metrics to mackerel-plugin-mysql #264 (netmarkjp)
+* [apache2] Support -metric-key-prefix option and get rid of default Tempfile specification #265 (astj)
+* [aws-rds] add `-engine` option #266 (Songmu)
+* [elasticsearch] Add open_file_descriptors metric in elasticsearch plugin #267 (kamijin-fanta)
+* Make *some* plugins to support MACKEREL_PLUGIN_WORKDIR #268 (astj)
+* [redis] deal with MACKEREL_PLUGIN_WORKDIR #269 (astj)
+
+
 ## 0.22.1 (2016-09-06)
 
 * Fixed README.md #253 (kakakakakku)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,30 @@
+mackerel-agent-plugins (0.23.0-1) stable; urgency=low
+
+  * mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/243>
+  * Fixed flag comment of mackerel-plugin-fluentd (by kakakakakku)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/257>
+  * Fix postgres.iotime.{blk_read_time,blk_write_time} (by mechairoi)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/259>
+  * [Plack] Adopt Plack::Middleware::ServerStatus::Lite 0.35's response (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/261>
+  * build with Go 1.7 (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/262>
+  * Add much graphs/metrics to mackerel-plugin-mysql (by netmarkjp)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/264>
+  * [apache2] Support -metric-key-prefix option and get rid of default Tempfile specification (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/265>
+  * [aws-rds] add `-engine` option (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/266>
+  * [elasticsearch] Add open_file_descriptors metric in elasticsearch plugin (by kamijin-fanta)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/267>
+  * Make *some* plugins to support MACKEREL_PLUGIN_WORKDIR (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/268>
+  * [redis] deal with MACKEREL_PLUGIN_WORKDIR (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/269>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 18 Oct 2016 08:36:50 +0000
+
 mackerel-agent-plugins (0.22.1-1) stable; urgency=low
 
   * Fixed README.md (by kakakakakku)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,19 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Tue Oct 18 2016 <mackerel-developers@hatena.ne.jp> - 0.23.0-1
+- mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics (by astj)
+- Fixed flag comment of mackerel-plugin-fluentd (by kakakakakku)
+- Fix postgres.iotime.{blk_read_time,blk_write_time} (by mechairoi)
+- [Plack] Adopt Plack::Middleware::ServerStatus::Lite 0.35's response (by astj)
+- build with Go 1.7 (by astj)
+- Add much graphs/metrics to mackerel-plugin-mysql (by netmarkjp)
+- [apache2] Support -metric-key-prefix option and get rid of default Tempfile specification (by astj)
+- [aws-rds] add `-engine` option (by Songmu)
+- [elasticsearch] Add open_file_descriptors metric in elasticsearch plugin (by kamijin-fanta)
+- Make *some* plugins to support MACKEREL_PLUGIN_WORKDIR (by astj)
+- [redis] deal with MACKEREL_PLUGIN_WORKDIR (by astj)
+
 * Tue Sep 06 2016 <mackerel-developers@hatena.ne.jp> - 0.22.1-1
 - Fixed README.md (by kakakakakku)
 - [memcached] Support -metric-key-prefix option  (by astj)


### PR DESCRIPTION
- mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics #243
- Fixed flag comment of mackerel-plugin-fluentd #257
- Fix postgres.iotime.{blk_read_time,blk_write_time} #259
- [Plack] Adopt Plack::Middleware::ServerStatus::Lite 0.35's response #261
- build with Go 1.7 #262
- Add much graphs/metrics to mackerel-plugin-mysql #264
- [apache2] Support -metric-key-prefix option and get rid of default Tempfile specification #265
- [aws-rds] add `-engine` option #266
- [elasticsearch] Add open_file_descriptors metric in elasticsearch plugin #267
- Make *some* plugins to support MACKEREL_PLUGIN_WORKDIR #268
- [redis] deal with MACKEREL_PLUGIN_WORKDIR #269