### PR TITLE
Release version 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,12 @@
 
 ## 0.25.0 (2017-01-04)
 
-* Test case is corresponding to httpd stub. #2 (koemu)
-* Better installation testing library on TravisCI #4 (yuuki)
 * Change directory structure convention of each plugin #289 (Songmu)
 * [apache2] fix typo in graphdef #291 (astj)
 * [apache2] Change metric name not to end with dot #293 (astj)
 * add mackerel-plugin-windows-server-sessions #294 (daiksy)
 * migrate from goamz to aws-sdk-go #295 (astj)
 * [docker] Add timeout for API request #296 (astj)
-* fix directory structure #298 (mattn)
-* [ci skip]Update readme #299 (mattn)
 
 
 ## 0.24.0 (2016-11-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.25.0 (2017-01-04)
+
+* Test case is corresponding to httpd stub. #2 (koemu)
+* Better installation testing library on TravisCI #4 (yuuki)
+* Change directory structure convention of each plugin #289 (Songmu)
+* [apache2] fix typo in graphdef #291 (astj)
+* [apache2] Change metric name not to end with dot #293 (astj)
+* add mackerel-plugin-windows-server-sessions #294 (daiksy)
+* migrate from goamz to aws-sdk-go #295 (astj)
+* [docker] Add timeout for API request #296 (astj)
+* fix directory structure #298 (mattn)
+* [ci skip]Update readme #299 (mattn)
+
+
 ## 0.24.0 (2016-11-29)
 
 * Implement mackerel-plugin-aws-ec2 #248 (yyoshiki41)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,28 @@
+mackerel-agent-plugins (0.25.0-1) stable; urgency=low
+
+  * Test case is corresponding to httpd stub. (by koemu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/2>
+  * Better installation testing library on TravisCI (by yuuki)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/4>
+  * Change directory structure convention of each plugin (by Songmu)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/289>
+  * [apache2] fix typo in graphdef (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/291>
+  * [apache2] Change metric name not to end with dot (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/293>
+  * add mackerel-plugin-windows-server-sessions (by daiksy)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/294>
+  * migrate from goamz to aws-sdk-go (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/295>
+  * [docker] Add timeout for API request (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/296>
+  * fix directory structure (by mattn)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/298>
+  * [ci skip]Update readme (by mattn)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/299>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 04 Jan 2017 07:28:06 +0000
+
 mackerel-agent-plugins (0.24.0-1) stable; urgency=low
 
   * Implement mackerel-plugin-aws-ec2 (by yyoshiki41)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,9 +1,5 @@
 mackerel-agent-plugins (0.25.0-1) stable; urgency=low
 
-  * Test case is corresponding to httpd stub. (by koemu)
-    <https://github.com/mackerelio/mackerel-agent-plugins/pull/2>
-  * Better installation testing library on TravisCI (by yuuki)
-    <https://github.com/mackerelio/mackerel-agent-plugins/pull/4>
   * Change directory structure convention of each plugin (by Songmu)
     <https://github.com/mackerelio/mackerel-agent-plugins/pull/289>
   * [apache2] fix typo in graphdef (by astj)
@@ -16,10 +12,6 @@ mackerel-agent-plugins (0.25.0-1) stable; urgency=low
     <https://github.com/mackerelio/mackerel-agent-plugins/pull/295>
   * [docker] Add timeout for API request (by astj)
     <https://github.com/mackerelio/mackerel-agent-plugins/pull/296>
-  * fix directory structure (by mattn)
-    <https://github.com/mackerelio/mackerel-agent-plugins/pull/298>
-  * [ci skip]Update readme (by mattn)
-    <https://github.com/mackerelio/mackerel-agent-plugins/pull/299>
 
  -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 04 Jan 2017 07:28:06 +0000
 

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -50,16 +50,12 @@ done
 
 %changelog
 * Wed Jan 04 2017 <mackerel-developers@hatena.ne.jp> - 0.25.0-1
-- Test case is corresponding to httpd stub. (by koemu)
-- Better installation testing library on TravisCI (by yuuki)
 - Change directory structure convention of each plugin (by Songmu)
 - [apache2] fix typo in graphdef (by astj)
 - [apache2] Change metric name not to end with dot (by astj)
 - add mackerel-plugin-windows-server-sessions (by daiksy)
 - migrate from goamz to aws-sdk-go (by astj)
 - [docker] Add timeout for API request (by astj)
-- fix directory structure (by mattn)
-- [ci skip]Update readme (by mattn)
 
 * Tue Nov 29 2016 <mackerel-developers@hatena.ne.jp> - 0.24.0-1
 - Implement mackerel-plugin-aws-ec2 (by yyoshiki41)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,18 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Wed Jan 04 2017 <mackerel-developers@hatena.ne.jp> - 0.25.0-1
+- Test case is corresponding to httpd stub. (by koemu)
+- Better installation testing library on TravisCI (by yuuki)
+- Change directory structure convention of each plugin (by Songmu)
+- [apache2] fix typo in graphdef (by astj)
+- [apache2] Change metric name not to end with dot (by astj)
+- add mackerel-plugin-windows-server-sessions (by daiksy)
+- migrate from goamz to aws-sdk-go (by astj)
+- [docker] Add timeout for API request (by astj)
+- fix directory structure (by mattn)
+- [ci skip]Update readme (by mattn)
+
 * Tue Nov 29 2016 <mackerel-developers@hatena.ne.jp> - 0.24.0-1
 - Implement mackerel-plugin-aws-ec2 (by yyoshiki41)
 - [postgres] support Pg9.1 (by Songmu)


### PR DESCRIPTION
- Change directory structure convention of each plugin #289
- [apache2] fix typo in graphdef #291
- [apache2] Change metric name not to end with dot #293
- add mackerel-plugin-windows-server-sessions #294
- migrate from goamz to aws-sdk-go #295
- [docker] Add timeout for API request #296
- fix directory structure #298
- [ci skip]Update readme #299