### PR TITLE
[aws-cloudfront] Fix regression #295

### DIFF
--- a/mackerel-plugin-aws-cloudfront/lib/aws-cloudfront.go
+++ b/mackerel-plugin-aws-cloudfront/lib/aws-cloudfront.go
@@ -111,11 +111,11 @@ func (p CloudFrontPlugin) getLastPoint(metric metrics) (float64, error) {
 
 	// get a least recently datapoint
 	// because a most recently datapoint is not stable.
-	least := new(time.Time)
+	least := time.Now()
 	var latestVal float64
 	for _, dp := range datapoints {
-		if dp.Timestamp.Before(*least) {
-			least = dp.Timestamp
+		if dp.Timestamp.Before(least) {
+			least = *dp.Timestamp
 			if metric.Type == metricsTypeAverage {
 				latestVal = *dp.Average
 			} else if metric.Type == metricsTypeSum {


### PR DESCRIPTION
Initial value of `latest` should be latest timestamp (like `now`).  I mistakingly change it on https://github.com/mackerelio/mackerel-agent-plugins/commit/e96e51e3e4e778b8332da346e62786c47d4af805#diff-9c38f5b9ec8b7f4bc9b48e08f544be3cR114 .