### PR TITLE
Fix a graph definition for Apache Solr's cumulative metric

### DIFF
--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -199,8 +199,12 @@ func (s SolrPlugin) GraphDefinition() map[string]mp.Graphs {
 			for _, path := range handlerPaths {
 				path = escapeSlash(path)
 				metricLabel := strings.Title(path)
+				diff := false
+				if key == "requests" {
+					diff = true
+				}
 				metrics = append(metrics,
-					mp.Metrics{Name: fmt.Sprintf("%s_%s_%s", core, key, path), Label: metricLabel},
+					mp.Metrics{Name: fmt.Sprintf("%s_%s_%s", core, key, path), Label: metricLabel, Diff: diff},
 				)
 			}
 			unit := "float"


### PR DESCRIPTION
According to [Performance Statistics Reference](https://cwiki.apache.org/confluence/display/solr/Performance+Statistics+Reference), `requests` attribute is cumulative value.

> Total number of requests made since the Solr process was started.

We might as well view it as differential value on a graph.