### PR TITLE
Fix lint error on aws-elasticsearch

### DIFF
--- a/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
+++ b/mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go
@@ -235,7 +235,7 @@ func (p ESPlugin) FetchMetrics() (map[string]float64, error) {
 			}
 			stat[*met.MetricName] = v
 		} else {
-			log.Printf("%s: %s", met.MetricName, err)
+			log.Printf("%s: %s", *met.MetricName, err)
 		}
 	}
 


### PR DESCRIPTION
This PR fixes following error:

```
$ make lint
go get -d -v -t ./...
go get github.com/golang/lint/golint
go get golang.org/x/tools/cmd/cover
go get github.com/pierrre/gotestcover
go get github.com/mattn/goveralls
go vet ./...
mackerel-plugin-aws-elasticsearch/lib/aws-elasticsearch.go:238: arg met.MetricName for printf verb %s of wrong type: *string
exit status 1
make: *** [lint] Error 1
```