### PR TITLE
Release version 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.24.0 (2016-11-29)
+
+* Implement mackerel-plugin-aws-ec2 #248 (yyoshiki41)
+* [postgres] support Pg9.1 #274 (Songmu)
+* Add new nvidia-smi plugin #280 (ksauzz)
+* [jvm] Add notice about user to README #281 (astj)
+* Implement mackerel-plugin-twemproxy #283 (yoheimuta)
+* fix cloudwatch dimensions for elb #284 (ki38sato)
+* Change error strings to pass current golint #285 (astj)
+* Add mackerel-plugin-twemproxy to package #286 (stefafafan)
+
+
 ## 0.23.1 (2016-10-27)
 
 * [redis] Fix a bug to fetch no metrics of keys and expired #272 (yoheimuta)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,24 @@
+mackerel-agent-plugins (0.24.0-1) stable; urgency=low
+
+  * Implement mackerel-plugin-aws-ec2 (by yyoshiki41)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/248>
+  * [postgres] support Pg9.1 (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/274>
+  * Add new nvidia-smi plugin (by ksauzz)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/280>
+  * [jvm] Add notice about user to README (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/281>
+  * Implement mackerel-plugin-twemproxy (by yoheimuta)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/283>
+  * fix cloudwatch dimensions for elb (by ki38sato)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/284>
+  * Change error strings to pass current golint (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/285>
+  * Add mackerel-plugin-twemproxy to package (by stefafafan)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/286>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Tue, 29 Nov 2016 06:18:37 +0000
+
 mackerel-agent-plugins (0.23.1-1) stable; urgency=low
 
   * [redis] Fix a bug to fetch no metrics of keys and expired (by yoheimuta)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,16 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Tue Nov 29 2016 <mackerel-developers@hatena.ne.jp> - 0.24.0-1
+- Implement mackerel-plugin-aws-ec2 (by yyoshiki41)
+- [postgres] support Pg9.1 (by Songmu)
+- Add new nvidia-smi plugin (by ksauzz)
+- [jvm] Add notice about user to README (by astj)
+- Implement mackerel-plugin-twemproxy (by yoheimuta)
+- fix cloudwatch dimensions for elb (by ki38sato)
+- Change error strings to pass current golint (by astj)
+- Add mackerel-plugin-twemproxy to package (by stefafafan)
+
 * Thu Oct 27 2016 <mackerel-developers@hatena.ne.jp> - 0.23.1-1
 - [redis] Fix a bug to fetch no metrics of keys and expired (by yoheimuta)
 - fix: "open file descriptors" property in elasticsearch  (by kamijin-fanta)


### PR DESCRIPTION
- Implement mackerel-plugin-aws-ec2 #248
- [postgres] support Pg9.1 #274
- Add new nvidia-smi plugin #280
- [jvm] Add notice about user to README #281
- Implement mackerel-plugin-twemproxy #283
- fix cloudwatch dimensions for elb #284
- Change error strings to pass current golint #285
- Add mackerel-plugin-twemproxy to package #286