### PR TITLE
[plack] Don't raise errors when parsing JSON fields failed

### DIFF
--- a/mackerel-plugin-plack/lib/plack.go
+++ b/mackerel-plugin-plack/lib/plack.go
@@ -95,11 +95,21 @@ func (p PlackPlugin) parseStats(body io.Reader) (map[string]interface{}, error) 
 		return nil, err
 	}
 
-	// If some values are not parsable, just skip and ignore them.
-	stat["busy_workers"], _ = strconv.ParseFloat(s.BusyWorkers, 64)
-	stat["idle_workers"], _ = strconv.ParseFloat(s.IdleWorkers, 64)
-	stat["requests"], _ = strconv.ParseUint(s.TotalAccesses, 10, 64)
-	stat["bytes_sent"], _ = strconv.ParseUint(s.TotalKbytes, 10, 64)
+	if s, err := strconv.ParseFloat(s.BusyWorkers, 64); err == nil {
+		stat["busy_workers"] = s
+	}
+
+	if s, err := strconv.ParseFloat(s.IdleWorkers, 64); err == nil {
+		stat["idle"] = s
+	}
+
+	if s, err := strconv.ParseUint(s.TotalAccesses, 10, 64); err == nil {
+		stat["requests"] = s
+	}
+
+	if s, err := strconv.ParseUint(s.TotalKbytes, 10, 64); err == nil {
+		stat["bytes_sent"] = s
+	}
 
 	return stat, nil
 }

--- a/mackerel-plugin-plack/lib/plack.go
+++ b/mackerel-plugin-plack/lib/plack.go
@@ -2,7 +2,6 @@ package mpplack
 
 import (
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -96,25 +95,12 @@ func (p PlackPlugin) parseStats(body io.Reader) (map[string]interface{}, error) 
 		return nil, err
 	}
 
-	stat["busy_workers"], err = strconv.ParseFloat(s.BusyWorkers, 64)
-	if err != nil {
-		return nil, errors.New("cannot get values")
-	}
+	// If some values are not parsable, just skip and ignore them.
+	stat["busy_workers"], _ = strconv.ParseFloat(s.BusyWorkers, 64)
+	stat["idle_workers"], _ = strconv.ParseFloat(s.IdleWorkers, 64)
+	stat["requests"], _ = strconv.ParseUint(s.TotalAccesses, 10, 64)
+	stat["bytes_sent"], _ = strconv.ParseUint(s.TotalKbytes, 10, 64)
 
-	stat["idle_workers"], err = strconv.ParseFloat(s.IdleWorkers, 64)
-	if err != nil {
-		return nil, errors.New("cannot get values")
-	}
-
-	stat["requests"], err = strconv.ParseUint(s.TotalAccesses, 10, 64)
-	if err != nil {
-		return nil, errors.New("cannot get values")
-	}
-
-	stat["bytes_sent"], err = strconv.ParseUint(s.TotalKbytes, 10, 64)
-	if err != nil {
-		return nil, errors.New("cannot get values")
-	}
 	return stat, nil
 }
 

--- a/mackerel-plugin-plack/lib/plack.go
+++ b/mackerel-plugin-plack/lib/plack.go
@@ -100,7 +100,7 @@ func (p PlackPlugin) parseStats(body io.Reader) (map[string]interface{}, error) 
 	}
 
 	if s, err := strconv.ParseFloat(s.IdleWorkers, 64); err == nil {
-		stat["idle"] = s
+		stat["idle_workers"] = s
 	}
 
 	if s, err := strconv.ParseUint(s.TotalAccesses, 10, 64); err == nil {

--- a/mackerel-plugin-plack/lib/plack_test.go
+++ b/mackerel-plugin-plack/lib/plack_test.go
@@ -85,11 +85,14 @@ func TestParse(t *testing.T) {
 func TestParseWithInsufficientResponse(t *testing.T) {
 	var plack PlackPlugin
 	stub := `
-{"TotalKbytes":"36","IdleWorkers":"","BusyWorkers":"0","TotalAccesses":"670","stats":[],"Uptime":1474047568}
+{"TotalKbytes":"36","IdleWorkers":"","BusyWorkers":"3","TotalAccesses":"670","stats":[],"Uptime":1474047568}
 `
 	plackStats := bytes.NewBufferString(stub)
 
 	stat, err := plack.parseStats(plackStats)
 	fmt.Println(stat)
 	assert.Nil(t, err)
+	assert.EqualValues(t, stat["bytes_sent"], 36)
+	assert.EqualValues(t, stat["busy_workers"], 3)
+	assert.EqualValues(t, stat["requests"], uint(670))
 }

--- a/mackerel-plugin-plack/lib/plack_test.go
+++ b/mackerel-plugin-plack/lib/plack_test.go
@@ -95,4 +95,5 @@ func TestParseWithInsufficientResponse(t *testing.T) {
 	assert.EqualValues(t, stat["bytes_sent"], 36)
 	assert.EqualValues(t, stat["busy_workers"], 3)
 	assert.EqualValues(t, stat["requests"], uint(670))
+	assert.Nil(t, stat["idle_workers"])
 }

--- a/mackerel-plugin-plack/lib/plack_test.go
+++ b/mackerel-plugin-plack/lib/plack_test.go
@@ -81,3 +81,15 @@ func TestParse(t *testing.T) {
 	fmt.Println(statWithIntUptime)
 	assert.Nil(t, err)
 }
+
+func TestParseWithInsufficientResponse(t *testing.T) {
+	var plack PlackPlugin
+	stub := `
+{"TotalKbytes":"36","IdleWorkers":"","BusyWorkers":"0","TotalAccesses":"670","stats":[],"Uptime":1474047568}
+`
+	plackStats := bytes.NewBufferString(stub)
+
+	stat, err := plack.parseStats(plackStats)
+	fmt.Println(stat)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Main purpose is to use mackerel-plugin-plack to monitor other platforms which is only PARTIALLY compatible with Plack::Middleware::ServerStatus::Lite, but I believe this is harmless for original Plack::Middleware::ServerStatus::Lite.