### PR TITLE
Add uWSGI vassal plugin

### DIFF
--- a/mackerel-plugin-uwsgi-vassal/README.md
+++ b/mackerel-plugin-uwsgi-vassal/README.md
@@ -1,0 +1,21 @@
+mackerel-plugin-uwsgi-vassal
+=====================
+
+uWSGI (vassal) custom metrics plugin for mackerel.io agent.
+
+## Synopsis
+
+```shell
+mackerel-plugin-uwsgi-vassal [-socket=<http://uri|unix:///tmp/tmp.sock>]
+```
+
+## Requirements
+
+This plugin requires that uWSGI use `--stats` options in vassal section.
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.uwsgi-vassal]
+command = "/path/to/mackerel-plugin-uwsgi-vassal --socket unix:///var/run/uwsgi-vassal-stats.sock"
+```

--- a/mackerel-plugin-uwsgi-vassal/README.md
+++ b/mackerel-plugin-uwsgi-vassal/README.md
@@ -6,12 +6,13 @@ uWSGI (vassal) custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-uwsgi-vassal [-socket=<http://uri|unix:///tmp/tmp.sock>]
+mackerel-plugin-uwsgi-vassal [-socket=<'http://host:port'|'unix:///var/run/uwsgi/stats.sock'>]
 ```
 
 ## Requirements
 
 This plugin requires that uWSGI use `--stats` options in vassal section.
+- [The uWSGI Stats Server — uWSGI 2.0 documentation](http://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html)
 
 ## Example of mackerel-agent.conf
 

--- a/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
+++ b/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
@@ -164,9 +164,11 @@ func (p UWSGIVassalPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 // GraphDefinition interface for mackerelplugin
 func (p UWSGIVassalPlugin) GraphDefinition() map[string]mp.Graphs {
+	labelPrefix := strings.Title(p.Prefix)
+
 	var graphdef = map[string]mp.Graphs{
 		(p.Prefix + ".workers"): {
-			Label: p.LabelPrefix + " Workers",
+			Label: labelPrefix + " Workers",
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
 				{Name: "busy", Label: "Busy", Diff: false, Stacked: true},
@@ -176,7 +178,7 @@ func (p UWSGIVassalPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		(p.Prefix + ".req"): {
-			Label: p.LabelPrefix + " Requests",
+			Label: labelPrefix + " Requests",
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
 				{Name: "requests", Label: "Requests", Diff: true, Type: "uint64"},
@@ -190,12 +192,11 @@ func (p UWSGIVassalPlugin) GraphDefinition() map[string]mp.Graphs {
 // Do the plugin
 func Do() {
 	optSocket := flag.String("socket", "", "Socket")
-	optPrefix := flag.String("metric-key-prefix", "uwsgi", "Prefix")
-	optLabelPrefix := flag.String("metric-label-prefix", "uWSGI", "Label Prefix")
+	optPrefix := flag.String("metric-key-prefix", "uWSGI", "Prefix")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
 
-	uwsgi := UWSGIVassalPlugin{Socket: *optSocket, Prefix: *optPrefix, LabelPrefix: *optLabelPrefix}
+	uwsgi := UWSGIVassalPlugin{Socket: *optSocket, Prefix: *optPrefix}
 	if uwsgi.LabelPrefix == "" {
 		uwsgi.LabelPrefix = strings.Title(uwsgi.Prefix)
 	}

--- a/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
+++ b/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
@@ -2,6 +2,7 @@ package mpuwsgivassal
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"net"
 	"net/http"
@@ -142,6 +143,9 @@ func (p UWSGIVassalPlugin) FetchMetrics() (map[string]float64, error) {
 		}
 		defer resp.Body.Close()
 		decoder = json.NewDecoder(resp.Body)
+	} else {
+		err := errors.New("'--socket' is neither http endpoint nor the unix domain socket, try '--help' for more information")
+		return nil, err
 	}
 
 	var workers UWSGIWorkers
@@ -197,7 +201,7 @@ func (p UWSGIVassalPlugin) MetricKeyPrefix() string {
 
 // Do the plugin
 func Do() {
-	optSocket := flag.String("socket", "", "Socket")
+	optSocket := flag.String("socket", "", "Socket (must be with prefix of 'http://' or 'unix://')")
 	optPrefix := flag.String("metric-key-prefix", "uWSGI", "Prefix")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()

--- a/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
+++ b/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"net"
 	"net/http"
-	"os"
 	"reflect"
 	"strings"
 
@@ -203,10 +202,5 @@ func Do() {
 
 	helper := mp.NewMackerelPlugin(uwsgi)
 	helper.Tempfile = *optTempfile
-
-	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
-		helper.OutputDefinitions()
-	} else {
-		helper.OutputValues()
-	}
+	helper.Run()
 }

--- a/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
+++ b/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
@@ -188,6 +188,14 @@ func (p UWSGIVassalPlugin) GraphDefinition() map[string]mp.Graphs {
 	return graphdef
 }
 
+// MetricKeyPrefix interface for PluginWithPrefix
+func (p UWSGIVassalPlugin) MetricKeyPrefix() string {
+	if p.Prefix == "" {
+		p.Prefix = "uWSGI"
+	}
+	return p.Prefix
+}
+
 // Do the plugin
 func Do() {
 	optSocket := flag.String("socket", "", "Socket")

--- a/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
+++ b/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
@@ -155,7 +155,7 @@ func (p UWSGIVassalPlugin) FetchMetrics() (map[string]interface{}, error) {
 		case "idle", "busy", "cheap", "pause":
 			stat[worker.Status] = reflect.ValueOf(stat[worker.Status]).Uint() + 1
 		}
-		stat["requests"] = reflect.ValueOf(stat["requests"]).Uint() + 1
+		stat["requests"] = reflect.ValueOf(stat["requests"]).Uint() + worker.Requests
 	}
 
 	return stat, nil

--- a/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
+++ b/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
@@ -203,9 +203,7 @@ func Do() {
 	flag.Parse()
 
 	uwsgi := UWSGIVassalPlugin{Socket: *optSocket, Prefix: *optPrefix}
-	if uwsgi.LabelPrefix == "" {
-		uwsgi.LabelPrefix = strings.Title(uwsgi.Prefix)
-	}
+	uwsgi.LabelPrefix = strings.Title(uwsgi.Prefix)
 
 	helper := mp.NewMackerelPlugin(uwsgi)
 	helper.Tempfile = *optTempfile

--- a/mackerel-plugin-uwsgi-vassal/main.go
+++ b/mackerel-plugin-uwsgi-vassal/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-uwsgi-vassal/lib"
+
+func main() {
+	mpuwsgivassal.Do()
+}


### PR DESCRIPTION
This plugin supports uWSGI worker metrics.  These metrics need to be provided by uWSGI `--stats` option in vassal not emperor (`--emperor-stats`).