### PR TITLE
Implement mackerel-plugin-twemproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Documentation for each plugin is located in its respective sub directory.
 * [mackerel-plugin-squid](./mackerel-plugin-squid/README.md)
 * [mackerel-plugin-td-table-count](./mackerel-plugin-td-table-count/README.md)
 * [mackerel-plugin-trafficserver](./mackerel-plugin-trafficserver/README.md)
+* [mackerel-plugin-twemproxy](./mackerel-plugin-twemproxy/README.md)
 * [mackerel-plugin-unicorn](./mackerel-plugin-unicorn/README.md)
 * [mackerel-plugin-uptime](./mackerel-plugin-uptime/README.md)
 * [mackerel-plugin-varnish](./mackerel-plugin-varnish/README.md)

--- a/mackerel-plugin-twemproxy/README.md
+++ b/mackerel-plugin-twemproxy/README.md
@@ -16,6 +16,11 @@ mackerel-plugin-twemproxy [-metric-key-prefix=twemproxy] [-timeout=5] [-address=
 command = "/path/to/mackerel-plugin-twemproxy"
 ```
 
+## Notes
+
+This plugin does not collect metrics of `fragments` and `server_ejected_at`.
+See https://github.com/mackerelio/mackerel-agent-plugins/pull/283 for details.
+
 ## References
 
 - https://github.com/twitter/twemproxy#observability

--- a/mackerel-plugin-twemproxy/README.md
+++ b/mackerel-plugin-twemproxy/README.md
@@ -1,0 +1,21 @@
+mackerel-plugin-twemproxy
+=====================
+
+twemproxy stats custom metrics plugin for [mackerel-agent](https://github.com/mackerelio/mackerel-agent).
+
+## Synopsis
+
+```shell
+mackerel-plugin-twemproxy [-metric-key-prefix=twemproxy] [-timeout=5] [-address=localhost:22222]
+```
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.twemproxy]
+command = "/path/to/mackerel-plugin-twemproxy"
+```
+
+## References
+
+- https://github.com/twitter/twemproxy#observability

--- a/mackerel-plugin-twemproxy/stats.go
+++ b/mackerel-plugin-twemproxy/stats.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+// TwemproxyStats represents a twemproxy stats
+type TwemproxyStats struct {
+	TotalConnections *uint64
+	CurrConnections  *uint64
+	Pools            map[string]*PoolStats
+}
+
+// PoolStats represents a pool stats
+type PoolStats struct {
+	ClientEOF         *uint64
+	ClientErr         *uint64
+	ClientConnections *uint64
+	ServerEjects      *uint64
+	ForwardError      *uint64
+	Servers           map[string]*ServerStats
+}
+
+// ServerStats represents a server stats
+type ServerStats struct {
+	ServerEOF         *uint64
+	ServerErr         *uint64
+	ServerTimedout    *uint64
+	ServerConnections *uint64
+	OutQueueBytes     *uint64
+	InQueueBytes      *uint64
+	OutQueue          *uint64
+	InQueue           *uint64
+	RequestBytes      *uint64
+	ResponseBytes     *uint64
+	Requests          *uint64
+	Responses         *uint64
+}
+
+func getStats(p TwemproxyPlugin) (*TwemproxyStats, error) {
+	// get json data
+	address := p.Address
+	timeout := time.Duration(p.Timeout) * time.Second
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	if err != nil {
+		return nil, err
+	}
+	res := bufio.NewReader(conn)
+
+	// decode the json data to TwemproxyStats struct
+	var t TwemproxyStats
+	decoder := json.NewDecoder(res)
+	err = decoder.Decode(&t)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// UnmarshalJSON interface for json.Unmarshaler
+func (t *TwemproxyStats) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	t.Pools = make(map[string]*PoolStats)
+
+L:
+	for k, v := range raw {
+		switch v.(type) {
+		case float64:
+			cv := uint64(v.(float64))
+			switch k {
+			case "total_connections":
+				t.TotalConnections = &cv
+			case "curr_connections":
+				t.CurrConnections = &cv
+			case "uptime", "timestamp":
+				// do not use these parameters. skip.
+			default:
+				err = fmt.Errorf("invalid key: %v in rawTwemproxy: %v", k, raw)
+				break L
+			}
+		case map[string]interface{}:
+			pool, perr := decodePoolStats(v.(map[string]interface{}))
+			if perr != nil {
+				err = perr
+				break L
+			}
+			t.Pools[k] = pool
+		case string:
+			// do not use parameters(service, source, version). skip.
+		default:
+			err = fmt.Errorf("invalid type in rawTwemproxy: %v", raw)
+			break L
+		}
+	}
+
+	return err
+}
+
+func decodePoolStats(rawStats map[string]interface{}) (*PoolStats, error) {
+	pool := new(PoolStats)
+	pool.Servers = make(map[string]*ServerStats)
+
+	var err error
+
+L:
+	for k, v := range rawStats {
+		switch v.(type) {
+		case float64:
+			cv := uint64(v.(float64))
+			switch k {
+			case "client_eof":
+				pool.ClientEOF = &cv
+			case "client_err":
+				pool.ClientErr = &cv
+			case "client_connections":
+				pool.ClientConnections = &cv
+			case "server_ejects":
+				pool.ServerEjects = &cv
+			case "forward_error":
+				pool.ForwardError = &cv
+			case "fragments":
+				// do not use this parameter. skip.
+			default:
+				err = fmt.Errorf("invalid key: %v in rawPool: %v", k, rawStats)
+				break L
+			}
+		case map[string]interface{}:
+			server, serr := decodeServerStats(v.(map[string]interface{}))
+			if serr != nil {
+				err = serr
+				break L
+			}
+			pool.Servers[k] = server
+		default:
+			err = fmt.Errorf("invalid type in rawPool: %v", rawStats)
+			break L
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return pool, nil
+}
+
+func decodeServerStats(rawStats map[string]interface{}) (*ServerStats, error) {
+	server := new(ServerStats)
+
+	var err error
+
+L:
+	for k, v := range rawStats {
+		cv := uint64(v.(float64))
+		switch k {
+		case "server_eof":
+			server.ServerEOF = &cv
+		case "server_err":
+			server.ServerErr = &cv
+		case "server_timedout":
+			server.ServerTimedout = &cv
+		case "server_connections":
+			server.ServerConnections = &cv
+		case "out_queue_bytes":
+			server.OutQueueBytes = &cv
+		case "in_queue_bytes":
+			server.InQueueBytes = &cv
+		case "out_queue":
+			server.OutQueue = &cv
+		case "in_queue":
+			server.InQueue = &cv
+		case "request_bytes":
+			server.RequestBytes = &cv
+		case "response_bytes":
+			server.ResponseBytes = &cv
+		case "requests":
+			server.Requests = &cv
+		case "responses":
+			server.Responses = &cv
+		case "server_ejected_at":
+			// do not use this parameter. skip.
+		default:
+			err = fmt.Errorf("invalid key: %v in rawServer: %v", k, rawStats)
+			break L
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return server, nil
+}

--- a/mackerel-plugin-twemproxy/twemproxy.go
+++ b/mackerel-plugin-twemproxy/twemproxy.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"regexp"
+	"strings"
+
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+)
+
+// TwemproxyPlugin mackerel plugin
+type TwemproxyPlugin struct {
+	Address string
+	Prefix  string
+	Timeout uint
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (p TwemproxyPlugin) MetricKeyPrefix() string {
+	if p.Prefix == "" {
+		p.Prefix = "twemproxy"
+	}
+	return p.Prefix
+}
+
+// GraphDefinition interface for mackerelplugin
+func (p TwemproxyPlugin) GraphDefinition() map[string]mp.Graphs {
+	labelPrefix := strings.Title(p.Prefix)
+
+	var graphdef = map[string]mp.Graphs{
+		"connections": {
+			Label: (labelPrefix + " Connections"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "total_connections", Label: "New Connections", Diff: true},
+				{Name: "curr_connections", Label: "Current Connections", Diff: false},
+			},
+		},
+		"pool_error.#": {
+			Label: (labelPrefix + " Pool Error"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "client_err", Label: "Client Error", Diff: true},
+				{Name: "server_ejects", Label: "Server Ejects", Diff: true},
+				{Name: "forward_error", Label: "Forward Error", Diff: true},
+			},
+		},
+		"pool_client_connections.#": {
+			Label: (labelPrefix + " Pool Client Connections"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "client_connections", Label: "Client Connections", Diff: false},
+				{Name: "client_eof", Label: "Client EOF", Diff: true},
+			},
+		},
+		"server_error.#": {
+			Label: (labelPrefix + " Server Error"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "server_err", Label: "Server Error", Diff: true},
+				{Name: "server_timedout", Label: "Server Timedout", Diff: true},
+			},
+		},
+		"server_connections.#": {
+			Label: (labelPrefix + " Server Connections"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "server_connections", Label: "Server Connections", Diff: false},
+				{Name: "server_eof", Label: "Server EOF", Diff: true},
+			},
+		},
+		"server_queue.#": {
+			Label: (labelPrefix + " Server Queue"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "out_queue", Label: "Out Queue", Diff: false},
+				{Name: "in_queue", Label: "In Queue", Diff: false},
+			},
+		},
+		"server_queue_bytes.#": {
+			Label: (labelPrefix + " Server Queue Bytes"),
+			Unit:  "bytes",
+			Metrics: []mp.Metrics{
+				{Name: "out_queue_bytes", Label: "Out Queue Bytes", Diff: false},
+				{Name: "in_queue_bytes", Label: "In Queue Bytes", Diff: false},
+			},
+		},
+		"server_communications.#": {
+			Label: (labelPrefix + " Server Communications"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "requests", Label: "Requests", Diff: true},
+				{Name: "responses", Label: "Responses", Diff: true},
+			},
+		},
+		"server_communication_bytes.#": {
+			Label: (labelPrefix + " Server Communication Bytes"),
+			Unit:  "bytes",
+			Metrics: []mp.Metrics{
+				{Name: "request_bytes", Label: "Request Bytes", Diff: true},
+				{Name: "response_bytes", Label: "Response Bytes", Diff: true},
+			},
+		},
+	}
+	return graphdef
+}
+
+// FetchMetrics interface for mackerelplugin
+func (p TwemproxyPlugin) FetchMetrics() (map[string]interface{}, error) {
+	stats, err := getStats(p)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch twemproxy metrics: %s", err)
+	}
+
+	metrics := map[string]interface{}{
+		"total_connections": *stats.TotalConnections,
+		"curr_connections":  *stats.CurrConnections,
+	}
+
+	// NOTE: Each custom metric name contains a wildcard.
+	for pName, p := range stats.Pools {
+		// A normalized pool name corresponds a wildcard
+		np := normalizeMetricName(pName)
+		wp := "." + np + "."
+		metrics["pool_error"+wp+"client_err"] = *p.ClientErr
+		metrics["pool_error"+wp+"server_ejects"] = *p.ServerEjects
+		metrics["pool_error"+wp+"forward_error"] = *p.ForwardError
+		metrics["pool_client_connections"+wp+"client_eof"] = *p.ClientEOF
+		metrics["pool_client_connections"+wp+"client_connections"] = *p.ClientConnections
+
+		for sName, s := range p.Servers {
+			// A concat of normalized pool and server names corresponds a wildcard
+			ns := normalizeMetricName(sName)
+			ws := "." + np + "_" + ns + "."
+			metrics["server_error"+ws+"server_err"] = *s.ServerErr
+			metrics["server_error"+ws+"server_timedout"] = *s.ServerTimedout
+			metrics["server_connections"+ws+"server_eof"] = *s.ServerEOF
+			metrics["server_connections"+ws+"server_connections"] = *s.ServerConnections
+			metrics["server_queue"+ws+"out_queue"] = *s.OutQueue
+			metrics["server_queue"+ws+"in_queue"] = *s.InQueue
+			metrics["server_queue_bytes"+ws+"out_queue_bytes"] = *s.OutQueueBytes
+			metrics["server_queue_bytes"+ws+"in_queue_bytes"] = *s.InQueueBytes
+			metrics["server_communications"+ws+"requests"] = *s.Requests
+			metrics["server_communications"+ws+"responses"] = *s.Responses
+			metrics["server_communication_bytes"+ws+"request_bytes"] = *s.RequestBytes
+			metrics["server_communication_bytes"+ws+"response_bytes"] = *s.ResponseBytes
+		}
+	}
+	return metrics, nil
+}
+
+var normalizeMetricNameRe = regexp.MustCompile(`[^-a-zA-Z0-9_]`)
+
+func normalizeMetricName(name string) string {
+	return normalizeMetricNameRe.ReplaceAllString(name, "_")
+}
+
+func main() {
+	optAddress := flag.String("address", "localhost:22222", "twemproxy stats Address")
+	optPrefix := flag.String("metric-key-prefix", "twemproxy", "Metric key prefix")
+	optTimeout := flag.Uint("timeout", 5, "Timeout")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	flag.Parse()
+
+	p := TwemproxyPlugin{
+		Address: *optAddress,
+		Prefix:  *optPrefix,
+		Timeout: *optTimeout,
+	}
+
+	helper := mp.NewMackerelPlugin(p)
+	helper.Tempfile = *optTempfile
+	helper.Run()
+}

--- a/mackerel-plugin-twemproxy/twemproxy_test.go
+++ b/mackerel-plugin-twemproxy/twemproxy_test.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat/go-tcptest"
+)
+
+var (
+	statsServer *tcptest.TCPTest
+	stats       string
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(mainTest(m))
+}
+
+func mainTest(m *testing.M) int {
+	flag.Parse()
+
+	// run a test server returning a dummy stats json
+	startStatsServer := func(port int) {
+		err := startTCPServer(port)
+		if err != nil {
+			panic("Failed to run a test server: " + err.Error())
+		}
+	}
+	server, err := tcptest.Start(startStatsServer, 10*time.Second)
+	if err != nil {
+		panic("Failed to start a stats server: " + err.Error())
+	}
+	statsServer = server
+
+	log.Printf("Started a stats server. port=%d", statsServer.Port())
+
+	return m.Run()
+}
+
+func startTCPServer(port int) error {
+	server, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+	if err != nil {
+		return err
+	}
+
+	ch := make(chan net.Conn)
+	go func() {
+		for {
+			client, err := server.Accept()
+			if err != nil {
+				log.Printf("Failed to accept: err=%v", err)
+			}
+			ch <- client
+		}
+	}()
+
+	for {
+		go func(client net.Conn) {
+			_, err = client.Write([]byte(stats))
+			if err != nil {
+				log.Printf("Failed to write %v: err=%v", stats, err)
+			}
+		}(<-ch)
+	}
+}
+
+var jsonStr = `{
+    "service": "nutcracker",
+    "source": "ip-10-0-1-10",
+    "version": "0.4.1",
+    "uptime": 74635,
+    "timestamp": 1477054533,
+    "total_connections": 3895,
+    "curr_connections": 272,
+    "redis-index": {
+        "index1.cache:6379": {
+            "out_queue_bytes": 80,
+            "out_queue": 1,
+            "in_queue_bytes": 50,
+            "in_queue": 2,
+            "requests": 3908,
+            "request_bytes": 170558,
+            "responses": 3908,
+            "response_bytes": 176918,
+            "server_connections": 4,
+            "server_eof": 2,
+            "server_timedout": 3,
+            "server_ejected_at": 0,
+            "server_err": 5
+        },
+        "client_eof": 1716,
+        "client_err": 10,
+        "client_connections": 121,
+        "server_ejects": 20,
+        "forward_error": 1,
+        "fragments": 0
+    },
+    "redis/budget": {
+        "budget1.cache:6379": {
+            "out_queue_bytes": 81,
+            "out_queue": 2,
+            "in_queue_bytes": 51,
+            "in_queue": 3,
+            "requests": 3909,
+            "request_bytes": 170559,
+            "responses": 3909,
+            "response_bytes": 176919,
+            "server_connections": 5,
+            "server_eof": 3,
+            "server_timedout": 4,
+            "server_ejected_at": 0,
+            "server_err": 3
+        },
+        "budget2.cache:6379": {
+            "out_queue_bytes": 83,
+            "out_queue": 4,
+            "in_queue_bytes": 53,
+            "in_queue": 5,
+            "requests": 3911,
+            "request_bytes": 170561,
+            "responses": 3911,
+            "response_bytes": 176921,
+            "server_connections": 7,
+            "server_eof": 5,
+            "server_timedout": 6,
+            "server_ejected_at": 2,
+            "server_err": 5
+        },
+        "client_eof": 2716,
+        "client_err": 30,
+        "client_connections": 221,
+        "server_ejects": 40,
+        "forward_error": 2,
+        "fragments": 0
+    }
+}`
+
+func TestFetchMetrics(t *testing.T) {
+	// response a valid stats json
+	stats = jsonStr
+
+	// get metrics
+	p := TwemproxyPlugin{
+		Address: "localhost:" + strconv.Itoa(statsServer.Port()),
+		Prefix:  "twemproxy",
+		Timeout: 5,
+	}
+	metrics, err := p.FetchMetrics()
+	if err != nil {
+		t.Errorf("Failed to FetchMetrics: %s", err)
+		return
+	}
+
+	// check the metrics
+	expected := map[string]uint64{
+		"total_connections":                                                         3895,
+		"curr_connections":                                                          272,
+		"pool_error.redis-index.client_err":                                         10,
+		"pool_error.redis-index.server_ejects":                                      20,
+		"pool_error.redis-index.forward_error":                                      1,
+		"pool_client_connections.redis-index.client_eof":                            1716,
+		"pool_client_connections.redis-index.client_connections":                    121,
+		"server_error.redis-index_index1_cache_6379.server_err":                     5,
+		"server_error.redis-index_index1_cache_6379.server_timedout":                3,
+		"server_connections.redis-index_index1_cache_6379.server_eof":               2,
+		"server_connections.redis-index_index1_cache_6379.server_connections":       4,
+		"server_queue.redis-index_index1_cache_6379.out_queue":                      1,
+		"server_queue.redis-index_index1_cache_6379.in_queue":                       2,
+		"server_queue_bytes.redis-index_index1_cache_6379.out_queue_bytes":          80,
+		"server_queue_bytes.redis-index_index1_cache_6379.in_queue_bytes":           50,
+		"server_communications.redis-index_index1_cache_6379.requests":              3908,
+		"server_communications.redis-index_index1_cache_6379.responses":             3908,
+		"server_communication_bytes.redis-index_index1_cache_6379.request_bytes":    170558,
+		"server_communication_bytes.redis-index_index1_cache_6379.response_bytes":   176918,
+		"pool_error.redis_budget.client_err":                                        30,
+		"pool_error.redis_budget.server_ejects":                                     40,
+		"pool_error.redis_budget.forward_error":                                     2,
+		"pool_client_connections.redis_budget.client_eof":                           2716,
+		"pool_client_connections.redis_budget.client_connections":                   221,
+		"server_error.redis_budget_budget1_cache_6379.server_err":                   3,
+		"server_error.redis_budget_budget1_cache_6379.server_timedout":              4,
+		"server_connections.redis_budget_budget1_cache_6379.server_eof":             3,
+		"server_connections.redis_budget_budget1_cache_6379.server_connections":     5,
+		"server_queue.redis_budget_budget1_cache_6379.out_queue":                    2,
+		"server_queue.redis_budget_budget1_cache_6379.in_queue":                     3,
+		"server_queue_bytes.redis_budget_budget1_cache_6379.out_queue_bytes":        81,
+		"server_queue_bytes.redis_budget_budget1_cache_6379.in_queue_bytes":         51,
+		"server_communications.redis_budget_budget1_cache_6379.requests":            3909,
+		"server_communications.redis_budget_budget1_cache_6379.responses":           3909,
+		"server_communication_bytes.redis_budget_budget1_cache_6379.request_bytes":  170559,
+		"server_communication_bytes.redis_budget_budget1_cache_6379.response_bytes": 176919,
+		"server_error.redis_budget_budget2_cache_6379.server_err":                   5,
+		"server_error.redis_budget_budget2_cache_6379.server_timedout":              6,
+		"server_connections.redis_budget_budget2_cache_6379.server_eof":             5,
+		"server_connections.redis_budget_budget2_cache_6379.server_connections":     7,
+		"server_queue.redis_budget_budget2_cache_6379.out_queue":                    4,
+		"server_queue.redis_budget_budget2_cache_6379.in_queue":                     5,
+		"server_queue_bytes.redis_budget_budget2_cache_6379.out_queue_bytes":        83,
+		"server_queue_bytes.redis_budget_budget2_cache_6379.in_queue_bytes":         53,
+		"server_communications.redis_budget_budget2_cache_6379.requests":            3911,
+		"server_communications.redis_budget_budget2_cache_6379.responses":           3911,
+		"server_communication_bytes.redis_budget_budget2_cache_6379.request_bytes":  170561,
+		"server_communication_bytes.redis_budget_budget2_cache_6379.response_bytes": 176921,
+	}
+
+	for k, v := range expected {
+		value, ok := metrics[k]
+		if !ok {
+			t.Errorf("metric of %s cannot be fetched", k)
+			continue
+		}
+		if v != value {
+			t.Errorf("metric of %s should be %v, but %v", k, v, value)
+		}
+	}
+}
+
+func TestFetchMetricsFail(t *testing.T) {
+	assertPanic := func(t *testing.T, f func() (map[string]interface{}, error)) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("FetchMetrics should be panic: stats=%v", stats)
+			}
+		}()
+		f()
+	}
+
+	p := TwemproxyPlugin{
+		Address: "localhost:" + strconv.Itoa(statsServer.Port()),
+		Prefix:  "twemproxy",
+		Timeout: 5,
+	}
+
+	// panic against a lacking stats json
+	noTotalConnectionsJSONStr := strings.Replace(
+		jsonStr, "\"total_connections\": 3895,\n", "", 1)
+	stats = noTotalConnectionsJSONStr
+	assertPanic(t, p.FetchMetrics)
+
+	noClientErrJSONStr := strings.Replace(
+		jsonStr, "\"client_err\": 10,\n", "", 1)
+	stats = noClientErrJSONStr
+	assertPanic(t, p.FetchMetrics)
+
+	noOutQueueJSONStr := strings.Replace(
+		jsonStr, "\"out_queue\": 1,\n", "", 1)
+	stats = noOutQueueJSONStr
+	assertPanic(t, p.FetchMetrics)
+
+	// return error against a stats json with addition
+	addInvalidParamJSONStr := strings.Replace(
+		jsonStr, "3895,", "3895, \"hoge\": 1,", 1)
+	stats = addInvalidParamJSONStr
+	_, err := p.FetchMetrics()
+	if err == nil {
+		t.Errorf("FetchMetrics should return error: stats=%v", stats)
+	}
+}
+
+func TestGraphDefinition(t *testing.T) {
+	p := TwemproxyPlugin{
+		Address: "",
+		Prefix:  "twemproxy",
+		Timeout: 5,
+	}
+	graphdef := p.GraphDefinition()
+
+	expectedNames := map[string]([]string){
+		"connections": {
+			"total_connections",
+			"curr_connections",
+		},
+		"pool_error.#": {
+			"client_err",
+			"server_ejects",
+			"forward_error",
+		},
+		"pool_client_connections.#": {
+			"client_connections",
+			"client_eof",
+		},
+		"server_error.#": {
+			"server_err",
+			"server_timedout",
+		},
+		"server_connections.#": {
+			"server_connections",
+			"server_eof",
+		},
+		"server_queue.#": {
+			"out_queue",
+			"in_queue",
+		},
+		"server_queue_bytes.#": {
+			"out_queue_bytes",
+			"in_queue_bytes",
+		},
+		"server_communications.#": {
+			"requests",
+			"responses",
+		},
+		"server_communication_bytes.#": {
+			"request_bytes",
+			"response_bytes",
+		},
+	}
+
+	expectedLabels := map[string]([]string){
+		"connections": {
+			"New Connections",
+			"Current Connections",
+		},
+		"pool_error.#": {
+			"Client Error",
+			"Server Ejects",
+			"Forward Error",
+		},
+		"pool_client_connections.#": {
+			"Client Connections",
+			"Client EOF",
+		},
+		"server_error.#": {
+			"Server Error",
+			"Server Timedout",
+		},
+		"server_connections.#": {
+			"Server Connections",
+			"Server EOF",
+		},
+		"server_queue.#": {
+			"Out Queue",
+			"In Queue",
+		},
+		"server_queue_bytes.#": {
+			"Out Queue Bytes",
+			"In Queue Bytes",
+		},
+		"server_communications.#": {
+			"Requests",
+			"Responses",
+		},
+		"server_communication_bytes.#": {
+			"Request Bytes",
+			"Response Bytes",
+		},
+	}
+
+	for k, names := range expectedNames {
+		value, ok := graphdef[k]
+		if !ok {
+			t.Errorf("graphdef of %s cannot be fetched", k)
+			continue
+		}
+
+		var metricNames []string
+		var metricLabels []string
+		for _, metric := range value.Metrics {
+			metricNames = append(metricNames, metric.Name)
+			metricLabels = append(metricLabels, metric.Label)
+		}
+
+		sort.Strings(names)
+		sort.Strings(metricNames)
+		if !reflect.DeepEqual(names, metricNames) {
+			t.Errorf("graphdef of %s should contain names %v, but %v",
+				k, names, metricNames)
+		}
+
+		labels := expectedLabels[k]
+		sort.Strings(labels)
+		sort.Strings(metricLabels)
+		if !reflect.DeepEqual(labels, metricLabels) {
+			t.Errorf("graphdef of %s should contain labels %v, but %v",
+				k, labels, metricLabels)
+		}
+	}
+}


### PR DESCRIPTION
We plan to use this plugin in production. After our test trial in production, we are sure that it's helpful for operators monitoring twemproxy(s). 

In my opinion, twemproxy is [a somewhat defacto standard](https://github.com/twitter/twemproxy#companies-using-twemproxy-in-production) proxy for redis and memcached, so I'm posting this PR.

- [x] Review https://github.com/mackerelio/mackerel-agent-plugins/blob/master/CONTRIBUTING.md