### PR TITLE
Update mackerel-plugin-dynamodb plugin

### DIFF
--- a/mackerel-plugin-aws-dynamodb/lib/aws-dynamo-db.go
+++ b/mackerel-plugin-aws-dynamodb/lib/aws-dynamo-db.go
@@ -74,7 +74,7 @@ func (p *DynamoDBPlugin) prepare() error {
 	return nil
 }
 
-func transformAndAppendDatapoint(dp *cloudwatch.Datapoint, dataType string, label string, stats map[string]interface{}) map[string]interface{} {
+func transformAndAppendDatapoint(stats map[string]interface{}, dp *cloudwatch.Datapoint, dataType string, label string) map[string]interface{} {
 	if dp != nil {
 		switch dataType {
 		case metricsTypeAverage:
@@ -138,7 +138,7 @@ func fetchOperationWildcardMetrics(cw cloudwatchiface.CloudWatchAPI, mg metricsG
 		if dp != nil {
 			for _, met := range mg.Metrics {
 				label := strings.Replace(met.MackerelName, "#", *operation, 1)
-				stats = transformAndAppendDatapoint(dp, met.Type, label, stats)
+				stats = transformAndAppendDatapoint(stats, dp, met.Type, label)
 			}
 		}
 	}
@@ -259,7 +259,7 @@ func (p DynamoDBPlugin) FetchMetrics() (map[string]interface{}, error) {
 			}
 			for _, m := range met.Metrics {
 				mu.Lock()
-				stats = transformAndAppendDatapoint(dp, m.Type, m.MackerelName, stats)
+				stats = transformAndAppendDatapoint(stats, dp, m.Type, m.MackerelName)
 				mu.Unlock()
 			}
 			return nil

--- a/mackerel-plugin-aws-dynamodb/lib/aws-dynamo-db.go
+++ b/mackerel-plugin-aws-dynamodb/lib/aws-dynamo-db.go
@@ -213,6 +213,9 @@ var defaultMetricsGroup = []metricsGroup{
 	{CloudWatchName: "UserErrors", Metrics: []metric{
 		{MackerelName: "UserErrors", Type: metricsTypeSum},
 	}},
+	{CloudWatchName: "ReadThrottleEvents", Metrics: []metric{
+		{MackerelName: "ReadThrottleEvents", Type: metricsTypeSum, FillZero: true},
+	}},
 	{CloudWatchName: "WriteThrottleEvents", Metrics: []metric{
 		{MackerelName: "WriteThrottleEvents", Type: metricsTypeSum, FillZero: true},
 	}},

--- a/mackerel-plugin-aws-dynamodb/lib/aws-dynamo-db.go
+++ b/mackerel-plugin-aws-dynamodb/lib/aws-dynamo-db.go
@@ -35,6 +35,7 @@ type metricsGroup struct {
 type metric struct {
 	MackerelName string
 	Type         string
+	FillZero     bool
 }
 
 // DynamoDBPlugin mackerel plugin for aws kinesis
@@ -211,7 +212,7 @@ var defaultMetricsGroup = []metricsGroup{
 		{MackerelName: "UserErrors", Type: metricsTypeSum},
 	}},
 	{CloudWatchName: "WriteThrottleEvents", Metrics: []metric{
-		{MackerelName: "WriteThrottleEvents", Type: metricsTypeSum},
+		{MackerelName: "WriteThrottleEvents", Type: metricsTypeSum, FillZero: true},
 	}},
 	{CloudWatchName: "TimeToLiveDeletedItemCount", Metrics: []metric{
 		{MackerelName: "TimeToLiveDeletedItemCount", Type: metricsTypeSum},


### PR DESCRIPTION
- ReadThrottleEvents metrics are missing, so added
- For ReadThrotttleEvents and WriteThrottleEvents metrics, fill 0 when values are not present