### PR TITLE
postgres: collect dbsize only if connectable

### DIFF
--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -218,7 +218,7 @@ func fetchConnections(db *sqlx.DB) (map[string]interface{}, error) {
 }
 
 func fetchDatabaseSize(db *sqlx.DB) (map[string]interface{}, error) {
-	rows, err := db.Query("select sum(pg_database_size(datname)) as dbsize from pg_database")
+	rows, err := db.Query("select sum(pg_database_size(datname)) as dbsize from pg_database where has_database_privilege(datname, 'connect')")
 	if err != nil {
 		logger.Errorf("Failed to select pg_database_size. %s", err)
 		return nil, err


### PR DESCRIPTION
`pg_dataase_size` throws error when cannot connect the database.
https://github.com/postgres/postgres/blob/REL9_6_3/src/backend/utils/adt/dbsize.c#L92-L96