### PR TITLE
Implemented mackerel-plugin-redash

### DIFF
--- a/mackerel-plugin-redash/README.md
+++ b/mackerel-plugin-redash/README.md
@@ -1,0 +1,27 @@
+mackerel-plugin-redash
+=====================
+
+redash stats custom metrics plugin for [mackerel-agent](https://github.com/mackerelio/mackerel-agent).
+
+## Synopsis
+
+```shell
+mackerel-plugin-redash [-metric-key-prefix=redash] [-timeout=5] [-uri=http://localhost/api/admin/queries/tasks?api_key=hoge]
+```
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.redash]
+command = "/path/to/mackerel-plugin-redash"
+```
+
+## Notes
+
+- This plugin uses an unsafe(unofficial) API.
+ - Operation verified with version `0.11.0+b2016`.
+- This plugin does not collect all metrics fetched by the uri.
+
+## References
+
+- https://discuss.redash.io/t/monitoring-the-status-of-tasks-using-a-http-request/683

--- a/mackerel-plugin-redash/lib/redash.go
+++ b/mackerel-plugin-redash/lib/redash.go
@@ -1,0 +1,110 @@
+package mpredash
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+)
+
+// RedashPlugin mackerel plugin
+type RedashPlugin struct {
+	URI     string
+	Prefix  string
+	Timeout uint
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (p RedashPlugin) MetricKeyPrefix() string {
+	if p.Prefix == "" {
+		p.Prefix = "redash"
+	}
+	return p.Prefix
+}
+
+// GraphDefinition interface for mackerelplugin
+func (p RedashPlugin) GraphDefinition() map[string]mp.Graphs {
+	labelPrefix := strings.Title(p.Prefix)
+
+	var graphdef = map[string]mp.Graphs{
+		"task_queues_count": {
+			Label: (labelPrefix + " Task Queues Count"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "wait", Label: "Wait", Diff: false},
+				{Name: "done", Label: "Done", Diff: false},
+				{Name: "in_progress", Label: "InProgress", Diff: false},
+			},
+		},
+		"task_scheduled_count.#": {
+			Label: (labelPrefix + " Task Scheduled Count"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "adhoc", Label: "Adhoc", Diff: false},
+				{Name: "scheduled", Label: "Scheduled", Diff: false},
+			},
+		},
+		"task_states_count": {
+			Label: (labelPrefix + " Task States Count"),
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "waiting", Label: "Waiting", Diff: true},
+				{Name: "finished", Label: "Finishing", Diff: true},
+				{Name: "executing_query", Label: "Executing Query", Diff: true},
+				{Name: "processing", Label: "Processing", Diff: true},
+				{Name: "checking_alerts", Label: "Checking Alerts", Diff: true},
+				{Name: "failed", Label: "Failed", Diff: true},
+				{Name: "other", Label: "Other", Diff: true},
+			},
+		},
+	}
+	return graphdef
+}
+
+// FetchMetrics interface for mackerelplugin
+func (p RedashPlugin) FetchMetrics() (map[string]interface{}, error) {
+	stats, err := getUnsafeStats(p)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch redash metrics: %s", err)
+	}
+
+	metrics := make(map[string]interface{})
+	metrics["wait"] = uint64(len(stats.WaitTasks))
+	metrics["done"] = uint64(len(stats.DoneTasks))
+	metrics["in_progress"] = uint64(len(stats.InProgressTasks))
+
+	metrics["task_scheduled_count.wait.adhoc"] = filterCount(stats.WaitTasks, isAdhoc)
+	metrics["task_scheduled_count.done.adhoc"] = filterCount(stats.DoneTasks, isAdhoc)
+	metrics["task_scheduled_count.in_progress.adhoc"] = filterCount(stats.InProgressTasks, isAdhoc)
+	metrics["task_scheduled_count.wait.scheduled"] = filterCount(stats.WaitTasks, isScheduled)
+	metrics["task_scheduled_count.done.scheduled"] = filterCount(stats.DoneTasks, isScheduled)
+	metrics["task_scheduled_count.in_progress.scheduled"] = filterCount(stats.InProgressTasks, isScheduled)
+
+	for _, state := range UnsafeAllTaskStates {
+		metrics[state] =
+			filterCount(stats.WaitTasks, isState(state)) +
+				filterCount(stats.DoneTasks, isState(state)) +
+				filterCount(stats.InProgressTasks, isState(state))
+	}
+	return metrics, nil
+}
+
+// Do the plugin
+func Do() {
+	optURI := flag.String("uri", "http://localhost/api/admin/queries/tasks?api_key=hoge", "stats URI")
+	optPrefix := flag.String("metric-key-prefix", "redash", "Metric key prefix")
+	optTimeout := flag.Uint("timeout", 5, "Timeout")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	flag.Parse()
+
+	p := RedashPlugin{
+		URI:     *optURI,
+		Prefix:  *optPrefix,
+		Timeout: *optTimeout,
+	}
+
+	helper := mp.NewMackerelPlugin(p)
+	helper.Tempfile = *optTempfile
+	helper.Run()
+}

--- a/mackerel-plugin-redash/lib/redash_test.go
+++ b/mackerel-plugin-redash/lib/redash_test.go
@@ -1,0 +1,187 @@
+package mpredash
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+var (
+	statsServer *httptest.Server
+	stub        string
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(mainTest(m))
+}
+
+func mainTest(m *testing.M) int {
+	flag.Parse()
+
+	// run a test server returning a dummy stats json
+	ts := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, stub)
+			}))
+	statsServer = ts
+
+	log.Println("Started a stats server")
+
+	return m.Run()
+}
+
+var jsonStr = `{
+    "waiting": [
+        {
+            "username": "Scheduled",
+            "retries": 0,
+            "scheduled_retries": 0,
+            "task_id": "8596cc9a-c42d-4518-a29c-12cb993b2b1e",
+            "created_at": 1496649134.345524,
+            "updated_at": 1496649148.593866,
+            "state": "waiting",
+            "query_id": 136,
+            "run_time": 14.219444036483765,
+            "error": null,
+            "scheduled": true,
+            "started_at": 1496649134.35855,
+            "data_source_id": 2,
+            "query_hash": "6e4d43f0dc697d33f632b63ecb55dd0f"
+        },
+        {
+            "username": "FugaFuga",
+            "retries": 0,
+            "scheduled_retries": 0,
+            "task_id": "8596cc9a-c42d-4518-a29c-12cb993b2b1e",
+            "created_at": 1496649134.345524,
+            "updated_at": 1496649148.593866,
+            "state": "unknown",
+            "query_id": 136,
+            "run_time": 14.219444036483765,
+            "error": null,
+            "scheduled": false,
+            "started_at": 1496649134.35855,
+            "data_source_id": 2,
+            "query_hash": "6e4d43f0dc697d33f632b63ecb55dd0f"
+        }
+    ],
+    "done": [
+        {
+            "username": "Scheduled",
+            "retries": 0,
+            "scheduled_retries": 0,
+            "task_id": "8596cc9a-c42d-4518-a29c-12cb993b2b1e",
+            "created_at": 1496649134.345524,
+            "updated_at": 1496649148.593866,
+            "state": "finished",
+            "query_id": 136,
+            "run_time": 14.219444036483765,
+            "error": null,
+            "scheduled": true,
+            "started_at": 1496649134.35855,
+            "data_source_id": 2,
+            "query_hash": "6e4d43f0dc697d33f632b63ecb55dd0f"
+        },
+        {
+            "username": "Scheduled",
+            "retries": 0,
+            "scheduled_retries": 0,
+            "task_id": "8596cc9a-c42d-4518-a29c-12cb993b2b1e",
+            "created_at": 1496649134.345524,
+            "updated_at": 1496649148.593866,
+            "state": "finished",
+            "query_id": 137,
+            "run_time": 14.219444036483765,
+            "error": null,
+            "scheduled": true,
+            "started_at": 1496649134.35855,
+            "data_source_id": 3,
+            "query_hash": "6e4d43f0dc697d33f632b63ecb55dd0f"
+        },
+        {
+            "username": "Hogehoge",
+            "retries": 0,
+            "scheduled_retries": 0,
+            "task_id": "8596cc9a-c42d-4518-a29c-12cb993b2b1e",
+            "created_at": 1496649134.345524,
+            "updated_at": 1496649148.593866,
+            "state": "failed",
+            "query_id": 136,
+            "run_time": 14.219444036483765,
+            "error": "You have an error in your SQL syntax",
+            "scheduled": false,
+            "started_at": 1496649134.35855,
+            "data_source_id": 2,
+            "query_hash": "6e4d43f0dc697d33f632b63ecb55dd0f"
+        }
+    ],
+    "in_progress": []
+}`
+
+func TestFetchMetrics(t *testing.T) {
+	// response a valid stats json
+	stub = jsonStr
+
+	// get metrics
+	p := RedashPlugin{
+		URI:     statsServer.URL,
+		Prefix:  "redash",
+		Timeout: 5,
+	}
+	metrics, err := p.FetchMetrics()
+	if err != nil {
+		t.Errorf("Failed to FetchMetrics: %s", err)
+		return
+	}
+
+	// check the metrics
+	expected := map[string]uint64{
+		"wait":                                       2,
+		"done":                                       3,
+		"in_progress":                                0,
+		"task_scheduled_count.wait.adhoc":            1,
+		"task_scheduled_count.done.adhoc":            1,
+		"task_scheduled_count.in_progress.adhoc":     0,
+		"task_scheduled_count.wait.scheduled":        1,
+		"task_scheduled_count.done.scheduled":        2,
+		"task_scheduled_count.in_progress.scheduled": 0,
+		"waiting":         1,
+		"finished":        2,
+		"executing_query": 0,
+		"failed":          1,
+		"processing":      0,
+		"checking_alerts": 0,
+		"other":           1,
+	}
+
+	for k, v := range expected {
+		value, ok := metrics[k]
+		if !ok {
+			t.Errorf("metric of %s cannot be fetched", k)
+			continue
+		}
+		if v != value {
+			t.Errorf("metric of %s should be %v, but %v", k, v, value)
+		}
+	}
+}
+
+func TestFetchMetricsFail(t *testing.T) {
+	p := RedashPlugin{
+		URI:     statsServer.URL,
+		Prefix:  "redash",
+		Timeout: 5,
+	}
+
+	// return error against an invalid stats json
+	stub = "{waiting: [],}"
+	_, err := p.FetchMetrics()
+	if err == nil {
+		t.Errorf("FetchMetrics should return error: stub=%v", stub)
+	}
+}

--- a/mackerel-plugin-redash/lib/unsafe_stats.go
+++ b/mackerel-plugin-redash/lib/unsafe_stats.go
@@ -19,7 +19,7 @@ type UnsafeTaskStats struct {
 	Scheduled bool   `json:"scheduled"`
 }
 
-// UnsafeAllTaskStats represents task states
+// UnsafeAllTaskStates represents task states
 var UnsafeAllTaskStates = []string{
 	"waiting",
 	"finished",

--- a/mackerel-plugin-redash/lib/unsafe_stats.go
+++ b/mackerel-plugin-redash/lib/unsafe_stats.go
@@ -1,0 +1,80 @@
+package mpredash
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// UnsafeRedashStats represents a redash stats
+type UnsafeRedashStats struct {
+	WaitTasks       []UnsafeTaskStats `json:"waiting"`
+	DoneTasks       []UnsafeTaskStats `json:"done"`
+	InProgressTasks []UnsafeTaskStats `json:"in_progress"`
+}
+
+// UnsafeTaskStats represents a task stats
+type UnsafeTaskStats struct {
+	State     string `json:"state"`
+	Scheduled bool   `json:"scheduled"`
+}
+
+// UnsafeAllTaskStats represents task states
+var UnsafeAllTaskStates = []string{
+	"waiting",
+	"finished",
+	"executing_query",
+	"failed",
+	"processing",
+	"checking_alerts",
+	"other", // other state is used for comprehensiveness
+}
+
+func getUnsafeStats(p RedashPlugin) (*UnsafeRedashStats, error) {
+	// get json data
+	timeout := time.Duration(p.Timeout) * time.Second
+	client := http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Get(p.URI)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// decode the json data to UnsafeRedashStats struct
+	var s UnsafeRedashStats
+	err = json.NewDecoder(resp.Body).Decode(&s)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func filterCount(ss []UnsafeTaskStats, test func(UnsafeTaskStats) bool) (count uint64) {
+	for _, s := range ss {
+		if test(s) {
+			count++
+		}
+	}
+	return
+}
+
+func isScheduled(s UnsafeTaskStats) bool { return s.Scheduled }
+func isAdhoc(s UnsafeTaskStats) bool     { return !isScheduled(s) }
+func isState(state string) func(UnsafeTaskStats) bool {
+	return func(s UnsafeTaskStats) bool {
+		if state == "other" {
+			return isOtherState(s)
+		}
+		return s.State == state
+	}
+}
+func isOtherState(s UnsafeTaskStats) bool {
+	for _, state := range UnsafeAllTaskStates[0 : len(UnsafeAllTaskStates)-1] {
+		if s.State == state {
+			return false
+		}
+	}
+	return true
+}

--- a/mackerel-plugin-redash/main.go
+++ b/mackerel-plugin-redash/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-redash/lib"
+
+func main() {
+	mpredash.Do()
+}


### PR DESCRIPTION
We plan to use this plugin in production. After our test trial in production, we are sure that it's helpful for operators monitoring redash. 

- [x] Review https://github.com/mackerelio/mackerel-agent-plugins/blob/master/CONTRIBUTING.md

![image](https://user-images.githubusercontent.com/1223268/26871292-ac957548-4bad-11e7-897e-66236e382bc2.png)
![image](https://user-images.githubusercontent.com/1223268/26871300-b2d60670-4bad-11e7-9d21-16e1b2e36c43.png)
![image](https://user-images.githubusercontent.com/1223268/26871309-b84f65f6-4bad-11e7-947b-9156340c3116.png)

Usage example of each graph is as follows.

- Queue count (wait)
  - Used to detect if queue is stuck
- Scheduled count
  - Ease of grasping usage situation and trend. It leads to judgment of which worker to increase
- State count (failed)
  - Used to detect failure of query