### PR TITLE
[nit] change import path for github.com/layeh/gumble/gumble

### DIFF
--- a/mackerel-plugin-murmur/lib/murmur.go
+++ b/mackerel-plugin-murmur/lib/murmur.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	mumble "github.com/layeh/gumble/gumble"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+	mumble "layeh.com/gumble/gumble"
 )
 
 var graphdef = map[string]mp.Graphs{


### PR DESCRIPTION
Its import path changed. ref: https://github.com/layeh/gumble/commit/1f539c85da553378dacd9814ce9b23142e4dcaf3
Otherwise we cannot `make testdeps` ref: https://travis-ci.org/mackerelio/mackerel-agent-plugins/builds/186792387

```
[github.com/mackerelio/mackerel-agent-plugins]$ make testdeps
go get -d -v -t ./...
Fetching https://layeh.com/gumble/gumble/MumbleProto?go-get=1
Parsing meta tags from https://layeh.com/gumble/gumble/MumbleProto?go-get=1 (status code 200)
get "layeh.com/gumble/gumble/MumbleProto": found meta tag main.metaImport{Prefix:"layeh.com/gumble", VCS:"git", RepoRoot:"https://github.com/layeh/gumble"} at https://layeh.com/gumble/gumble/MumbleProto?go-get=1
get "layeh.com/gumble/gumble/MumbleProto": verifying non-authoritative meta tag
Fetching https://layeh.com/gumble?go-get=1
Parsing meta tags from https://layeh.com/gumble?go-get=1 (status code 200)
layeh.com/gumble (download)
mackerel-plugin-murmur/lib/murmur.go:9:2: code in directory /Users/astj/.go/src/github.com/layeh/gumble/gumble expects import "layeh.com/gumble/gumble"
make: *** [testdeps] Error 1
```