### PR TITLE
[apache2] Change metric name not to end with dot

### DIFF
--- a/mackerel-plugin-apache2/lib/apache2.go
+++ b/mackerel-plugin-apache2/lib/apache2.go
@@ -140,6 +140,9 @@ func parseApache2Scoreboard(str string, p *map[string]interface{}) error {
 		}
 		record := strings.Split(line, ":")
 		for _, sb := range strings.Split(strings.Trim(record[1], " "), "") {
+			if sb == "." {
+				sb = ""
+			}
 			name := fmt.Sprintf("score-%s", sb)
 			c, assert := (*p)[name].(float64)
 			if !assert {

--- a/mackerel-plugin-apache2/lib/apache2.go
+++ b/mackerel-plugin-apache2/lib/apache2.go
@@ -82,7 +82,7 @@ func (c Apache2Plugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "score-L", Label: "Logging", Diff: false, Stacked: true},
 				{Name: "score-G", Label: "Gracefully finishing", Diff: false, Stacked: true},
 				{Name: "score-I", Label: "Idle cleanup", Diff: false, Stacked: true},
-				{Name: "score-.", Label: "Open slot", Diff: false, Stacked: true},
+				{Name: "score-", Label: "Open slot", Diff: false, Stacked: true},
 			},
 		},
 	}

--- a/mackerel-plugin-apache2/lib/apache2_test.go
+++ b/mackerel-plugin-apache2/lib/apache2_test.go
@@ -27,7 +27,7 @@ func TestParseApache2Scoreboard(t *testing.T) {
 	assert.EqualValues(t, stat["score-L"], 1)
 	assert.EqualValues(t, stat["score-G"], 1)
 	assert.EqualValues(t, stat["score-I"], 1)
-	assert.EqualValues(t, stat["score-."], 5)
+	assert.EqualValues(t, stat["score-"], 5)
 }
 
 func TestParseApache2Status(t *testing.T) {


### PR DESCRIPTION
According to [spec of `/api/v0/graph-defs/create`](https://mackerel.io/api-docs/entry/host-metrics#post-graphdef), metric name ending with dot (`.`) is invalid.

# Breaking change

A metric name will be changed.
```
custom.apache2.scoreboard.score-. => custom.apache2.scoreboard.score-
```