### PR TITLE
Add mackerel-plugin-gunicorn

### DIFF
--- a/mackerel-plugin-gunicorn/README.md
+++ b/mackerel-plugin-gunicorn/README.md
@@ -11,7 +11,7 @@ mackerel-plugin-gunicorn [-status-file=<path>]
 
 ## Requirements
 
-This plugin require that gunicorn include the following code in its `config.py`.
+This plugin requires that gunicorn include the following code in its `config.py`.
 
 ``` python
 import fcntl

--- a/mackerel-plugin-gunicorn/README.md
+++ b/mackerel-plugin-gunicorn/README.md
@@ -1,0 +1,210 @@
+mackerel-plugin-gunicorn
+=====================
+
+Gunicorn custom metrics plugin for mackerel.io agent.
+
+## Synopsis
+
+```shell
+mackerel-plugin-gunicorn [-status-file=<path>]
+```
+
+## Requirements
+
+This plugin require that gunicorn include the following code in its `config.py`.
+
+``` python
+import fcntl
+import json
+import os
+import stat
+
+SERVER_STATUS = "/dev/shm/gunicorn_status.json"
+
+
+def on_starting(servers):
+    if os.path.exists(SERVER_STATUS):
+        os.remove(SERVER_STATUS)
+    with open(SERVER_STATUS, mode="w") as f:
+        obj = {
+            "TotalAccesses": "0",
+            "IdleWorkers": "0",
+            "BusyWorkers": "0",
+            "stats": [],
+        }
+        json.dump(obj, f)
+    os.chown(SERVER_STATUS, os.getuid(), servers.cfg.gid)
+    statinfo = os.stat(SERVER_STATUS)
+    mode = statinfo.st_mode + stat.S_IWGRP
+    os.chmod(SERVER_STATUS, mode=mode)
+
+
+def post_fork(server, worker):
+    stat = {
+        "pid": worker.pid,
+        "host": "",
+        "method": "",
+        "uri": "",
+        "status": "_"
+    }
+
+    with open(SERVER_STATUS, mode="r+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            obj = json.load(f)
+
+            stats = [(i, v) for i, v in enumerate(obj["stats"]) if v["pid"] == worker.pid]
+            if len(stats) == 0:
+                obj["stats"].append(stat)
+            else:
+                for i, _ in stats:
+                    obj["stats"][i] = stat
+
+            obj["IdleWorkers"] = str(int(obj["IdleWorkers"]) + 1)
+
+            f.seek(0)
+            f.truncate(0)
+            json.dump(obj, f)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def pre_request(worker, req):
+    headers = dict(req.headers)
+    stat = {
+        "pid": worker.pid,
+        "host": headers["HOST"],
+        "method": req.method,
+        "uri": req.uri,
+        "status": "A"
+    }
+
+    with open(SERVER_STATUS, mode="r+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            obj = json.load(f)
+
+            stats = [(i, v) for i, v in enumerate(obj["stats"]) if v["pid"] == worker.pid]
+            for i, _ in stats:
+                obj["stats"][i] = stat
+
+            obj["TotalAccesses"] = str(int(obj["TotalAccesses"]) + 1)
+            obj["IdleWorkers"] = str(int(obj["IdleWorkers"]) - 1)
+            obj["BusyWorkers"] = str(int(obj["BusyWorkers"]) + 1)
+
+            f.seek(0)
+            f.truncate(0)
+            json.dump(obj, f)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def post_request(worker, req):
+    headers = dict(req.headers)
+    stat = {
+        "pid": worker.pid,
+        "host": headers["HOST"],
+        "method": req.method,
+        "uri": req.uri,
+        "status": "_"
+    }
+
+    with open(SERVER_STATUS, mode="r+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            obj = json.load(f)
+
+            stats = [(i, v) for i, v in enumerate(obj["stats"]) if v["pid"] == worker.pid]
+            if len(stats) == 0:
+                worker.log.warn("not find worker.pid: %d in stats object", worker.pid)
+            else:
+                for i, _ in stats:
+                    obj["stats"][i] = stat
+
+            obj["IdleWorkers"] = str(int(obj["IdleWorkers"]) + 1)
+            obj["BusyWorkers"] = str(int(obj["BusyWorkers"]) - 1)
+
+            f.seek(0)
+            f.truncate(0)
+            json.dump(obj, f)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def worker_int(worker):
+    stat = {
+        "pid": worker.pid,
+        "host": "",
+        "method": "",
+        "uri": "",
+        "status": "SIGINT",
+    }
+
+    with open(SERVER_STATUS, mode="r+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            obj = json.load(f)
+
+            stats = [(i, v) for i, v in enumerate(obj["stats"]) if v["pid"] == worker.pid]
+            if len(stats) == 0:
+                obj["stats"].append(stat)
+                obj["IdleWorkers"] = str(int(obj["IdleWorkers"]) - 1)
+            else:
+                for i, v in stats:
+                    obj["stats"][i] = stat
+                    if v["status"] == "A":
+                        obj["BusyWorkers"] = str(int(obj["BusyWorkers"]) - 1)
+                    else:
+                        obj["IdleWorkers"] = str(int(obj["IdleWorkers"]) - 1)
+
+            f.seek(0)
+            f.truncate(0)
+            json.dump(obj, f)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def worker_abort(worker):
+    stat = {
+        "pid": worker.pid,
+        "host": "",
+        "method": "",
+        "uri": "",
+        "status": "SIGABRT",
+    }
+
+    with open(SERVER_STATUS, mode="r+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            obj = json.load(f)
+
+            stats = [(i, v) for i, v in enumerate(obj["stats"]) if v["pid"] == worker.pid]
+            if len(stats) == 0:
+                obj["stats"].append(stat)
+                obj["IdleWorkers"] = str(int(obj["IdleWorkers"]) - 1)
+            else:
+                for i, v in stats:
+                    obj["stats"][i] = stat
+                    if v["status"] == "A":
+                        obj["BusyWorkers"] = str(int(obj["BusyWorkers"]) - 1)
+                    else:
+                        obj["IdleWorkers"] = str(int(obj["IdleWorkers"]) - 1)
+
+            f.seek(0)
+            f.truncate(0)
+            json.dump(obj, f)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+```
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.gunicorn]
+command = "/path/to/mackerel-plugin-gunicorn -status-file /dev/shm/gunicorn_status.json"
+```

--- a/mackerel-plugin-gunicorn/lib/gunicorn.go
+++ b/mackerel-plugin-gunicorn/lib/gunicorn.go
@@ -22,7 +22,7 @@ type GunicornPlugin struct {
 // {
 //   "BusyWorkers": "0",
 //   "IdleWorkers": "4",
-//   "TotalAccesses": "440"
+//   "TotalAccesses": "440",
 //   "stats": [
 //     {
 //       "uri": "/",
@@ -52,7 +52,7 @@ type GunicornPlugin struct {
 //       "pid": 26724,
 //       "status": "_"
 //     }
-//   ],
+//   ]
 // }
 
 // field types vary between versions

--- a/mackerel-plugin-gunicorn/lib/gunicorn.go
+++ b/mackerel-plugin-gunicorn/lib/gunicorn.go
@@ -1,0 +1,154 @@
+package mpgunicorn
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+)
+
+// GunicornPlugin mackerel plugin for Gunicorn
+type GunicornPlugin struct {
+	FilePath    string
+	Prefix      string
+	LabelPrefix string
+}
+
+// {
+//   "BusyWorkers": "0",
+//   "IdleWorkers": "4",
+//   "TotalAccesses": "440"
+//   "stats": [
+//     {
+//       "uri": "/",
+//       "method": "GET",
+//       "host": "localhost:8000",
+//       "pid": 26727,
+//       "status": "_"
+//     },
+//     {
+//       "uri": "/",
+//       "method": "GET",
+//       "host": "localhost:8000",
+//       "pid": 26725,
+//       "status": "_"
+//     },
+//     {
+//       "uri": "/",
+//       "method": "GET",
+//       "host": "localhost:8000",
+//       "pid": 26726,
+//       "status": "_"
+//     },
+//     {
+//       "host": "localhost:8000",
+//       "method": "GET",
+//       "uri": "/",
+//       "pid": 26724,
+//       "status": "_"
+//     }
+//   ],
+// }
+
+// field types vary between versions
+
+// GunicornWorkerStatus struct
+type GunicornWorkerStatus struct{}
+
+// GunicornStatus sturct for file json
+type GunicornStatus struct {
+	TotalAccesses string                 `json:"TotalAccesses"`
+	BusyWorkers   string                 `json:"BusyWorkers"`
+	IdleWorkers   string                 `json:"IdleWorkers"`
+	Stats         []GunicornWorkerStatus `json:"stats"`
+}
+
+// FetchMetrics interface for mackerelplugin
+func (p GunicornPlugin) FetchMetrics() (map[string]interface{}, error) {
+	file, err := os.Open(p.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return p.parseStats(file)
+}
+
+func (p GunicornPlugin) parseStats(body io.Reader) (map[string]interface{}, error) {
+	stat := make(map[string]interface{})
+	decoder := json.NewDecoder(body)
+
+	var s GunicornStatus
+	err := decoder.Decode(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	stat["busy_workers"], err = strconv.ParseFloat(s.BusyWorkers, 64)
+	if err != nil {
+		return nil, errors.New("cannot get values")
+	}
+
+	stat["idle_workers"], err = strconv.ParseFloat(s.IdleWorkers, 64)
+	if err != nil {
+		return nil, errors.New("cannot get values")
+	}
+
+	stat["requests"], err = strconv.ParseUint(s.TotalAccesses, 10, 64)
+	if err != nil {
+		return nil, errors.New("cannot get values")
+	}
+
+	return stat, nil
+}
+
+// GraphDefinition interface for mackerelplugin
+func (p GunicornPlugin) GraphDefinition() map[string]mp.Graphs {
+	var graphdef = map[string]mp.Graphs{
+		(p.Prefix + ".workers"): {
+			Label: p.LabelPrefix + " Workers",
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "busy_workers", Label: "Busy Workers", Diff: false, Stacked: true},
+				{Name: "idle_workers", Label: "Idle Workers", Diff: false, Stacked: true},
+			},
+		},
+		(p.Prefix + ".req"): {
+			Label: p.LabelPrefix + " Requests",
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "requests", Label: "Requests", Diff: true, Type: "uint64"},
+			},
+		},
+	}
+
+	return graphdef
+}
+
+// Do the plugin
+func Do() {
+	optFilePath := flag.String("status-file", "", "FilePath")
+	optPrefix := flag.String("metric-key-prefix", "gunicorn", "Prefix")
+	optLabelPrefix := flag.String("metric-label-prefix", "", "Label Prefix")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	flag.Parse()
+
+	gunicorn := GunicornPlugin{FilePath: *optFilePath, Prefix: *optPrefix, LabelPrefix: *optLabelPrefix}
+	if gunicorn.LabelPrefix == "" {
+		gunicorn.LabelPrefix = strings.Title(gunicorn.Prefix)
+	}
+
+	helper := mp.NewMackerelPlugin(gunicorn)
+	helper.Tempfile = *optTempfile
+
+	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
+		helper.OutputDefinitions()
+	} else {
+		helper.OutputValues()
+	}
+}

--- a/mackerel-plugin-gunicorn/main.go
+++ b/mackerel-plugin-gunicorn/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-gunicorn/lib"
+
+func main() {
+	mpgunicorn.Do()
+}


### PR DESCRIPTION
This plugin is inspired by mackerel-plugin-plack.

Many monitoring SaaS tool support gunicorn monitoring using statsd daemon.  But, Gunicorn send the number of all worker to statd server.  This plugin support to distinguish active worker from idle worker without statsd daemon.
