### PR TITLE
[postgres] support Pg9.1

### DIFF
--- a/mackerel-plugin-postgres/postgres.go
+++ b/mackerel-plugin-postgres/postgres.go
@@ -101,19 +101,19 @@ func fetchStatDatabase(db *sqlx.DB) (map[string]interface{}, error) {
 	}
 
 	type pgStat struct {
-		XactCommit   *uint64 `db:"xact_commit"`
-		XactRollback *uint64 `db:"xact_rollback"`
-		BlksRead     *uint64 `db:"blks_read"`
-		BlksHit      *uint64 `db:"blks_hit"`
-		BlkReadTime  *uint64 `db:"blk_read_time"`
-		BlkWriteTime *uint64 `db:"blk_write_time"`
-		TupReturned  *uint64 `db:"tup_returned"`
-		TupFetched   *uint64 `db:"tup_fetched"`
-		TupInserted  *uint64 `db:"tup_inserted"`
-		TupUpdated   *uint64 `db:"tup_updated"`
-		TupDeleted   *uint64 `db:"tup_deleted"`
-		Deadlocks    *uint64 `db:"deadlocks"`
-		TempBytes    *uint64 `db:"temp_bytes"`
+		XactCommit   uint64   `db:"xact_commit"`
+		XactRollback uint64   `db:"xact_rollback"`
+		BlksRead     uint64   `db:"blks_read"`
+		BlksHit      uint64   `db:"blks_hit"`
+		BlkReadTime  *float64 `db:"blk_read_time"`
+		BlkWriteTime *float64 `db:"blk_write_time"`
+		TupReturned  uint64   `db:"tup_returned"`
+		TupFetched   uint64   `db:"tup_fetched"`
+		TupInserted  uint64   `db:"tup_inserted"`
+		TupUpdated   uint64   `db:"tup_updated"`
+		TupDeleted   uint64   `db:"tup_deleted"`
+		Deadlocks    *uint64  `db:"deadlocks"`
+		TempBytes    *uint64  `db:"temp_bytes"`
 	}
 
 	totalStat := pgStat{}
@@ -123,34 +123,10 @@ func fetchStatDatabase(db *sqlx.DB) (map[string]interface{}, error) {
 			logger.Warningf("Failed to scan. %s", err)
 			continue
 		}
-		if p.XactCommit != nil {
-			if totalStat.XactCommit == nil {
-				totalStat.XactCommit = p.XactCommit
-			} else {
-				*totalStat.XactCommit += *p.XactCommit
-			}
-		}
-		if p.XactRollback != nil {
-			if totalStat.XactRollback == nil {
-				totalStat.XactRollback = p.XactRollback
-			} else {
-				*totalStat.XactRollback += *p.XactRollback
-			}
-		}
-		if p.BlksRead != nil {
-			if totalStat.BlksRead == nil {
-				totalStat.BlksRead = p.BlksRead
-			} else {
-				*totalStat.BlksRead += *p.BlksRead
-			}
-		}
-		if p.BlksHit != nil {
-			if totalStat.BlksHit == nil {
-				totalStat.BlksHit = p.BlksHit
-			} else {
-				*totalStat.BlksHit += *p.BlksHit
-			}
-		}
+		totalStat.XactCommit += p.XactCommit
+		totalStat.XactRollback += p.XactRollback
+		totalStat.BlksRead += p.BlksRead
+		totalStat.BlksHit += p.BlksHit
 		if p.BlkReadTime != nil {
 			if totalStat.BlkReadTime == nil {
 				totalStat.BlkReadTime = p.BlkReadTime
@@ -165,41 +141,11 @@ func fetchStatDatabase(db *sqlx.DB) (map[string]interface{}, error) {
 				*totalStat.BlkWriteTime += *p.BlkWriteTime
 			}
 		}
-		if p.TupReturned != nil {
-			if totalStat.TupReturned == nil {
-				totalStat.TupReturned = p.TupReturned
-			} else {
-				*totalStat.TupReturned += *p.TupReturned
-			}
-		}
-		if p.TupFetched != nil {
-			if totalStat.TupFetched == nil {
-				totalStat.TupFetched = p.TupFetched
-			} else {
-				*totalStat.TupFetched += *p.TupFetched
-			}
-		}
-		if p.TupInserted != nil {
-			if totalStat.TupInserted == nil {
-				totalStat.TupInserted = p.TupInserted
-			} else {
-				*totalStat.TupInserted += *p.TupInserted
-			}
-		}
-		if p.TupUpdated != nil {
-			if totalStat.TupUpdated == nil {
-				totalStat.TupUpdated = p.TupUpdated
-			} else {
-				*totalStat.TupUpdated += *p.TupUpdated
-			}
-		}
-		if p.TupDeleted != nil {
-			if totalStat.TupDeleted == nil {
-				totalStat.TupDeleted = p.TupDeleted
-			} else {
-				*totalStat.TupDeleted += *p.TupDeleted
-			}
-		}
+		totalStat.TupReturned += p.TupReturned
+		totalStat.TupFetched += p.TupFetched
+		totalStat.TupInserted += p.TupInserted
+		totalStat.TupUpdated += p.TupUpdated
+		totalStat.TupDeleted += p.TupDeleted
 		if p.Deadlocks != nil {
 			if totalStat.Deadlocks == nil {
 				totalStat.Deadlocks = p.Deadlocks
@@ -216,39 +162,21 @@ func fetchStatDatabase(db *sqlx.DB) (map[string]interface{}, error) {
 		}
 	}
 	stat := make(map[string]interface{})
-	if totalStat.XactCommit != nil {
-		stat["xact_commit"] = *totalStat.XactCommit
-	}
-	if totalStat.XactRollback != nil {
-		stat["xact_rollback"] = *totalStat.XactRollback
-	}
-	if totalStat.BlksRead != nil {
-		stat["blks_read"] = *totalStat.BlksRead
-	}
-	if totalStat.BlksHit != nil {
-		stat["blks_hit"] = *totalStat.BlksHit
-	}
+	stat["xact_commit"] = totalStat.XactCommit
+	stat["xact_rollback"] = totalStat.XactRollback
+	stat["blks_read"] = totalStat.BlksRead
+	stat["blks_hit"] = totalStat.BlksHit
 	if totalStat.BlkReadTime != nil {
 		stat["blk_read_time"] = *totalStat.BlkReadTime
 	}
 	if totalStat.BlkWriteTime != nil {
 		stat["blk_write_time"] = *totalStat.BlkWriteTime
 	}
-	if totalStat.TupReturned != nil {
-		stat["tup_returned"] = *totalStat.TupReturned
-	}
-	if totalStat.TupFetched != nil {
-		stat["tup_fetched"] = *totalStat.TupFetched
-	}
-	if totalStat.TupInserted != nil {
-		stat["tup_inserted"] = *totalStat.TupInserted
-	}
-	if totalStat.TupUpdated != nil {
-		stat["tup_updated"] = *totalStat.TupUpdated
-	}
-	if totalStat.TupDeleted != nil {
-		stat["tup_deleted"] = *totalStat.TupDeleted
-	}
+	stat["tup_returned"] = totalStat.TupReturned
+	stat["tup_fetched"] = totalStat.TupFetched
+	stat["tup_inserted"] = totalStat.TupInserted
+	stat["tup_updated"] = totalStat.TupUpdated
+	stat["tup_deleted"] = totalStat.TupDeleted
 	if totalStat.Deadlocks != nil {
 		stat["deadlocks"] = *totalStat.Deadlocks
 	}

--- a/mackerel-plugin-postgres/postgres.go
+++ b/mackerel-plugin-postgres/postgres.go
@@ -103,7 +103,21 @@ func fetchStatDatabase(db *sqlx.DB) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	stat := make(map[string]interface{})
+	type pgStat struct {
+		XactCommit   *float64 `db:"xact_commit"`
+		XactRollback *float64 `db:"xact_rollback"`
+		BlksRead     *float64 `db:"blks_read"`
+		BlksHit      *float64 `db:"blks_hit"`
+		BlkReadTime  *float64 `db:"blk_read_time"`
+		BlkWriteTime *float64 `db:"blk_write_time"`
+		TupReturned  *float64 `db:"tup_returned"`
+		TupFetched   *float64 `db:"tup_fetched"`
+		TupInserted  *float64 `db:"tup_inserted"`
+		TupUpdated   *float64 `db:"tup_updated"`
+		TupDeleted   *float64 `db:"tup_deleted"`
+		Deadlocks    *float64 `db:"deadlocks"`
+		TempBytes    *float64 `db:"temp_bytes"`
+	}
 
 	var totalXactCommit, totalXactRollback, totalBlksRead, totalBlksHit, totalBlkReadTime, totalBlkWriteTime, totalTupReturned, totalTupFetched, totalTupInserted, totalTupUpdated, totalTupDeleted, totalDeadlocks, totalTempBytes float64
 

--- a/mackerel-plugin-postgres/postgres_test.go
+++ b/mackerel-plugin-postgres/postgres_test.go
@@ -24,20 +24,25 @@ func TestFetchStatDatabase(t *testing.T) {
 
 	stat, err := fetchStatDatabase(db)
 
+	expected := map[string]interface{}{
+		"xact_commit":  11.0,
+		"blks_hit":     44.0,
+		"tup_returned": 77.0,
+	}
+
 	if err != nil {
 		t.Errorf("Expected no error, but got %s instead", err)
 	}
 	if err = db.Close(); err != nil {
 		t.Errorf("Error '%s' was not expected while closing the database", err)
 	}
-	if stat["xact_commit"] != 11 {
+	if stat["xact_commit"] != expected["xact_commit"] {
 		t.Error("should be 11")
 	}
-	if stat["blks_hit"] != 44 {
+	if stat["blks_hit"] != expected["blks_hit"] {
 		t.Error("should be 44")
 	}
-	if stat["tup_returned"] != 77 {
+	if stat["tup_returned"] != expected["tup_returned"] {
 		t.Error("should be 77")
 	}
-
 }

--- a/mackerel-plugin-postgres/postgres_test.go
+++ b/mackerel-plugin-postgres/postgres_test.go
@@ -13,11 +13,7 @@ func TestFetchStatDatabase(t *testing.T) {
 	columns := []string{"xact_commit", "xact_rollback", "blks_read", "blks_hit", "blk_read_time", "blk_write_time",
 		"tup_returned", "tup_fetched", "tup_inserted", "tup_updated", "tup_deleted", "deadlocks", "temp_bytes"}
 
-	testdb.StubQuery(`
-		select xact_commit, xact_rollback, blks_read, blks_hit, blk_read_time, blk_write_time,
-		tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted, deadlocks, temp_bytes
-		from pg_stat_database
-	`, testdb.RowsFromCSVString(columns, `
+	testdb.StubQuery(`SELECT * FROM pg_stat_database`, testdb.RowsFromCSVString(columns, `
 	1,2,3,4,5,6,7,8,9,10,11,12,13
 	10,20,30,40,50,60,70,80,90,100,110,120,130
 	`))
@@ -25,9 +21,9 @@ func TestFetchStatDatabase(t *testing.T) {
 	stat, err := fetchStatDatabase(db)
 
 	expected := map[string]interface{}{
-		"xact_commit":  11.0,
-		"blks_hit":     44.0,
-		"tup_returned": 77.0,
+		"xact_commit":  uint64(11),
+		"blks_hit":     uint64(44),
+		"tup_returned": uint64(77),
 	}
 
 	if err != nil {

--- a/mackerel-plugin-postgres/postgres_test.go
+++ b/mackerel-plugin-postgres/postgres_test.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"database/sql"
 	"testing"
 
 	"github.com/erikstmartin/go-testdb"
+	"github.com/jmoiron/sqlx"
 )
 
 func TestFetchStatDatabase(t *testing.T) {
-	db, _ := sql.Open("testdb", "")
+	db, _ := sqlx.Connect("testdb", "")
 
 	columns := []string{"xact_commit", "xact_rollback", "blks_read", "blks_hit", "blk_read_time", "blk_write_time",
 		"tup_returned", "tup_fetched", "tup_inserted", "tup_updated", "tup_deleted", "deadlocks", "temp_bytes"}


### PR DESCRIPTION
The columns `pg_stat_database.blk_read_time/blk_write_time/deadlocks/temp_bytes` are introduced at Pg 9.2. So care them.

- introduce `jmoiron/sqlx` for handling asterisk queries
- introduce `mackerelio/go-mackerel-plugin-helper`