### PR TITLE
Use mackerelio/golib/logging as logger, not mackerelio/mackerel-agent/logging

### DIFF
--- a/mackerel-plugin-elasticsearch/lib/elasticsearch.go
+++ b/mackerel-plugin-elasticsearch/lib/elasticsearch.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.elasticsearch")

--- a/mackerel-plugin-inode/lib/inode.go
+++ b/mackerel-plugin-inode/lib/inode.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.inode")

--- a/mackerel-plugin-jmx-jolokia/lib/jmx-jolokia.go
+++ b/mackerel-plugin-jmx-jolokia/lib/jmx-jolokia.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.jmx-jolokia")

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Songmu/timeout"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.jvm")

--- a/mackerel-plugin-mongodb/lib/mongodb.go
+++ b/mackerel-plugin-mongodb/lib/mongodb.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )

--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -13,7 +13,7 @@ import (
 	// PostgreSQL Driver
 	_ "github.com/lib/pq"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.postgres")

--- a/mackerel-plugin-proc-fd/lib/proc_fd.go
+++ b/mackerel-plugin-proc-fd/lib/proc_fd.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.proc-fd")

--- a/mackerel-plugin-redis/lib/redis.go
+++ b/mackerel-plugin-redis/lib/redis.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/fzzy/radix/redis"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.redis")

--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var (

--- a/mackerel-plugin-td-table-count/lib/mackerel-plugin-td-table-count.go
+++ b/mackerel-plugin-td-table-count/lib/mackerel-plugin-td-table-count.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 	td "github.com/mattn/go-treasuredata"
 )
 

--- a/mackerel-plugin-unicorn/lib/unicorn.go
+++ b/mackerel-plugin-unicorn/lib/unicorn.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.unicorn")

--- a/mackerel-plugin-windows-server-sessions/lib/sessions.go
+++ b/mackerel-plugin-windows-server-sessions/lib/sessions.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
-	"github.com/mackerelio/mackerel-agent/logging"
+	"github.com/mackerelio/golib/logging"
 )
 
 var logger = logging.GetLogger("metrics.plugin.windows-server-sessions")


### PR DESCRIPTION
ref: https://github.com/mackerelio/mackerel-agent/pull/395

Since (currently) their implementations are the same, just replacing `import` is enough.