### PR TITLE
Support twemproxy v0.3, Add total_server_error

### DIFF
--- a/mackerel-plugin-twemproxy/lib/twemproxy_test.go
+++ b/mackerel-plugin-twemproxy/lib/twemproxy_test.go
@@ -239,12 +239,6 @@ func TestFetchMetricsFail(t *testing.T) {
 		Timeout: 5,
 	}
 
-	// panic against a lacking stats json
-	noTotalConnectionsJSONStr := strings.Replace(
-		jsonStr, "\"total_connections\": 3895,\n", "", 1)
-	stats = noTotalConnectionsJSONStr
-	assertPanic(t, p.FetchMetrics)
-
 	noClientErrJSONStr := strings.Replace(
 		jsonStr, "\"client_err\": 10,\n", "", 1)
 	stats = noClientErrJSONStr


### PR DESCRIPTION
* In twemproxy v0.3 excluded because total_connections and curr_connections does not exist.
* Added total_server_error. (Assuming monitoring of multiple pool collectively)
