### PR TITLE
[aws-rds] Make it possible to get metrics from Aurora.

### DIFF
--- a/mackerel-plugin-aws-rds/lib/metrics.go
+++ b/mackerel-plugin-aws-rds/lib/metrics.go
@@ -74,11 +74,48 @@ func (p RDSPlugin) postgreSQLGraphDefinition() map[string]mp.Graphs {
 
 func (p RDSPlugin) auroraGraphDefinition() map[string]mp.Graphs {
 	return map[string]mp.Graphs{
+		p.Prefix + ".CPUUtilization": {
+			Label: p.LabelPrefix + " CPU Utilization",
+			Unit:  "percentage",
+			Metrics: []mp.Metrics{
+				{Name: "CPUUtilization", Label: "CPUUtilization"},
+			},
+		},
+		// .CPUCreditBalance ...Only valid for T2 instances
+		p.Prefix + ".CPUCreditBalance": {
+			Label: p.LabelPrefix + " CPU CreditBalance",
+			Unit:  "float",
+			Metrics: []mp.Metrics{
+				{Name: "CPUCreditBalance", Label: "CPUCreditBalance"},
+			},
+		},
+		// .CPUCreditUsage ...Only valid for T2 instances
+		p.Prefix + ".CPUCreditUsage": {
+			Label: p.LabelPrefix + " CPU CreditUsage",
+			Unit:  "float",
+			Metrics: []mp.Metrics{
+				{Name: "CPUCreditUsage", Label: "CPUCreditUsage"},
+			},
+		},
 		p.Prefix + ".Deadlocks": {
 			Label: p.LabelPrefix + " Dead Locks",
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "Deadlocks", Label: "Deadlocks"},
+			},
+		},
+		p.Prefix + ".DatabaseConnections": {
+			Label: p.LabelPrefix + " Database Connections",
+			Unit:  "float",
+			Metrics: []mp.Metrics{
+				{Name: "DatabaseConnections", Label: "DatabaseConnections"},
+			},
+		},
+		p.Prefix + ".FreeableMemory": {
+			Label: p.LabelPrefix + " Freeable Memory",
+			Unit:  "bytes",
+			Metrics: []mp.Metrics{
+				{Name: "FreeableMemory", Label: "FreeableMemory"},
 			},
 		},
 		p.Prefix + ".Transaction": {


### PR DESCRIPTION
### Add Aurora metrics below:
* CPUUtilization
* CPUCreditBalance //only t2 instance
* CPUCreditUsage //only t2 instance
* DatabaseConnections
* FreeableMemory

### before output
```shell
rds.CacheHitRatio.ResultSetCacheHitRatio	17.307692	1485506194
rds.CacheHitRatio.BufferCacheHitRatio	100	1485506194
rds.AuroraReplicaLag.AuroraReplicaLagMaximum	26.157000	1485506194
rds.AuroraReplicaLag.AuroraReplicaLagMinimum	26.157000	1485506194
rds.Deadlocks.Deadlocks	0	1485506194
rds.Transaction.ActiveTransactions	0	1485506194
rds.Transaction.BlockedTransactions	0	1485506194
rds.Throughput.SelectThroughput	4.333406	1485506194
rds.Throughput.InsertThroughput	0.533342	1485506194
rds.Throughput.UpdateThroughput	0.250004	1485506194
rds.Throughput.DeleteThroughput	0	1485506194
rds.Throughput.CommitThroughput	0.750013	1485506194
rds.Throughput.DDLThroughput	0	1485506194
rds.Throughput.DMLThroughput	0.783346	1485506194
rds.Queries.Queries	14.233096	1485506194
rds.LoginFailures.LoginFailures	0.016666	1485506194
rds.AuroraBinlogReplicaLag.AuroraBinlogReplicaLag	0	1485506194
rds.EngineUptime.EngineUptime	4367521	1485506194
rds.Latency.SelectThroughput	4.333406	1485506194
rds.Latency.InsertLatency	0.183031	1485506194
rds.Latency.UpdateLatency	0.165933	1485506194
rds.Latency.DeleteLatency	0	1485506194
rds.Latency.CommitLatency	5.696622	1485506194
rds.Latency.DDLLatency	0	1485506194
rds.Latency.DMLLatency	0.177574	1485506194
```

### after output (sorry, this Aurora instance is not t2 instance)
```shell
2017/01/27 17:38:18 CPUCreditBalance: fetched no datapoints
2017/01/27 17:38:18 CPUCreditUsage: fetched no datapoints
rds.Deadlocks.Deadlocks	0	1485506298
rds.FreeableMemory.FreeableMemory	6914674688	1485506298
rds.Throughput.SelectThroughput	3.266721	1485506298
rds.Throughput.InsertThroughput	0.600010	1485506298
rds.Throughput.UpdateThroughput	0.116669	1485506298
rds.Throughput.DeleteThroughput	0	1485506298
rds.Throughput.CommitThroughput	0.583343	1485506298
rds.Throughput.DDLThroughput	0	1485506298
rds.Throughput.DMLThroughput	0.716679	1485506298
rds.AuroraBinlogReplicaLag.AuroraBinlogReplicaLag	0	1485506298
rds.AuroraReplicaLag.AuroraReplicaLagMaximum	19.820000	1485506298
rds.AuroraReplicaLag.AuroraReplicaLagMinimum	19.820000	1485506298
rds.DatabaseConnections.DatabaseConnections	6	1485506298
rds.EngineUptime.EngineUptime	4367641	1485506298
rds.Latency.SelectThroughput	3.266721	1485506298
rds.Latency.InsertLatency	0.181861	1485506298
rds.Latency.UpdateLatency	0.157286	1485506298
rds.Latency.DeleteLatency	0	1485506298
rds.Latency.CommitLatency	5.982371	1485506298
rds.Latency.DDLLatency	0	1485506298
rds.Latency.DMLLatency	0.177860	1485506298
rds.CPUUtilization.CPUUtilization	2.500000	1485506298
rds.Transaction.ActiveTransactions	0	1485506298
rds.Transaction.BlockedTransactions	0	1485506298
rds.Queries.Queries	10.405203	1485506298
rds.LoginFailures.LoginFailures	0.016675	1485506298
rds.CacheHitRatio.ResultSetCacheHitRatio	13.265306	1485506298
rds.CacheHitRatio.BufferCacheHitRatio	100	1485506298
```