### PR TITLE
Add new nvidia-smi plugin

### DIFF
--- a/mackerel-plugin-nvidia-smi/README.md
+++ b/mackerel-plugin-nvidia-smi/README.md
@@ -1,0 +1,18 @@
+mackerel-plugin-nvidia-smi
+==========================
+
+GPU custom metrics plugin using nvidia-smi for mackerel.io agent.
+
+## Synopsis
+
+```shell
+mackerel-plugin-nvidia-smi [-prefix=<prefix>]
+```
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.nvidia-smi]
+command = "/path/to/mackerel-plugin-nvidia-smi"
+```
+

--- a/mackerel-plugin-nvidia-smi/README.md
+++ b/mackerel-plugin-nvidia-smi/README.md
@@ -6,7 +6,7 @@ GPU custom metrics plugin using nvidia-smi for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-nvidia-smi [-prefix=<prefix>]
+mackerel-plugin-nvidia-smi [-metric-key-prefix=<Metric key prefix>]
 ```
 
 ## Example of mackerel-agent.conf

--- a/mackerel-plugin-nvidia-smi/nvidia_smi.go
+++ b/mackerel-plugin-nvidia-smi/nvidia_smi.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var queryOptions = []string{
+	"utilization.gpu",
+	"utilization.memory",
+	"temperature.gpu",
+	"fan.speed",
+	"memory.total",
+	"memory.used",
+	"memory.free",
+}
+
+var formatOptions = []string{
+	"noheader",
+	"nounits",
+	"csv",
+}
+
+var nvidiaSmiOptions = []string{
+	fmt.Sprintf("--format=%s", strings.Join(formatOptions, ",")),
+	fmt.Sprintf("--query-gpu=%s", strings.Join(queryOptions, ",")),
+}
+
+var metricsKeyFormats = []string{
+	"gpu.util.gpu%d",
+	"memory.util.gpu%d",
+	"temperature.gpu%d",
+	"fanspeed.gpu%d",
+	"memory.usage.gpu%d.total",
+	"memory.usage.gpu%d.used",
+	"memory.usage.gpu%d.free",
+}
+
+func (n NVidiaSMIPlugin) getMetricKey(index int, gpuIndex int) string {
+	return fmt.Sprintf(metricsKeyFormats[index], gpuIndex)
+}
+
+// NVidiaSMIPlugin mackerel plugin for nvidia-smi
+type NVidiaSMIPlugin struct {
+	Prefix string
+}
+
+func (n NVidiaSMIPlugin) GraphDefinition() map[string](mp.Graphs) {
+	var graphdef = map[string](mp.Graphs){
+		"gpu.util": mp.Graphs{
+			Label: "GPU Utilization",
+			Unit:  "percentage",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "#", Label: "util"},
+			},
+		},
+		"memory.util": mp.Graphs{
+			Label: "GPU Memory Utilization",
+			Unit:  "percentage",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "#", Label: "util"},
+			},
+		},
+		"temperature": mp.Graphs{
+			Label: "GPU Temperature",
+			Unit:  "integer",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "#", Label: "temp"},
+			},
+		},
+		"fanspeed": mp.Graphs{
+			Label: "GPU Fan Speed",
+			Unit:  "percentage",
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "#", Label: "fan speed"},
+			},
+		},
+		"memory.usage.#": mp.Graphs{
+			Label: "GPU Memory Usage",
+			Unit:  "bytes",
+
+			Metrics: [](mp.Metrics){
+				mp.Metrics{Name: "total", Label: "total", Scale: 1024 * 1024},
+				mp.Metrics{Name: "used", Label: "used", Scale: 1024 * 1024, Stacked: true},
+				mp.Metrics{Name: "free", Label: "free", Scale: 1024 * 1024, Stacked: true},
+			},
+		},
+	}
+	return graphdef
+}
+
+func (n NVidiaSMIPlugin) FetchMetrics() (map[string]interface{}, error) {
+	ret, err := exec.Command("nvidia-smi", nvidiaSmiOptions...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", err, ret)
+	}
+	return n.parseStats(string(ret))
+}
+
+func (n NVidiaSMIPlugin) MetricKeyPrefix() string {
+	return n.Prefix
+}
+
+func (n NVidiaSMIPlugin) parseStats(ret string) (map[string]interface{}, error) {
+	stats := make(map[string]interface{})
+	for id, line := range strings.Split(ret, "\n") {
+		err := n.parseLine(id, line, &stats)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %s", err, ret)
+		}
+	}
+	return stats, nil
+}
+
+func (n NVidiaSMIPlugin) parseLine(id int, line string, stats *map[string]interface{}) error {
+	if strings.TrimSpace(line) == "" {
+		return nil
+	}
+
+	for i, value := range strings.Split(line, ",") {
+		value, err := strconv.ParseUint(strings.TrimSpace(value), 10, 64)
+		if err != nil {
+			return err
+		}
+		(*stats)[n.getMetricKey(i, id)] = value
+	}
+	return nil
+}
+
+func main() {
+	optPrefix := flag.String("prefix", "nvidia.gpu", "Metric key prefix")
+	flag.Parse()
+	var plugin NVidiaSMIPlugin
+	plugin.Prefix = *optPrefix
+	helper := mp.NewMackerelPlugin(plugin)
+	helper.Run()
+}

--- a/mackerel-plugin-nvidia-smi/nvidia_smi.go
+++ b/mackerel-plugin-nvidia-smi/nvidia_smi.go
@@ -50,33 +50,33 @@ type NVidiaSMIPlugin struct {
 }
 
 // GraphDefinition interface for mackerelplugin
-func (n NVidiaSMIPlugin) GraphDefinition() map[string](mp.Graphs) {
-	var graphdef = map[string](mp.Graphs){
+func (n NVidiaSMIPlugin) GraphDefinition() map[string]mp.Graphs {
+	var graphdef = map[string]mp.Graphs{
 		"gpu.util": mp.Graphs{
 			Label: "GPU Utilization",
 			Unit:  "percentage",
-			Metrics: [](mp.Metrics){
+			Metrics: []mp.Metrics{
 				mp.Metrics{Name: "#", Label: "util"},
 			},
 		},
 		"memory.util": mp.Graphs{
 			Label: "GPU Memory Utilization",
 			Unit:  "percentage",
-			Metrics: [](mp.Metrics){
+			Metrics: []mp.Metrics{
 				mp.Metrics{Name: "#", Label: "util"},
 			},
 		},
 		"temperature": mp.Graphs{
 			Label: "GPU Temperature",
 			Unit:  "integer",
-			Metrics: [](mp.Metrics){
+			Metrics: []mp.Metrics{
 				mp.Metrics{Name: "#", Label: "temp"},
 			},
 		},
 		"fanspeed": mp.Graphs{
 			Label: "GPU Fan Speed",
 			Unit:  "percentage",
-			Metrics: [](mp.Metrics){
+			Metrics: []mp.Metrics{
 				mp.Metrics{Name: "#", Label: "fan speed"},
 			},
 		},
@@ -84,7 +84,7 @@ func (n NVidiaSMIPlugin) GraphDefinition() map[string](mp.Graphs) {
 			Label: "GPU Memory Usage",
 			Unit:  "bytes",
 
-			Metrics: [](mp.Metrics){
+			Metrics: []mp.Metrics{
 				mp.Metrics{Name: "total", Label: "total", Scale: 1024 * 1024},
 				mp.Metrics{Name: "used", Label: "used", Scale: 1024 * 1024, Stacked: true},
 				mp.Metrics{Name: "free", Label: "free", Scale: 1024 * 1024, Stacked: true},

--- a/mackerel-plugin-nvidia-smi/nvidia_smi.go
+++ b/mackerel-plugin-nvidia-smi/nvidia_smi.go
@@ -135,7 +135,7 @@ func (n NVidiaSMIPlugin) parseLine(id int, line string, stats *map[string]interf
 }
 
 func main() {
-	optPrefix := flag.String("prefix", "nvidia.gpu", "Metric key prefix")
+	optPrefix := flag.String("metric-key-prefix", "nvidia.gpu", "Metric key prefix")
 	flag.Parse()
 	var plugin NVidiaSMIPlugin
 	plugin.Prefix = *optPrefix

--- a/mackerel-plugin-nvidia-smi/nvidia_smi.go
+++ b/mackerel-plugin-nvidia-smi/nvidia_smi.go
@@ -49,6 +49,7 @@ type NVidiaSMIPlugin struct {
 	Prefix string
 }
 
+// GraphDefinition interface for mackerelplugin
 func (n NVidiaSMIPlugin) GraphDefinition() map[string](mp.Graphs) {
 	var graphdef = map[string](mp.Graphs){
 		"gpu.util": mp.Graphs{
@@ -93,6 +94,7 @@ func (n NVidiaSMIPlugin) GraphDefinition() map[string](mp.Graphs) {
 	return graphdef
 }
 
+// FetchMetrics interface for mackerelplugin
 func (n NVidiaSMIPlugin) FetchMetrics() (map[string]interface{}, error) {
 	ret, err := exec.Command("nvidia-smi", nvidiaSmiOptions...).CombinedOutput()
 	if err != nil {
@@ -101,6 +103,7 @@ func (n NVidiaSMIPlugin) FetchMetrics() (map[string]interface{}, error) {
 	return n.parseStats(string(ret))
 }
 
+// MetricKeyPrefix interface for mackerelplugin
 func (n NVidiaSMIPlugin) MetricKeyPrefix() string {
 	return n.Prefix
 }

--- a/mackerel-plugin-nvidia-smi/nvidia_smi.go
+++ b/mackerel-plugin-nvidia-smi/nvidia_smi.go
@@ -127,7 +127,7 @@ func (n NVidiaSMIPlugin) parseLine(id int, line string, stats *map[string]interf
 	for i, value := range strings.Split(line, ",") {
 		value, err := strconv.ParseUint(strings.TrimSpace(value), 10, 64)
 		if err != nil {
-			return err
+			continue
 		}
 		(*stats)[n.getMetricKey(i, id)] = value
 	}

--- a/mackerel-plugin-nvidia-smi/nvidia_smi_test.go
+++ b/mackerel-plugin-nvidia-smi/nvidia_smi_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphDefinition(t *testing.T) {
+	var plugin NVidiaSMIPlugin
+
+	graphdef := plugin.GraphDefinition()
+	if len(graphdef) != 5 {
+		t.Errorf("GraphDef's size: %d should be 5", len(graphdef))
+	}
+}
+
+func TestParse(t *testing.T) {
+	var plugin NVidiaSMIPlugin
+	plugin.Prefix = "nvidia.gpu"
+	data := `10, 20, 30, 40, 1024, 64, 962
+11, 21, 31, 41, 1024, 65, 961
+`
+
+	stats, err := plugin.parseStats(data)
+
+	assert.Nil(t, err)
+
+	assert.EqualValues(t, 10, stats["gpu.util.gpu0"])
+	assert.EqualValues(t, 20, stats["memory.util.gpu0"])
+	assert.EqualValues(t, 30, stats["temperature.gpu0"])
+	assert.EqualValues(t, 40, stats["fanspeed.gpu0"])
+	assert.EqualValues(t, 1024, stats["memory.usage.gpu0.total"])
+	assert.EqualValues(t, 64, stats["memory.usage.gpu0.used"])
+	assert.EqualValues(t, 962, stats["memory.usage.gpu0.free"])
+
+	assert.EqualValues(t, 11, stats["gpu.util.gpu1"])
+	assert.EqualValues(t, 21, stats["memory.util.gpu1"])
+	assert.EqualValues(t, 31, stats["temperature.gpu1"])
+	assert.EqualValues(t, 41, stats["fanspeed.gpu1"])
+	assert.EqualValues(t, 1024, stats["memory.usage.gpu1.total"])
+	assert.EqualValues(t, 65, stats["memory.usage.gpu1.used"])
+	assert.EqualValues(t, 961, stats["memory.usage.gpu1.free"])
+}

--- a/mackerel-plugin-nvidia-smi/nvidia_smi_test.go
+++ b/mackerel-plugin-nvidia-smi/nvidia_smi_test.go
@@ -20,6 +20,7 @@ func TestParse(t *testing.T) {
 	plugin.Prefix = "nvidia.gpu"
 	data := `10, 20, 30, 40, 1024, 64, 962
 11, 21, 31, 41, 1024, 65, 961
+12, 22, [Not Supported], [Not Supported], 1024, 66, 960
 `
 
 	stats, err := plugin.parseStats(data)
@@ -41,4 +42,12 @@ func TestParse(t *testing.T) {
 	assert.EqualValues(t, 1024, stats["memory.usage.gpu1.total"])
 	assert.EqualValues(t, 65, stats["memory.usage.gpu1.used"])
 	assert.EqualValues(t, 961, stats["memory.usage.gpu1.free"])
+
+	assert.EqualValues(t, 12, stats["gpu.util.gpu2"])
+	assert.EqualValues(t, 22, stats["memory.util.gpu2"])
+	assert.Nil(t, stats["temperature.gpu2"])
+	assert.Nil(t, stats["fanspeed.gpu2"])
+	assert.EqualValues(t, 1024, stats["memory.usage.gpu2.total"])
+	assert.EqualValues(t, 66, stats["memory.usage.gpu2.used"])
+	assert.EqualValues(t, 960, stats["memory.usage.gpu2.free"])
 }


### PR DESCRIPTION
I'd like to add new plugin for monitoring GPUs, which utilizes [nvidia-smi](https://developer.nvidia.com/nvidia-system-management-interface)

new Metrics this plugin introduces:

- GPU Utilization
- GPU Memory Utilization
- GPU Fan Speed
- GPU Temperature
- GPU Memory Usage (free/used/total)