### PR TITLE
[cloudfront] add -metric-key-prefix option

### DIFF
--- a/mackerel-plugin-aws-cloudfront/README.md
+++ b/mackerel-plugin-aws-cloudfront/README.md
@@ -6,7 +6,7 @@ AWS CloudFront custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-cloudfront -identifier=<cloudfront-distribution-id> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-cloudfront -identifier=<cloudfront-distribution-id> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>] [-metric-key-prefix=<prefix>]
 ```
 
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`


### PR DESCRIPTION
Added `-metric-key-prefix` option to support multiple cloudfront distributions.