### PR TITLE
migrate from goamz to aws-sdk-go

### DIFF
--- a/mackerel-plugin-aws-cloudfront/lib/aws-cloudfront.go
+++ b/mackerel-plugin-aws-cloudfront/lib/aws-cloudfront.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/crowdmob/goamz/aws"
-	"github.com/crowdmob/goamz/cloudwatch"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
@@ -59,15 +61,18 @@ type CloudFrontPlugin struct {
 }
 
 func (p *CloudFrontPlugin) prepare() error {
-	auth, err := aws.GetAuth(p.AccessKeyID, p.SecretAccessKey, "", time.Now())
+	sess, err := session.NewSession()
 	if err != nil {
 		return err
 	}
 
-	p.CloudWatch, err = cloudwatch.NewCloudWatch(auth, aws.Regions[region].CloudWatchServicepoint)
-	if err != nil {
-		return err
+	config := aws.NewConfig()
+	if p.AccessKeyID != "" && p.SecretAccessKey != "" {
+		config = config.WithCredentials(credentials.NewStaticCredentials(p.AccessKeyID, p.SecretAccessKey, ""))
 	}
+	config = config.WithRegion(region)
+
+	p.CloudWatch = cloudwatch.New(sess, config)
 
 	return nil
 }
@@ -75,46 +80,46 @@ func (p *CloudFrontPlugin) prepare() error {
 func (p CloudFrontPlugin) getLastPoint(metric metrics) (float64, error) {
 	now := time.Now()
 
-	dimensions := []cloudwatch.Dimension{
+	dimensions := []*cloudwatch.Dimension{
 		{
-			Name:  "DistributionId",
-			Value: p.Name,
+			Name:  aws.String("DistributionId"),
+			Value: aws.String(p.Name),
 		},
 		{
-			Name:  "Region",
-			Value: "Global",
+			Name:  aws.String("Region"),
+			Value: aws.String("Global"),
 		},
 	}
 
-	response, err := p.CloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsRequest{
+	response, err := p.CloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsInput{
 		Dimensions: dimensions,
-		StartTime:  now.Add(time.Duration(180) * time.Second * -1), // 3 min (to fetch at least 1 data-point)
-		EndTime:    now,
-		MetricName: metric.Name,
-		Period:     60,
-		Statistics: []string{metric.Type},
-		Namespace:  namespace,
+		StartTime:  aws.Time(now.Add(time.Duration(180) * time.Second * -1)), // 3 min (to fetch at least 1 data-point)
+		EndTime:    aws.Time(now),
+		MetricName: aws.String(metric.Name),
+		Period:     aws.Int64(60),
+		Statistics: []*string{aws.String(metric.Type)},
+		Namespace:  aws.String(namespace),
 	})
 	if err != nil {
 		return 0, err
 	}
 
-	datapoints := response.GetMetricStatisticsResult.Datapoints
+	datapoints := response.Datapoints
 	if len(datapoints) == 0 {
 		return 0, errors.New("fetched no datapoints")
 	}
 
 	// get a least recently datapoint
 	// because a most recently datapoint is not stable.
-	least := now
+	least := new(time.Time)
 	var latestVal float64
 	for _, dp := range datapoints {
-		if dp.Timestamp.Before(least) {
+		if dp.Timestamp.Before(*least) {
 			least = dp.Timestamp
 			if metric.Type == metricsTypeAverage {
-				latestVal = dp.Average
+				latestVal = *dp.Average
 			} else if metric.Type == metricsTypeSum {
-				latestVal = dp.Sum
+				latestVal = *dp.Sum
 			}
 		}
 	}

--- a/mackerel-plugin-aws-cloudfront/lib/aws-cloudfront.go
+++ b/mackerel-plugin-aws-cloudfront/lib/aws-cloudfront.go
@@ -174,11 +174,7 @@ func Do() {
 	}
 
 	helper := mp.NewMackerelPlugin(plugin)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-cloudfront"
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-aws-ec2-cpucredit/lib/aws-ec2-cpucredit.go
+++ b/mackerel-plugin-aws-ec2-cpucredit/lib/aws-ec2-cpucredit.go
@@ -140,11 +140,7 @@ func Do() {
 	cpucredit.SecretAccessKey = *optSecretAccessKey
 
 	helper := mp.NewMackerelPlugin(cpucredit)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-cpucredit"
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-aws-elasticache/lib/aws-elasticache.go
+++ b/mackerel-plugin-aws-elasticache/lib/aws-elasticache.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
@@ -345,6 +346,15 @@ func Do() {
 	flag.Parse()
 
 	var ecache ECachePlugin
+
+	if *optRegion == "" {
+		ec2metadata := ec2metadata.New(session.New())
+		if ec2metadata.Available() {
+			ecache.Region, _ = ec2metadata.Region()
+		}
+	} else {
+		ecache.Region = *optRegion
+	}
 
 	ecache.Region = *optRegion
 	ecache.AccessKeyID = *optAccessKeyID

--- a/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
+++ b/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
@@ -271,11 +271,7 @@ func Do() {
 	}
 
 	helper := mp.NewMackerelPlugin(es)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-aws-elasticsearch"
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
+++ b/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/crowdmob/goamz/aws"
-	"github.com/crowdmob/goamz/cloudwatch"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
@@ -138,49 +140,54 @@ type ESPlugin struct {
 const esNameSpace = "AWS/ES"
 
 func (p *ESPlugin) prepare() error {
-	auth, err := aws.GetAuth(p.AccessKeyID, p.SecretAccessKey, "", time.Now())
+	sess, err := session.NewSession()
 	if err != nil {
 		return err
 	}
 
-	p.CloudWatch, err = cloudwatch.NewCloudWatch(auth, aws.Regions[p.Region].CloudWatchServicepoint)
-	if err != nil {
-		return err
+	config := aws.NewConfig()
+	if p.AccessKeyID != "" && p.SecretAccessKey != "" {
+		config = config.WithCredentials(credentials.NewStaticCredentials(p.AccessKeyID, p.SecretAccessKey, ""))
 	}
+	if p.Region != "" {
+		config = config.WithRegion(p.Region)
+	}
+
+	p.CloudWatch = cloudwatch.New(sess, config)
 	return nil
 }
 
-func (p ESPlugin) getLastPoint(dimensions *[]cloudwatch.Dimension, metricName string) (float64, error) {
+func (p ESPlugin) getLastPoint(dimensions []*cloudwatch.Dimension, metricName *string) (float64, error) {
 	now := time.Now()
 
-	response, err := p.CloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsRequest{
-		Dimensions: *dimensions,
-		StartTime:  now.Add(time.Duration(180) * time.Second * -1),
-		EndTime:    now,
+	response, err := p.CloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsInput{
+		Dimensions: dimensions,
+		StartTime:  aws.Time(now.Add(time.Duration(180) * time.Second * -1)),
+		EndTime:    aws.Time(now),
 		MetricName: metricName,
-		Period:     60,
-		Statistics: []string{"Average"},
-		Namespace:  esNameSpace,
+		Period:     aws.Int64(60),
+		Statistics: []*string{aws.String("Average")},
+		Namespace:  aws.String(esNameSpace),
 	})
 
 	if err != nil {
 		return 0, err
 	}
 
-	datapoints := response.GetMetricStatisticsResult.Datapoints
+	datapoints := response.Datapoints
 	if len(datapoints) == 0 {
 		return 0, errors.New("fetched no datapoints")
 	}
 
-	latest := time.Unix(0, 0)
+	latest := new(time.Time)
 	var latestVal float64
 	for _, dp := range datapoints {
-		if dp.Timestamp.Before(latest) {
+		if dp.Timestamp.Before(*latest) {
 			continue
 		}
 
 		latest = dp.Timestamp
-		latestVal = dp.Average
+		latestVal = *dp.Average
 	}
 
 	return latestVal, nil
@@ -188,20 +195,20 @@ func (p ESPlugin) getLastPoint(dimensions *[]cloudwatch.Dimension, metricName st
 
 // FetchMetrics interface for mackerelplugin
 func (p ESPlugin) FetchMetrics() (map[string]float64, error) {
-	dimensions := []cloudwatch.Dimension{
+	dimensionFilters := []*cloudwatch.DimensionFilter{
 		{
-			Name:  "DomainName",
-			Value: p.Domain,
+			Name:  aws.String("DomainName"),
+			Value: aws.String(p.Domain),
 		},
 		{
-			Name:  "ClientId",
-			Value: p.ClientID,
+			Name:  aws.String("ClientId"),
+			Value: aws.String(p.ClientID),
 		},
 	}
 
-	ret, err := p.CloudWatch.ListMetrics(&cloudwatch.ListMetricsRequest{
-		Namespace:  esNameSpace,
-		Dimensions: dimensions,
+	ret, err := p.CloudWatch.ListMetrics(&cloudwatch.ListMetricsInput{
+		Namespace:  aws.String(esNameSpace),
+		Dimensions: dimensionFilters,
 	})
 	if err != nil {
 		log.Printf("%s", err)
@@ -209,14 +216,24 @@ func (p ESPlugin) FetchMetrics() (map[string]float64, error) {
 
 	stat := make(map[string]float64)
 
-	for _, met := range ret.ListMetricsResult.Metrics {
-		v, err := p.getLastPoint(&dimensions, met.MetricName)
+	dimensions := []*cloudwatch.Dimension{
+		{
+			Name:  aws.String("DomainName"),
+			Value: aws.String(p.Domain),
+		},
+		{
+			Name:  aws.String("ClientId"),
+			Value: aws.String(p.ClientID),
+		},
+	}
+	for _, met := range ret.Metrics {
+		v, err := p.getLastPoint(dimensions, met.MetricName)
 		if err == nil {
-			if met.MetricName == "MasterFreeStorageSpace" || met.MetricName == "FreeStorageSpace" {
+			if *met.MetricName == "MasterFreeStorageSpace" || *met.MetricName == "FreeStorageSpace" {
 				// MBytes -> Bytes
 				v = v * 1024 * 1024
 			}
-			stat[met.MetricName] = v
+			stat[*met.MetricName] = v
 		} else {
 			log.Printf("%s: %s", met.MetricName, err)
 		}
@@ -242,12 +259,7 @@ func Do() {
 
 	var es ESPlugin
 
-	if *optRegion == "" {
-		es.Region = aws.InstanceRegion()
-	} else {
-		es.Region = *optRegion
-	}
-
+	es.Region = *optRegion
 	es.Domain = *optDomain
 	es.ClientID = *optClientID
 	es.AccessKeyID = *optAccessKeyID

--- a/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
+++ b/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
@@ -258,6 +259,15 @@ func Do() {
 	flag.Parse()
 
 	var es ESPlugin
+
+	if *optRegion == "" {
+		ec2metadata := ec2metadata.New(session.New())
+		if ec2metadata.Available() {
+			es.Region, _ = ec2metadata.Region()
+		}
+	} else {
+		es.Region = *optRegion
+	}
 
 	es.Region = *optRegion
 	es.Domain = *optDomain

--- a/mackerel-plugin-aws-elb/lib/aws-elb.go
+++ b/mackerel-plugin-aws-elb/lib/aws-elb.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
@@ -236,7 +237,14 @@ func Do() {
 
 	var elb ELBPlugin
 
-	elb.Region = *optRegion
+	if *optRegion == "" {
+		ec2metadata := ec2metadata.New(session.New())
+		if ec2metadata.Available() {
+			elb.Region, _ = ec2metadata.Region()
+		}
+	} else {
+		elb.Region = *optRegion
+	}
 	elb.AccessKeyID = *optAccessKeyID
 	elb.SecretAccessKey = *optSecretAccessKey
 	elb.Lbname = *optLbname

--- a/mackerel-plugin-aws-elb/lib/aws-elb.go
+++ b/mackerel-plugin-aws-elb/lib/aws-elb.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/crowdmob/goamz/aws"
-	"github.com/crowdmob/goamz/cloudwatch"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
@@ -55,41 +57,46 @@ type ELBPlugin struct {
 	Region          string
 	AccessKeyID     string
 	SecretAccessKey string
-	AZs             []string
+	AZs             []*string
 	CloudWatch      *cloudwatch.CloudWatch
 	Lbname          string
 }
 
 func (p *ELBPlugin) prepare() error {
-	auth, err := aws.GetAuth(p.AccessKeyID, p.SecretAccessKey, "", time.Now())
+	sess, err := session.NewSession()
 	if err != nil {
 		return err
 	}
 
-	p.CloudWatch, err = cloudwatch.NewCloudWatch(auth, aws.Regions[p.Region].CloudWatchServicepoint)
-	if err != nil {
-		return err
+	config := aws.NewConfig()
+	if p.AccessKeyID != "" && p.SecretAccessKey != "" {
+		config = config.WithCredentials(credentials.NewStaticCredentials(p.AccessKeyID, p.SecretAccessKey, ""))
+	}
+	if p.Region != "" {
+		config = config.WithRegion(p.Region)
 	}
 
-	ret, err := p.CloudWatch.ListMetrics(&cloudwatch.ListMetricsRequest{
-		Namespace: "AWS/ELB",
-		Dimensions: []cloudwatch.Dimension{
+	p.CloudWatch = cloudwatch.New(sess, config)
+
+	ret, err := p.CloudWatch.ListMetrics(&cloudwatch.ListMetricsInput{
+		Namespace: aws.String("AWS/ELB"),
+		Dimensions: []*cloudwatch.DimensionFilter{
 			{
-				Name: "AvailabilityZone",
+				Name: aws.String("AvailabilityZone"),
 			},
 		},
-		MetricName: "HealthyHostCount",
+		MetricName: aws.String("HealthyHostCount"),
 	})
 
 	if err != nil {
 		return err
 	}
 
-	p.AZs = make([]string, 0, len(ret.ListMetricsResult.Metrics))
-	for _, met := range ret.ListMetricsResult.Metrics {
+	p.AZs = make([]*string, 0, len(ret.Metrics))
+	for _, met := range ret.Metrics {
 		if len(met.Dimensions) > 1 {
 			continue
-		} else if met.Dimensions[0].Name != "AvailabilityZone" {
+		} else if *met.Dimensions[0].Name != "AvailabilityZone" {
 			continue
 		}
 
@@ -99,40 +106,40 @@ func (p *ELBPlugin) prepare() error {
 	return nil
 }
 
-func (p ELBPlugin) getLastPoint(dimensions *[]cloudwatch.Dimension, metricName string, sTyp statType) (float64, error) {
+func (p ELBPlugin) getLastPoint(dimensions []*cloudwatch.Dimension, metricName string, sTyp statType) (float64, error) {
 	now := time.Now()
 
-	response, err := p.CloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsRequest{
-		Dimensions: *dimensions,
-		StartTime:  now.Add(time.Duration(120) * time.Second * -1), // 2 min (to fetch at least 1 data-point)
-		EndTime:    now,
-		MetricName: metricName,
-		Period:     60,
-		Statistics: []string{sTyp.String()},
-		Namespace:  "AWS/ELB",
+	response, err := p.CloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsInput{
+		Dimensions: dimensions,
+		StartTime:  aws.Time(now.Add(time.Duration(120) * time.Second * -1)), // 2 min (to fetch at least 1 data-point)
+		EndTime:    aws.Time(now),
+		MetricName: aws.String(metricName),
+		Period:     aws.Int64(60),
+		Statistics: []*string{aws.String(sTyp.String())},
+		Namespace:  aws.String("AWS/ELB"),
 	})
 	if err != nil {
 		return 0, err
 	}
 
-	datapoints := response.GetMetricStatisticsResult.Datapoints
+	datapoints := response.Datapoints
 	if len(datapoints) == 0 {
 		return 0, errors.New("fetched no datapoints")
 	}
 
-	latest := time.Unix(0, 0)
+	latest := new(time.Time)
 	var latestVal float64
 	for _, dp := range datapoints {
-		if dp.Timestamp.Before(latest) {
+		if dp.Timestamp.Before(*latest) {
 			continue
 		}
 
 		latest = dp.Timestamp
 		switch sTyp {
 		case stAve:
-			latestVal = dp.Average
+			latestVal = *dp.Average
 		case stSum:
-			latestVal = dp.Sum
+			latestVal = *dp.Sum
 		}
 	}
 
@@ -145,43 +152,43 @@ func (p ELBPlugin) FetchMetrics() (map[string]float64, error) {
 
 	// HostCount per AZ
 	for _, az := range p.AZs {
-		d := []cloudwatch.Dimension{
+		d := []*cloudwatch.Dimension{
 			{
-				Name:  "AvailabilityZone",
+				Name:  aws.String("AvailabilityZone"),
 				Value: az,
 			},
 		}
 		if p.Lbname != "" {
-			d2 := cloudwatch.Dimension{
-				Name:  "LoadBalancerName",
-				Value: p.Lbname,
+			d2 := &cloudwatch.Dimension{
+				Name:  aws.String("LoadBalancerName"),
+				Value: aws.String(p.Lbname),
 			}
 			d = append(d, d2)
 		}
 		for _, met := range []string{"HealthyHostCount", "UnHealthyHostCount"} {
-			v, err := p.getLastPoint(&d, met, stAve)
+			v, err := p.getLastPoint(d, met, stAve)
 			if err == nil {
-				stat[met+"_"+az] = v
+				stat[met+"_"+*az] = v
 			}
 		}
 	}
 
-	glb := []cloudwatch.Dimension{}
+	glb := []*cloudwatch.Dimension{}
 	if p.Lbname != "" {
-		g2 := cloudwatch.Dimension{
-			Name:  "LoadBalancerName",
-			Value: p.Lbname,
+		g2 := &cloudwatch.Dimension{
+			Name:  aws.String("LoadBalancerName"),
+			Value: aws.String(p.Lbname),
 		}
 		glb = append(glb, g2)
 	}
 
-	v, err := p.getLastPoint(&glb, "Latency", stAve)
+	v, err := p.getLastPoint(glb, "Latency", stAve)
 	if err == nil {
 		stat["Latency"] = v
 	}
 
 	for _, met := range [...]string{"HTTPCode_Backend_2XX", "HTTPCode_Backend_3XX", "HTTPCode_Backend_4XX", "HTTPCode_Backend_5XX"} {
-		v, err := p.getLastPoint(&glb, met, stSum)
+		v, err := p.getLastPoint(glb, met, stSum)
 		if err == nil {
 			stat[met] = v
 		}
@@ -206,7 +213,7 @@ func (p ELBPlugin) GraphDefinition() map[string]mp.Graphs {
 
 		var metrics []mp.Metrics
 		for _, az := range p.AZs {
-			metrics = append(metrics, mp.Metrics{Name: namePre + az, Label: az, Stacked: true})
+			metrics = append(metrics, mp.Metrics{Name: namePre + *az, Label: *az, Stacked: true})
 		}
 		graphdef[grp] = mp.Graphs{
 			Label:   label,
@@ -229,12 +236,7 @@ func Do() {
 
 	var elb ELBPlugin
 
-	if *optRegion == "" {
-		elb.Region = aws.InstanceRegion()
-	} else {
-		elb.Region = *optRegion
-	}
-
+	elb.Region = *optRegion
 	elb.AccessKeyID = *optAccessKeyID
 	elb.SecretAccessKey = *optSecretAccessKey
 	elb.Lbname = *optLbname

--- a/mackerel-plugin-aws-elb/lib/aws-elb.go
+++ b/mackerel-plugin-aws-elb/lib/aws-elb.go
@@ -247,11 +247,7 @@ func Do() {
 	}
 
 	helper := mp.NewMackerelPlugin(elb)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-elb"
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()

--- a/mackerel-plugin-aws-rds/lib/aws-rds.go
+++ b/mackerel-plugin-aws-rds/lib/aws-rds.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
@@ -229,7 +230,15 @@ func Do() {
 		rds.LabelPrefix = *optLabelPrefix
 	}
 
-	rds.Region = *optRegion
+	if *optRegion == "" {
+		ec2metadata := ec2metadata.New(session.New())
+		if ec2metadata.Available() {
+			rds.Region, _ = ec2metadata.Region()
+		}
+	} else {
+		rds.Region = *optRegion
+	}
+
 	rds.Identifier = *optIdentifier
 	rds.AccessKeyID = *optAccessKeyID
 	rds.SecretAccessKey = *optSecretAccessKey

--- a/mackerel-plugin-aws-rds/lib/aws-rds.go
+++ b/mackerel-plugin-aws-rds/lib/aws-rds.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/crowdmob/goamz/aws"
-	"github.com/crowdmob/goamz/cloudwatch"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
@@ -27,33 +29,33 @@ type RDSPlugin struct {
 func getLastPoint(cloudWatch *cloudwatch.CloudWatch, dimension *cloudwatch.Dimension, metricName string) (float64, error) {
 	now := time.Now()
 
-	response, err := cloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsRequest{
-		Dimensions: []cloudwatch.Dimension{*dimension},
-		StartTime:  now.Add(time.Duration(180) * time.Second * -1), // 3 min (to fetch at least 1 data-point)
-		EndTime:    now,
-		MetricName: metricName,
-		Period:     60,
-		Statistics: []string{"Average"},
-		Namespace:  "AWS/RDS",
+	response, err := cloudWatch.GetMetricStatistics(&cloudwatch.GetMetricStatisticsInput{
+		Dimensions: []*cloudwatch.Dimension{dimension},
+		StartTime:  aws.Time(now.Add(time.Duration(180) * time.Second * -1)), // 3 min (to fetch at least 1 data-point)
+		EndTime:    aws.Time(now),
+		MetricName: aws.String(metricName),
+		Period:     aws.Int64(60),
+		Statistics: []*string{aws.String("Average")},
+		Namespace:  aws.String("AWS/RDS"),
 	})
 	if err != nil {
 		return 0, err
 	}
 
-	datapoints := response.GetMetricStatisticsResult.Datapoints
+	datapoints := response.Datapoints
 	if len(datapoints) == 0 {
 		return 0, errors.New("fetched no datapoints")
 	}
 
-	latest := time.Unix(0, 0)
+	latest := new(time.Time)
 	var latestVal float64
 	for _, dp := range datapoints {
-		if dp.Timestamp.Before(latest) {
+		if dp.Timestamp.Before(*latest) {
 			continue
 		}
 
 		latest = dp.Timestamp
-		latestVal = dp.Average
+		latestVal = *dp.Average
 	}
 
 	return latestVal, nil
@@ -61,21 +63,26 @@ func getLastPoint(cloudWatch *cloudwatch.CloudWatch, dimension *cloudwatch.Dimen
 
 // FetchMetrics interface for mackerel-plugin
 func (p RDSPlugin) FetchMetrics() (map[string]float64, error) {
-	auth, err := aws.GetAuth(p.AccessKeyID, p.SecretAccessKey, "", time.Now())
+	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err
 	}
 
-	cloudWatch, err := cloudwatch.NewCloudWatch(auth, aws.Regions[p.Region].CloudWatchServicepoint)
-	if err != nil {
-		return nil, err
+	config := aws.NewConfig()
+	if p.AccessKeyID != "" && p.SecretAccessKey != "" {
+		config = config.WithCredentials(credentials.NewStaticCredentials(p.AccessKeyID, p.SecretAccessKey, ""))
 	}
+	if p.Region != "" {
+		config = config.WithRegion(p.Region)
+	}
+
+	cloudWatch := cloudwatch.New(sess, config)
 
 	stat := make(map[string]float64)
 
 	perInstance := &cloudwatch.Dimension{
-		Name:  "DBInstanceIdentifier",
-		Value: p.Identifier,
+		Name:  aws.String("DBInstanceIdentifier"),
+		Value: aws.String(p.Identifier),
 	}
 
 	for _, met := range p.rdsMetrics() {
@@ -222,12 +229,7 @@ func Do() {
 		rds.LabelPrefix = *optLabelPrefix
 	}
 
-	if *optRegion == "" {
-		rds.Region = aws.InstanceRegion()
-	} else {
-		rds.Region = *optRegion
-	}
-
+	rds.Region = *optRegion
 	rds.Identifier = *optIdentifier
 	rds.AccessKeyID = *optAccessKeyID
 	rds.SecretAccessKey = *optSecretAccessKey

--- a/mackerel-plugin-aws-rds/lib/aws-rds.go
+++ b/mackerel-plugin-aws-rds/lib/aws-rds.go
@@ -236,11 +236,7 @@ func Do() {
 	rds.Engine = *optEngine
 
 	helper := mp.NewMackerelPlugin(rds)
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-rds"
-	}
+	helper.Tempfile = *optTempfile
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
 		helper.OutputDefinitions()


### PR DESCRIPTION
# background

- https://github.com/crowdmob/goamz is deprecated
  - (And https://github.com/AdRoll/goamz is suggested)
- Currently we cannot build plugins using  crowdmob/goamz
- Maybe official SDK https://github.com/aws/aws-sdk-go is enough

# Changes introducing

 - For aws-{cloudfront, ec2-cpuredit, elasticache, elasticsearch, elb, rds}, Migrate from goamz to aws-sdk-go
- aws-ses also uses goamz, but it only uses its authentication part and we can build it now, so keep it
  - And practically it uses go-ses, which uses goamz's authentication interface, therefore it's harder to migrate to aws-sdk-go
- And I removed explicitly default Tempfile definition from some plugins
  - These changes improve compatibility with `MACKEREL_PLUGIN_WORKDIR` env.
