### PR TITLE
Release version 0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.25.2 (2017-02-08)
+
+* [aws-rds] fix metric name #306 (TakashiKaga)
+* [aws-ses] ses.stats is unit type #308 (holidayworking)
+* [aws-cloudfront] Fix regression #295 #309 (astj)
+
+
 ## 0.25.1 (2017-01-25)
 
 * Make more plugins to support MACKEREL_PLUGIN_WORKDIR #301 (astj)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent-plugins (0.25.2-1) stable; urgency=low
+
+  * [aws-rds] fix metric name (by TakashiKaga)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/306>
+  * [aws-ses] ses.stats is unit type (by holidayworking)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/308>
+  * [aws-cloudfront] Fix regression #295 (by astj)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/309>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 08 Feb 2017 02:09:23 +0000
+
 mackerel-agent-plugins (0.25.1-1) stable; urgency=low
 
   * Make more plugins to support MACKEREL_PLUGIN_WORKDIR (by astj)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,11 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Wed Feb 08 2017 <mackerel-developers@hatena.ne.jp> - 0.25.2-1
+- [aws-rds] fix metric name (by TakashiKaga)
+- [aws-ses] ses.stats is unit type (by holidayworking)
+- [aws-cloudfront] Fix regression #295 (by astj)
+
 * Wed Jan 25 2017 <mackerel-developers@hatena.ne.jp> - 0.25.1-1
 - Make more plugins to support MACKEREL_PLUGIN_WORKDIR (by astj)
 - [jvm] Fix the label and scale (by itchyny)


### PR DESCRIPTION
- [aws-rds] fix metric name #306
- [aws-ses] ses.stats is unit type #308
- [aws-cloudfront] Fix regression #295 #309