### PR TITLE
Shorten builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build: deps
 build/mackerel-plugin: deps
 	mkdir -p build
 	go build -ldflags="-s -w -X main.gitcommit=$(CURRENT_REVISION)" \
-	  -o build/mackerel-plugin
+	  -o $(BINDIR)/mackerel-plugin
 
 test: testgo lint testconvention
 
@@ -76,7 +76,7 @@ rpm-v1: crossbuild-package
 
 rpm-v2: crossbuild-package
 	rpmbuild --define "_sourcedir `pwd`"  --define "_version ${VERSION}" \
-	  --define "buildarch x86_64" --define "dist .el7.centos" \
+	  --define "buildarch x86_64" --define "dist .el7.centos" --define "_bindir build/linux/amd64" \
 	  -bb packaging/rpm/mackerel-agent-plugins-v2.spec
 
 deb: deb-v1 deb-v2
@@ -88,7 +88,7 @@ deb-v1: crossbuild-package
 	cd packaging/deb && debuild --no-tgz-check -rfakeroot -uc -us
 
 deb-v2: crossbuild-package
-	cp build/mackerel-plugin packaging/deb-v2/debian/
+	cp build/linux/amd64/mackerel-plugin packaging/deb-v2/debian/
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us
 
 release: check-release-deps

--- a/packaging/rpm/mackerel-agent-plugins-v2.spec
+++ b/packaging/rpm/mackerel-agent-plugins-v2.spec
@@ -26,7 +26,7 @@ This package provides metric plugins for Mackerel.
 
 %{__mkdir} -p %{buildroot}%{__targetdir}
 
-%{__install} -m0755 %{_sourcedir}/build/mackerel-plugin %{buildroot}%{__targetdir}/
+%{__install} -m0755 %{_sourcedir}/%{_bindir}/mackerel-plugin %{buildroot}%{__targetdir}/
 
 for i in accesslog apache2 aws-dynamodb aws-ec2-cpucredit aws-elasticache aws-elasticsearch aws-elb aws-kinesis-streams aws-lambda aws-rds aws-ses conntrack elasticsearch gostats graphite haproxy jmx-jolokia jvm linux mailq memcached mongodb multicore munin mysql nginx openldap php-apc php-fpm php-opcache plack postgres proc-fd solr rabbitmq redis snmp squid td-table-count trafficserver twemproxy uwsgi-vassal varnish xentop aws-cloudfront aws-ec2-ebs fluentd docker unicorn uptime inode; do \
     ln -s ./mackerel-plugin %{buildroot}%{__targetdir}/mackerel-plugin-$i; \


### PR DESCRIPTION
Currently, `make all` triggers `make build` 3 times and `make build/mackerel-plugin` 2 times.
With this p-r, `make build` will be triggered 2 times and `make build/mackerel-plugins` once.