### PR TITLE
Release version 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.23.1 (2016-10-27)
+
+* [redis] Fix a bug to fetch no metrics of keys and expired #272 (yoheimuta)
+* fix: "open file descriptors" property in elasticsearch  #273 (kamijin-fanta)
+* [memcached] Supported memcached curr_items metric #275 (kakakakakku)
+* [memcached] support new_items metrics #276 (Songmu)
+* [redis] s/memoty/memory/ #277 (astj)
+
+
 ## 0.23.0 (2016-10-18)
 
 * mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics #243 (astj)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,18 @@
+mackerel-agent-plugins (0.23.1-1) stable; urgency=low
+
+  * [redis] Fix a bug to fetch no metrics of keys and expired (by yoheimuta)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/272>
+  * fix: "open file descriptors" property in elasticsearch  (by kamijin-fanta)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/273>
+  * [memcached] Supported memcached curr_items metric (by kakakakakku)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/275>
+  * [memcached] support new_items metrics (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/276>
+  * [redis] s/memoty/memory/ (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/277>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 27 Oct 2016 04:40:46 +0000
+
 mackerel-agent-plugins (0.23.0-1) stable; urgency=low
 
   * mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics (by astj)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,13 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Thu Oct 27 2016 <mackerel-developers@hatena.ne.jp> - 0.23.1-1
+- [redis] Fix a bug to fetch no metrics of keys and expired (by yoheimuta)
+- fix: "open file descriptors" property in elasticsearch  (by kamijin-fanta)
+- [memcached] Supported memcached curr_items metric (by kakakakakku)
+- [memcached] support new_items metrics (by Songmu)
+- [redis] s/memoty/memory/ (by astj)
+
 * Tue Oct 18 2016 <mackerel-developers@hatena.ne.jp> - 0.23.0-1
 - mackerel-plugin-linux: Allow to select multiple (but not all) sets of metrics (by astj)
 - Fixed flag comment of mackerel-plugin-fluentd (by kakakakakku)


### PR DESCRIPTION
- [redis] Fix a bug to fetch no metrics of keys and expired #272
- fix: "open file descriptors" property in elasticsearch  #273
- [memcached] Supported memcached curr_items metric #275
- [memcached] support new_items metrics #276
- [redis] s/memoty/memory/ #277