### PR TITLE
Use SetTempfileByBasename to support MACKEREL_PLUGIN_WORKDIR

### DIFF
--- a/mackerel-plugin-aws-ec2/lib/aws-ec2.go
+++ b/mackerel-plugin-aws-ec2/lib/aws-ec2.go
@@ -184,7 +184,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-aws-ec2-%s", ec2.InstanceID)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-aws-ec2-%s", ec2.InstanceID))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-aws-elasticache/lib/aws-elasticache.go
+++ b/mackerel-plugin-aws-elasticache/lib/aws-elasticache.go
@@ -376,7 +376,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-aws-elasticache-%s-%s", *optCacheClusterID, *optCacheNodeID)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-aws-elasticache-%s-%s", *optCacheClusterID, *optCacheNodeID))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-docker/lib/docker.go
+++ b/mackerel-plugin-docker/lib/docker.go
@@ -471,7 +471,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-docker-%s", normalizeMetricName(*optHost))
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-docker-%s", normalizeMetricName(*optHost)))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-elasticsearch/lib/elasticsearch.go
+++ b/mackerel-plugin-elasticsearch/lib/elasticsearch.go
@@ -266,7 +266,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-elasticsearch-%s-%s", *optHost, *optPort)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-elasticsearch-%s-%s", *optHost, *optPort))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -163,7 +163,7 @@ func Do() {
 		if *pluginIDPatternString != "" {
 			tempFileSuffix = append(tempFileSuffix, fmt.Sprintf("%x", md5.Sum([]byte(*pluginIDPatternString))))
 		}
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-fluentd-%s", strings.Join(tempFileSuffix, "-"))
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-fluentd-%s", strings.Join(tempFileSuffix, "-")))
 	}
 
 	helper.Run()

--- a/mackerel-plugin-gcp-compute-engine/lib/gcp-compute-engine.go
+++ b/mackerel-plugin-gcp-compute-engine/lib/gcp-compute-engine.go
@@ -263,7 +263,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-gcp-compute-engine-%s", computeEngine.InstanceName)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-gcp-compute-engine-%s", computeEngine.InstanceName))
 	}
 
 	helper.Run()

--- a/mackerel-plugin-gearmand/lib/gearmand.go
+++ b/mackerel-plugin-gearmand/lib/gearmand.go
@@ -170,9 +170,9 @@ func Do() {
 		helper.Tempfile = *optTempfile
 	} else {
 		if gearmand.Socket != "" {
-			helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-gearmand-%s", fmt.Sprintf("%x", md5.Sum([]byte(gearmand.Socket))))
+			helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-gearmand-%s", fmt.Sprintf("%x", md5.Sum([]byte(gearmand.Socket)))))
 		} else {
-			helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-gearmand-%s-%s", *optHost, *optPort)
+			helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-gearmand-%s-%s", *optHost, *optPort))
 		}
 	}
 	helper.Run()

--- a/mackerel-plugin-jmx-jolokia/lib/jmx-jolokia.go
+++ b/mackerel-plugin-jmx-jolokia/lib/jmx-jolokia.go
@@ -182,7 +182,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-jmx-jolokia-%s-%s", *optHost, *optPort)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-jmx-jolokia-%s-%s", *optHost, *optPort))
 	}
 	helper.Run()
 }

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -337,7 +337,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-jvm-%s", *optHost)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-jvm-%s", *optHost))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-mongodb/lib/mongodb.go
+++ b/mackerel-plugin-mongodb/lib/mongodb.go
@@ -284,7 +284,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-mongodb-%s-%s", *optHost, *optPort)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-mongodb-%s-%s", *optHost, *optPort))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-munin/lib/munin.go
+++ b/mackerel-plugin-munin/lib/munin.go
@@ -310,7 +310,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-munin-%s", munin.GraphName)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-munin-%s", munin.GraphName))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {

--- a/mackerel-plugin-murmur/lib/murmur.go
+++ b/mackerel-plugin-murmur/lib/murmur.go
@@ -65,7 +65,7 @@ func Do() {
 	if *optTempfile != "" {
 		helper.Tempfile = *optTempfile
 	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-murmur-%s-%s", *optHost, *optPort)
+		helper.SetTempfileByBasename(fmt.Sprintf("mackerel-plugin-murmur-%s-%s", *optHost, *optPort))
 	}
 
 	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {


### PR DESCRIPTION
ref: #268, #269, #301

With this p-r and #338, all plugins use `MACKEREL_PLUGIN_WORKDIR` for Tempfile by default.