### PR TITLE
Fixed mackerel-plugin-nginx/README.md

### DIFF
--- a/mackerel-plugin-nginx/README.md
+++ b/mackerel-plugin-nginx/README.md
@@ -6,7 +6,7 @@ Nginx custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-nginx [-scheme=<'http'|'https'>] [-host=<host>] [-port=<port>] [-path=<path>] [-tempfile=<tempfile>]
+mackerel-plugin-nginx [-header=<header>] [-host=<host>] [-path=<path>] [-port=<port>] [-scheme=<'http'|'https'>] [-tempfile=<tempfile>] [-uri=<uri>]
 ```
 
 ## Requirements


### PR DESCRIPTION
# What is this

Hi !

I found that `mackerel-plugin-nginx` already supports `-header` option via https://github.com/mackerelio/mackerel-agent-plugins/pull/78 .
We can use `-header` option like `-header='User-Agent: xxx'` .

```sh
$ /usr/bin/mackerel-plugin-nginx -h
Usage of /usr/bin/mackerel-plugin-nginx:
  -header value
    	Set http header (e.g. "Host: servername")
  -host string
    	Hostname (default "localhost")
  -path string
    	Path (default "/nginx_status")
  -port string
    	Port (default "8080")
  -scheme string
    	Scheme (default "http")
  -tempfile string
    	Temp file name
  -uri string
    	URI
```

So, I fixed `mackerel-plugin-nginx/README.md` .

- Added `-header` option
- Added `-uri` option
- Switched order of the options according to output `-h`

Thanks 👍 