### PR TITLE
Improve mackerel-plugin-postgres

### DIFF
--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -129,7 +129,7 @@ func fetchConnections(db *sqlx.DB, version version) (map[string]interface{}, err
 	var query string
 
 	if version.first > 9 || version.first == 9 && version.second >= 6 {
-		query = `select count(*), state, wait_event is not null from pg_stat_activity group by state, wait_event is not null`
+		query = `select count(*), state, wait_event is not null from pg_stat_activity where state is not null group by state, wait_event is not null`
 	} else {
 		query = `select count(*), state, waiting from pg_stat_activity group by state, waiting`
 	}

--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -227,7 +227,7 @@ func fetchVersion(db *sqlx.DB) (version, error) {
 			if err != nil {
 				return res, err
 			}
-			if len(submatch) == 5 {
+			if len(submatch) == 5 && submatch[4] != "" {
 				third, err = strconv.ParseUint(submatch[4], 10, 0)
 				if err != nil {
 					return res, err

--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -190,7 +190,7 @@ func fetchDatabaseSize(db *sqlx.DB) (map[string]interface{}, error) {
 	}, nil
 }
 
-var versionRe = regexp.MustCompile("PostgreSQL (\\d+)\\.(\\d+)(\\.(\\d+))? ")
+var versionRe = regexp.MustCompile("PostgreSQL (\\d+)\\.(\\d+)(\\.(\\d+))?")
 
 type version struct {
 	first  uint

--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -195,7 +195,7 @@ var versionRe = regexp.MustCompile("PostgreSQL (\\d+)\\.(\\d+)(\\.(\\d+))? ")
 type version struct {
 	first  uint
 	second uint
-	thrird uint
+	third  uint
 }
 
 func fetchVersion(db *sqlx.DB) (version, error) {

--- a/mackerel-plugin-postgres/lib/postgres_test.go
+++ b/mackerel-plugin-postgres/lib/postgres_test.go
@@ -54,6 +54,7 @@ var fetchVersionTests = []struct {
 		version{uint(9), uint(6), uint(4)},
 	},
 	{
+		// Azure Database for PostgreSQL
 		`
 		PostgreSQL 9.6.5, compiled by Visual C++ build 1800, 64-bit
 		`,

--- a/mackerel-plugin-postgres/lib/postgres_test.go
+++ b/mackerel-plugin-postgres/lib/postgres_test.go
@@ -60,6 +60,12 @@ var fetchVersionTests = []struct {
 		`,
 		version{uint(9), uint(6), uint(5)},
 	},
+	{
+		`
+		PostgreSQL 10.0 on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18) 6.3.0 20170516, 64-bit
+		`,
+		version{uint(10), uint(0), uint(0)},
+	},
 }
 
 func TestFetchVersion(t *testing.T) {


### PR DESCRIPTION
- Support parsing version of Azure Database for PostgreSQL and PostgreSQL 10
- Change pg_stat_activity query to exclude stats which has null state value

This is a response for `pg_stat_activity` on my local PostgreSQL 10 running in Docker:
```
postgres=# select * from pg_stat_activity;
 datid | datname  | pid | usesysid | usename  | application_name | client_addr | client_hostname | client_port |         backend_start         |          xact_start           |          query_start          |         state_change          | wait_event_type |     wait_event      | state  | backend_xid | backend_xmin |              query              |    backend_type
-------+----------+-----+----------+----------+------------------+-------------+-----------------+-------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------------+---------------------+--------+-------------+--------------+---------------------------------+---------------------
       |          |  58 |          |          |                  |             |                 |             | 2017-11-06 03:18:42.412697+00 |                               |                               |                               | Activity        | AutoVacuumMain      |        |             |              |                                 | autovacuum launcher
       |          |  60 |       10 | postgres |                  |             |                 |             | 2017-11-06 03:18:42.412317+00 |                               |                               |                               | Activity        | LogicalLauncherMain |        |             |              |                                 | background worker
 12994 | postgres |  62 |       10 | postgres | psql             | 172.17.0.1  |                 |       39832 | 2017-11-06 03:19:01.442573+00 | 2017-11-06 03:42:04.419422+00 | 2017-11-06 03:42:04.419422+00 | 2017-11-06 03:42:04.419434+00 |                 |                     | active |             |          556 | select * from pg_stat_activity; | client backend
       |          |  56 |          |          |                  |             |                 |             | 2017-11-06 03:18:42.410605+00 |                               |                               |                               | Activity        | BgWriterHibernate   |        |             |              |                                 | background writer
       |          |  55 |          |          |                  |             |                 |             | 2017-11-06 03:18:42.410246+00 |                               |                               |                               | Activity        | CheckpointerMain    |        |             |              |                                 | checkpointer
       |          |  57 |          |          |                  |             |                 |             | 2017-11-06 03:18:42.410961+00 |                               |                               |                               | Activity        | WalWriterMain       |        |             |              |                                 | walwriter
```