### PR TITLE
Fix a graph label definition issue (Apache Solr)

### DIFF
--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -242,6 +242,14 @@ func (s SolrPlugin) GraphDefinition() map[string]mp.Graphs {
 	return graphdef
 }
 
+// MetricKeyPrefix interface for mackerelplugin
+func (s SolrPlugin) MetricKeyPrefix() string {
+	if s.Prefix == "" {
+		s.Prefix = "solr"
+	}
+	return s.Prefix
+}
+
 // Do the plugin
 func Do() {
 	optHost := flag.String("host", "localhost", "Hostname")


### PR DESCRIPTION
Fix a graph label definition issue that reproduce only if plugin used [go-mackerel-plugin-helper](https://github.com/mackerelio/go-mackerel-plugin-helper) without `#MetricKeyPrefix` interface implementation.

We could not view `Label` text in graph on mackerel.io. Perhaps other plugins are reproduced too.

* JVM
* Linux
* etc...

### Issue Report
#### STDOUT (If `#MetricKeyPrefix` was not implemented)
##### Graph Definitions
```
$ MACKEREL_AGENT_PLUGIN_META=1 ./mackerel-plugin-solr | tail -n 1 | jq . | head
{
  "graphs": {
    "solr.testcore.15minRateReqsPerSecond": {
      "label": "testcore 15minRateReqsPerSecond",
      "unit": "float",
      "metrics": [
        {
          "name": "testcore_15minRateReqsPerSecond_updatejson",
          "label": "Updatejson",
          "stacked": false
```
##### Metrics Values
```
$ ./mackerel-plugin-solr | tail -n 1 | jq . | head
2017/08/02 16:54:01 testcore_requests_updatejson does not exist at last fetch
2017/08/02 16:54:01 testcore_requests_select does not exist at last fetch
2017/08/02 16:54:01 testcore_requests_updatejsondocs does not exist at last fetch
2017/08/02 16:54:01 testcore_requests_get does not exist at last fetch
2017/08/02 16:54:01 testcore_requests_updatecsv does not exist at last fetch
2017/08/02 16:54:01 testcore_requests_replication does not exist at last fetch
2017/08/02 16:54:01 testcore_requests_update does not exist at last fetch
parse error: Invalid numeric literal at line 1, column 59
```
#### STDOUT (If `#MetricKeyPrefix` was implemented)
##### Graph Definitions
```
$ MACKEREL_AGENT_PLUGIN_META=1 ./mackerel-plugin-solr | tail -n 1 | jq . | head
{
  "graphs": {
    "solr.solr.testcore.15minRateReqsPerSecond": {
      "label": "testcore 15minRateReqsPerSecond",
      "unit": "float",
      "metrics": [
        {
          "name": "testcore_15minRateReqsPerSecond_updatejson",
          "label": "Updatejson",
          "stacked": false
```
##### Metrics Values
```
$ ./mackerel-plugin-solr | tail -n 1 | jq . | head
2017/08/02 16:53:52 testcore_requests_updatejson does not exist at last fetch
2017/08/02 16:53:52 testcore_requests_select does not exist at last fetch
2017/08/02 16:53:52 testcore_requests_updatejsondocs does not exist at last fetch
2017/08/02 16:53:52 testcore_requests_get does not exist at last fetch
2017/08/02 16:53:52 testcore_requests_updatecsv does not exist at last fetch
2017/08/02 16:53:52 testcore_requests_replication does not exist at last fetch
2017/08/02 16:53:52 testcore_requests_update does not exist at last fetch
parse error: Invalid numeric literal at line 1, column 54
```

#### Differences
| `#MetricKeyPrefix` | Graph Name (STDOUT) | Graph Label (mackerel.io) |
| --- | --- | --- |
| Not implemented | solr.testcore.15minRateReqsPerSecond | custom.solr.testcore.15minRateReqsPerSecond.* |
| Implemented | solr.solr.testcore.15minRateReqsPerSecond | testcore 15minRateReqsPerSecond |

* [go-mackerel-plugin-helper#OutputDefinitions](https://github.com/mackerelio/go-mackerel-plugin-helper/blob/master/mackerel-plugin.go#L359)