### PR TITLE
[gostats] Use go-mackerel-plugin instead of go-mackerel-plugin-helper

### DIFF
--- a/mackerel-plugin-gostats/lib/mackerel-plugin-gostats.go
+++ b/mackerel-plugin-gostats/lib/mackerel-plugin-gostats.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/fukata/golang-stats-api-handler"
-	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
 // GostatsPlugin mackerel plugin for go server
@@ -103,7 +103,7 @@ func (m GostatsPlugin) GraphDefinition() map[string]mp.Graphs {
 }
 
 // FetchMetrics interface for mackerelplugin
-func (m GostatsPlugin) FetchMetrics() (map[string]interface{}, error) {
+func (m GostatsPlugin) FetchMetrics() (map[string]float64, error) {
 	resp, err := http.Get(m.URI)
 	if err != nil {
 		return nil, err
@@ -113,8 +113,8 @@ func (m GostatsPlugin) FetchMetrics() (map[string]interface{}, error) {
 	return m.parseStats(resp.Body)
 }
 
-func (m GostatsPlugin) parseStats(body io.Reader) (map[string]interface{}, error) {
-	stat := make(map[string]interface{})
+func (m GostatsPlugin) parseStats(body io.Reader) (map[string]float64, error) {
+	stat := make(map[string]float64)
 	decoder := json.NewDecoder(body)
 
 	s := stats_api.Stats{}
@@ -122,21 +122,21 @@ func (m GostatsPlugin) parseStats(body io.Reader) (map[string]interface{}, error
 	if err != nil {
 		return nil, err
 	}
-	stat["goroutine_num"] = uint64(s.GoroutineNum)
-	stat["cgo_call_num"] = uint64(s.CgoCallNum)
-	stat["memory_sys"] = s.MemorySys
-	stat["memory_alloc"] = s.MemoryAlloc
-	stat["memory_stack"] = s.StackInUse
-	stat["memory_lookups"] = s.MemoryLookups
-	stat["memory_frees"] = s.MemoryFrees
-	stat["memory_mallocs"] = s.MemoryMallocs
-	stat["heap_sys"] = s.HeapSys
-	stat["heap_idle"] = s.HeapIdle
-	stat["heap_inuse"] = s.HeapInuse
-	stat["heap_released"] = s.HeapReleased
-	stat["gc_num"] = s.GcNum
-	stat["gc_per_second"] = s.GcPerSecond
-	stat["gc_pause_per_second"] = s.GcPausePerSecond
+	stat["goroutine_num"] = float64(s.GoroutineNum)
+	stat["cgo_call_num"] = float64(s.CgoCallNum)
+	stat["memory_sys"] = float64(s.MemorySys)
+	stat["memory_alloc"] = float64(s.MemoryAlloc)
+	stat["memory_stack"] = float64(s.StackInUse)
+	stat["memory_lookups"] = float64(s.MemoryLookups)
+	stat["memory_frees"] = float64(s.MemoryFrees)
+	stat["memory_mallocs"] = float64(s.MemoryMallocs)
+	stat["heap_sys"] = float64(s.HeapSys)
+	stat["heap_idle"] = float64(s.HeapIdle)
+	stat["heap_inuse"] = float64(s.HeapInuse)
+	stat["heap_released"] = float64(s.HeapReleased)
+	stat["gc_num"] = float64(s.GcNum)
+	stat["gc_per_second"] = float64(s.GcPerSecond)
+	stat["gc_pause_per_second"] = float64(s.GcPausePerSecond)
 
 	return stat, nil
 }

--- a/mackerel-plugin-gostats/lib/mackerel-plugin-gostats_test.go
+++ b/mackerel-plugin-gostats/lib/mackerel-plugin-gostats_test.go
@@ -1,0 +1,67 @@
+package mpgostats
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseStats(t *testing.T) {
+	stat := `{
+  "time": 1449124022112358000,
+  "go_version": "go1.5.1",
+  "go_os": "darwin",
+  "go_arch": "amd64",
+  "cpu_num": 4,
+  "goroutine_num": 6,
+  "gomaxprocs": 4,
+  "cgo_call_num": 5,
+  "memory_alloc": 213360,
+  "memory_total_alloc": 213360,
+  "memory_sys": 3377400,
+  "memory_lookups": 15,
+  "memory_mallocs": 1137,
+  "memory_frees": 0,
+  "memory_stack": 393216,
+  "heap_alloc": 213360,
+  "heap_sys": 655360,
+  "heap_idle": 65536,
+  "heap_inuse": 589824,
+  "heap_released": 0,
+  "heap_objects": 1137,
+  "gc_next": 4194304,
+  "gc_last": 0,
+  "gc_num": 0,
+  "gc_per_second": 0,
+  "gc_pause_per_second": 0,
+  "gc_pause": []
+}`
+
+	expected := map[string]float64{
+		"goroutine_num":       6.0,
+		"cgo_call_num":        5.0,
+		"memory_sys":          3377400.0,
+		"memory_alloc":        213360.0,
+		"memory_stack":        393216.0,
+		"memory_lookups":      15.0,
+		"memory_frees":        0.0,
+		"memory_mallocs":      1137.0,
+		"heap_sys":            655360.0,
+		"heap_idle":           65536.0,
+		"heap_inuse":          589824.0,
+		"heap_released":       0.0,
+		"gc_num":              0.0,
+		"gc_per_second":       0.0,
+		"gc_pause_per_second": 0.0,
+	}
+
+	m := GostatsPlugin{}
+	got, err := m.parseStats(strings.NewReader(stat))
+	if err != nil {
+		t.Fatalf("error should be nil but got: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("stats differs: %v (expected: %v)", got, expected)
+	}
+}


### PR DESCRIPTION
We recommend go-mackerel-plugin over go-mackerel-plugin-helper.