### PR TITLE
Cross compile by go's native cross build, not by gox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - PATH=~/gopath/bin:$PATH DEBIAN_FRONTEND=noninteractive
   - secure: "eLpMK47AnVEw3GJw+FGS/LwCPlZ+lLPZ2gHDgOk9v3FWQc1pdDvC/Ot9fUWR/H1h0TWZ6W7Jly1h9ZbCS/VclgbBa3g1PqNDjLLZDUVGVjzAe666zGmkgyvdjIXnqDD0NCwA6BmdoQv1xwAovquKagRMi58Hb9Zy0RclZ/fx4SI="
 install:
-- go get github.com/mitchellh/gox
 - sudo apt-get update
 - DEBIAN_FRONTEND=noninteractive sudo apt-get install -y rpm devscripts debhelper
 - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}

--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,14 @@ VERBOSE_FLAG = $(if $(VERBOSE),-verbose)
 CURRENT_VERSION = $(shell git log --merges --oneline | perl -ne 'if(m/^.+Merge pull request \#[0-9]+ from .+\/bump-version-([0-9\.]+)/){print $$1;exit}')
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 BUILD_LDFLAGS = "-s -w"
-TARGET_OSARCH="linux/amd64"
-
-check-variables:
-	echo "CURRENT_VERSION: ${CURRENT_VERSION}"
-	echo "TARGET_OSARCH: ${TARGET_OSARCH}"
 
 all: lint cover testtool testconvention rpm deb
 
 build: deps
 	mkdir -p build
 	for i in mackerel-plugin-*; do \
-	  gox $(VERBOSE_FLAG) -ldflags="-s -w" \
-	    -osarch=$(TARGET_OSARCH) -output build/$$i \
-			`pwd | sed -e "s|${GOPATH}/src/||"`/$$i; \
+		go build  -ldflags="-s -w" -o build/$$i \
+		`pwd | sed -e "s|${GOPATH}/src/||"`/$$i; \
 	done
 
 build/mackerel-plugin: deps
@@ -53,19 +47,15 @@ cover: testdeps
 	gotestcover -v -covermode=count -coverprofile=.profile.cov -parallelpackages=4 ./...
 
 rpm: build
-	make build TARGET_OSARCH="linux/386"
+	make build GOOS=linux GOARCH=386
 	rpmbuild --define "_sourcedir `pwd`"  --define "_version ${CURRENT_VERSION}" --define "buildarch noarch" -bb packaging/rpm/mackerel-agent-plugins.spec
-	make build TARGET_OSARCH="linux/amd64"
+	make build GOOS=linux GOARCH=amd64
 	rpmbuild --define "_sourcedir `pwd`"  --define "_version ${CURRENT_VERSION}" --define "buildarch x86_64" -bb packaging/rpm/mackerel-agent-plugins.spec
 
 deb: build
-	make build TARGET_OSARCH="linux/386"
+	make build GOOS=linux GOARCH=386
 	cp build/mackerel-plugin-* packaging/deb/debian/
 	cd packaging/deb && debuild --no-tgz-check -rfakeroot -uc -us
-
-gox:
-	go get github.com/mitchellh/gox
-	gox -build-toolchain -osarch=$(TARGET_OSARCH)
 
 clean:
 	if [ -d build ]; then \
@@ -76,4 +66,4 @@ clean:
 release:
 	tool/releng
 
-.PHONY: all build test testgo deps testdeps rpm deb gox clean release lint cover testtool testconvention
+.PHONY: all build test testgo deps testdeps rpm deb clean release lint cover testtool testconvention

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ dependencies:
 
 test:
   pre:
-    - go get github.com/mitchellh/gox
     - sudo service mongod stop
   override:
     - make test


### PR DESCRIPTION
Since mackerel-agent-plugins' build process is simple (compared to mackerel-agent), maybe native `go build` is enough.