### PR TITLE
Release version 0.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.25.3 (2017-02-16)
+
+* Feature/gcp compute engine #304 (littlekbt)
+* [aws-rds] Make it possible to get metrics from Aurora. #307 (TakashiKaga)
+* [multicore]fix tempfile path #311 (daiksy)
+
+
 ## 0.25.2 (2017-02-08)
 
 * [aws-rds] fix metric name #306 (TakashiKaga)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-agent-plugins (0.25.3-1) stable; urgency=low
+
+  * Feature/gcp compute engine (by littlekbt)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/304>
+  * [aws-rds] Make it possible to get metrics from Aurora. (by TakashiKaga)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/307>
+  * [multicore]fix tempfile path (by daiksy)
+    <https://github.com/mackerelio/mackerel-agent-plugins/pull/311>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Thu, 16 Feb 2017 04:34:10 +0000
+
 mackerel-agent-plugins (0.25.2-1) stable; urgency=low
 
   * [aws-rds] fix metric name (by TakashiKaga)

--- a/packaging/rpm/mackerel-agent-plugins.spec
+++ b/packaging/rpm/mackerel-agent-plugins.spec
@@ -49,6 +49,11 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Thu Feb 16 2017 <mackerel-developers@hatena.ne.jp> - 0.25.3-1
+- Feature/gcp compute engine (by littlekbt)
+- [aws-rds] Make it possible to get metrics from Aurora. (by TakashiKaga)
+- [multicore]fix tempfile path (by daiksy)
+
 * Wed Feb 08 2017 <mackerel-developers@hatena.ne.jp> - 0.25.2-1
 - [aws-rds] fix metric name (by TakashiKaga)
 - [aws-ses] ses.stats is unit type (by holidayworking)


### PR DESCRIPTION
- Feature/gcp compute engine #304
- [aws-rds] Make it possible to get metrics from Aurora. #307
- [multicore]fix tempfile path #311