### PR TITLE
[nit] [mackerel-plugin-linux] Remove a test which is not necessary and may fall sometimes

### DIFF
--- a/mackerel-plugin-linux/lib/linux_test.go
+++ b/mackerel-plugin-linux/lib/linux_test.go
@@ -189,5 +189,4 @@ func TestGetProc(t *testing.T) {
 	ret, err := getProc(stub)
 	assert.Nil(t, err)
 	assert.NotNil(t, ret)
-	assert.Contains(t, ret, "ram0")
 }


### PR DESCRIPTION
`getProc` just executes `cat` and returns its content, so imo we don't have to test its contents.
(This test causes failure on https://travis-ci.org/mackerelio/mackerel-agent-plugins/builds/266481092,  in which environment `/proc/diskstats` does not contain `"ram0"`.)