### PR TITLE
[redis] Fix a bug to fetch no metrics of keys and expired

### DIFF
--- a/mackerel-plugin-redis/redis.go
+++ b/mackerel-plugin-redis/redis.go
@@ -177,14 +177,14 @@ func (m RedisPlugin) FetchMetrics() (map[string]interface{}, error) {
 			continue
 		}
 
-		stat["keys"] = keysStat
-		stat["expired"] = expiredStat
-
 		stat[key], err = strconv.ParseFloat(value, 64)
 		if err != nil {
 			continue
 		}
 	}
+
+	stat["keys"] = keysStat
+	stat["expired"] = expiredStat
 
 	if _, ok := stat["keys"]; !ok {
 		stat["keys"] = 0


### PR DESCRIPTION
The plugin can't send any valid values because [assignments to each metric](https://github.com/mackerelio/mackerel-agent-plugins/commit/ee04a0e52e161ba4a559c6129123e157b702dd4f#diff-4b78c4735dfe237f16d9d8d5c5de90a3R172) are never operated after the line started 'db'.