### PR TITLE
Change error strings to pass current golint

### DIFF
--- a/mackerel-plugin-apache2/apache2.go
+++ b/mackerel-plugin-apache2/apache2.go
@@ -150,7 +150,7 @@ func parseApache2Scoreboard(str string, p *map[string]interface{}) error {
 		return nil
 	}
 
-	return errors.New("Scoreboard data is not found.")
+	return errors.New("scoreboard data is not found")
 }
 
 // parsing metrics from server-status?auto
@@ -176,7 +176,7 @@ func parseApache2Status(str string, p *map[string]interface{}) error {
 	}
 
 	if len(*p) == 0 {
-		return errors.New("Status data not found.")
+		return errors.New("status data not found")
 	}
 
 	return nil

--- a/mackerel-plugin-docker/docker.go
+++ b/mackerel-plugin-docker/docker.go
@@ -136,7 +136,7 @@ func findPrefixPath() (string, error) {
 			return path, nil
 		}
 	}
-	return "", errors.New("No prefix path is found.")
+	return "", errors.New("no prefix path is found")
 }
 
 type pathBuilder struct {

--- a/mackerel-plugin-haproxy/haproxy.go
+++ b/mackerel-plugin-haproxy/haproxy.go
@@ -85,7 +85,7 @@ func (p HAProxyPlugin) parseStats(statsBody io.Reader) (map[string]float64, erro
 		}
 
 		if len(columns) < 60 {
-			return nil, errors.New("Length of stats csv is too short. Specified uri may be wrong.")
+			return nil, errors.New("length of stats csv is too short (specified uri may be wrong)")
 		}
 
 		if columns[1] != "BACKEND" {

--- a/mackerel-plugin-jvm/jvm.go
+++ b/mackerel-plugin-jvm/jvm.go
@@ -51,7 +51,7 @@ func fetchLvmidByAppname(appname, target, jpsPath string) (string, error) {
 			return lvmid, nil
 		}
 	}
-	return "", fmt.Errorf("Cannot get lvmid from %s. Please run with the java process user.", appname)
+	return "", fmt.Errorf("cannot get lvmid from %s (please run with the java process user)", appname)
 }
 
 func fetchJstatMetrics(lvmid, option, jstatPath string) (map[string]float64, error) {

--- a/mackerel-plugin-php-apc/php-apc.go
+++ b/mackerel-plugin-php-apc/php-apc.go
@@ -114,7 +114,7 @@ func parsePhpApcStatus(str string, p *map[string]float64) error {
 	}
 
 	if len(*p) == 0 {
-		return errors.New("Status data not found.")
+		return errors.New("status data not found")
 	}
 
 	return nil

--- a/mackerel-plugin-php-opcache/php-opcache.go
+++ b/mackerel-plugin-php-opcache/php-opcache.go
@@ -95,7 +95,7 @@ func parsePhpOpcacheStatus(str string, p *map[string]float64) error {
 	}
 
 	if len(*p) == 0 {
-		return errors.New("Status data not found.")
+		return errors.New("status data not found")
 	}
 
 	return nil


### PR DESCRIPTION
ref: https://github.com/mackerelio/mackerel-agent/pull/295

Without this change `golint` fails. example: https://travis-ci.org/mackerelio/mackerel-agent-plugins/builds/177070744