### PR TITLE
Fix redundant error by golint in redis.go

### DIFF
--- a/mackerel-plugin-redis/lib/redis.go
+++ b/mackerel-plugin-redis/lib/redis.go
@@ -90,10 +90,7 @@ func calculateCapacity(c *redis.Client, stat map[string]interface{}) error {
 	if err := fetchPercentageOfMemory(c, stat); err != nil {
 		return err
 	}
-	if err := fetchPercentageOfClients(c, stat); err != nil {
-		return err
-	}
-	return nil
+	return fetchPercentageOfClients(c, stat)
 }
 
 // MetricKeyPrefix interface for PluginWithPrefix


### PR DESCRIPTION
TravisCI build is failed with "mackerel-plugin-redis/lib/redis.go:93:2: redundant if ...; err != nil check, just return error instead" ( https://travis-ci.org/mackerelio/mackerel-agent-plugins/jobs/277135454#L1091 ).

This is because golint's specification change (https://github.com/golang/lint/pull/319).

So I fixed redis.go to pass golint.