### PR TITLE
Supported memcached curr_items metric

### DIFF
--- a/mackerel-plugin-memcached/memcached.go
+++ b/mackerel-plugin-memcached/memcached.go
@@ -143,6 +143,13 @@ func (m MemcachedPlugin) GraphDefinition() map[string](mp.Graphs) {
 				mp.Metrics{Name: "bytes", Label: "Used", Diff: false, Type: "uint64"},
 			},
 		},
+		"items": mp.Graphs{
+			Label: (labelPrefix + " Items"),
+			Unit:  "integer",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "curr_items", Label: "Current Items", Diff: false},
+			},
+		},
 	}
 	return graphdef
 }

--- a/mackerel-plugin-memcached/memcached_test.go
+++ b/mackerel-plugin-memcached/memcached_test.go
@@ -13,7 +13,7 @@ func TestGraphDefinition(t *testing.T) {
 	var memcached MemcachedPlugin
 
 	graphdef := memcached.GraphDefinition()
-	if len(graphdef) != 8 {
+	if len(graphdef) != 9 {
 		t.Errorf("GetTempfilename: %d should be 8", len(graphdef))
 	}
 }


### PR DESCRIPTION
Hi !

I think that memcached `curr_items` metric is useful for monitoring.
I added this metric to mackerel-plugin-memcached.

>| curr_items            | 64u     | Current number of items stored            |
https://github.com/memcached/memcached/blob/master/doc/protocol.txt

How about this ?
Please review, thank you 🙇 

# Sample

```
$ go run memcached.go
memcached.cachesize.limit_maxbytes	67108864.000000	1477038754
memcached.cachesize.bytes	370	1477038754
memcached.items.curr_items	5.000000	1477038754
memcached.connections.curr_connections	16.000000	1477038754
memcached.hitmiss.get_hits	0.000000	1477038754
memcached.hitmiss.get_misses	0.000000	1477038754
memcached.hitmiss.delete_hits	0.000000	1477038754
memcached.hitmiss.delete_misses	0.000000	1477038754
memcached.hitmiss.incr_hits	0.000000	1477038754
memcached.hitmiss.incr_misses	0.000000	1477038754
memcached.hitmiss.cas_hits	0.000000	1477038754
memcached.hitmiss.cas_misses	0.000000	1477038754
memcached.hitmiss.touch_hits	0.000000	1477038754
memcached.hitmiss.touch_misses	0.000000	1477038754
memcached.unfetched.expired_unfetched	0.000000	1477038754
memcached.unfetched.evicted_unfetched	0.000000	1477038754
memcached.bytes.bytes_read	60.000000	1477038754
memcached.bytes.bytes_written	11380.000000	1477038754
memcached.cmd.cmd_get	0.000000	1477038754
memcached.cmd.cmd_set	0.000000	1477038754
memcached.cmd.cmd_flush	0.000000	1477038754
memcached.cmd.cmd_touch	0.000000	1477038754
memcached.evictions.evictions	0.000000	1477038754
memcached.rusage.rusage_user	0.001140	1477038754
memcached.rusage.rusage_system	0.003800	1477038754
```

# My Account

![local](https://cloud.githubusercontent.com/assets/1573290/19592750/21d11e84-97b8-11e6-99ab-488dc6f3a0e1.png)