### PR TITLE
Fix the label and scale in jvm plugin

### DIFF
--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -221,7 +221,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.gc_time", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s GC time (msec)", rawJavaName),
+			Label: fmt.Sprintf("JVM %s GC time (sec)", rawJavaName),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "YGCT", Label: "Young GC time", Diff: true},

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -233,8 +233,8 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			Unit:  "percentage",
 			Metrics: []mp.Metrics{
 				// gc_time_percentage is the percentage of gc time to 60 sec.
-				{Name: "YGCT", Label: "Young GC time", Diff: true, Scale: (0.001 / 60)},
-				{Name: "FGCT", Label: "Full GC time", Diff: true, Scale: (0.001 / 60)},
+				{Name: "YGCT", Label: "Young GC time", Diff: true, Scale: (100.0 / 60)},
+				{Name: "FGCT", Label: "Full GC time", Diff: true, Scale: (100.0 / 60)},
 			},
 		},
 		fmt.Sprintf("jvm.%s.new_space", lowerJavaName): {


### PR DESCRIPTION
Due to the references, the unit of gc times are available in seconds. However, the jvm plugin

- outputs the label as msec.
- scales incorrectly to calculate the gc time rate to 60 seconds.

I fixed

- the label of the graph of GC time (msec -> sec).
- the scale of GC time percentage.

References
  http://docs.oracle.com/javase/7/docs/technotes/tools/share/jstat.html#gcutil_option
  https://docs.oracle.com/javase/8/docs/technotes/tools/unix/jstat.html