### PR TITLE
fix cloudwatch dimensions for elb

### DIFF
--- a/mackerel-plugin-aws-elb/aws-elb.go
+++ b/mackerel-plugin-aws-elb/aws-elb.go
@@ -166,12 +166,7 @@ func (p ELBPlugin) FetchMetrics() (map[string]float64, error) {
 		}
 	}
 
-	glb := []cloudwatch.Dimension{
-		{
-			Name:  "Service",
-			Value: "ELB",
-		},
-	}
+	glb := []cloudwatch.Dimension{}
 	if p.Lbname != "" {
 		g2 := cloudwatch.Dimension{
 			Name:  "LoadBalancerName",


### PR DESCRIPTION
I noticed that mackerel-plugin-aws-elb failed to get some values.
`elb.http_backend. *`, `elb.latency` failed,
`elb.healthy_host_count. *`, `elb.unhealthy_host_count.*` will succeed.
Since the difference between the two is how to set `dimensions`, 
I tried several settings of `dimensions` based on the document.
As a result, values can be acquired by excluding the following specifications.
```
{　Name: "Service", Value: "ELB", },
```
