### PR TITLE
[twemproxy] [incompatible] add `-enable-each-pool-metrics` option

### DIFF
--- a/mackerel-plugin-twemproxy/lib/twemproxy_test.go
+++ b/mackerel-plugin-twemproxy/lib/twemproxy_test.go
@@ -149,9 +149,10 @@ func TestFetchMetrics(t *testing.T) {
 
 	// get metrics
 	p := TwemproxyPlugin{
-		Address: "localhost:" + strconv.Itoa(statsServer.Port()),
-		Prefix:  "twemproxy",
-		Timeout: 5,
+		Address:         "localhost:" + strconv.Itoa(statsServer.Port()),
+		Prefix:          "twemproxy",
+		Timeout:         5,
+		EachPoolMetrics: true,
 	}
 	metrics, err := p.FetchMetrics()
 	if err != nil {
@@ -223,6 +224,44 @@ func TestFetchMetrics(t *testing.T) {
 	}
 }
 
+func TestFetchMetrics_disableEachMetrics(t *testing.T) {
+	// response a valid stats json
+	stats = jsonStr
+
+	// get metrics
+	p := TwemproxyPlugin{
+		Address: "localhost:" + strconv.Itoa(statsServer.Port()),
+		Prefix:  "twemproxy",
+		Timeout: 5,
+	}
+	metrics, err := p.FetchMetrics()
+	if err != nil {
+		t.Errorf("Failed to FetchMetrics: %s", err)
+		return
+	}
+
+	if len(metrics) != 7 {
+		t.Errorf("7 metrics are expected to be collected, but it was %d", len(metrics))
+	}
+
+	// check the metrics
+	expected := map[string]uint64{
+		"total_connections": 3895,
+		"curr_connections":  272,
+	}
+
+	for k, v := range expected {
+		value, ok := metrics[k]
+		if !ok {
+			t.Errorf("metric of %s cannot be fetched", k)
+			continue
+		}
+		if v != value {
+			t.Errorf("metric of %s should be %v, but %v", k, v, value)
+		}
+	}
+}
+
 func TestFetchMetricsFail(t *testing.T) {
 	assertPanic := func(t *testing.T, f func() (map[string]interface{}, error)) {
 		defer func() {
@@ -234,9 +273,10 @@ func TestFetchMetricsFail(t *testing.T) {
 	}
 
 	p := TwemproxyPlugin{
-		Address: "localhost:" + strconv.Itoa(statsServer.Port()),
-		Prefix:  "twemproxy",
-		Timeout: 5,
+		Address:         "localhost:" + strconv.Itoa(statsServer.Port()),
+		Prefix:          "twemproxy",
+		Timeout:         5,
+		EachPoolMetrics: true,
 	}
 
 	noClientErrJSONStr := strings.Replace(


### PR DESCRIPTION
When collecting metrics for each pool of twemproxy, it is needed to explicitly specify `-enable-each-pool-metrics` option now.

This is an incompatible change, but I think that sending the metrics of each pool by default is noisy and it may even cause a metric increase that the user doesn't expect.