### PR TITLE
[docker] Don't log when regexp does not match

### DIFF
--- a/mackerel-plugin-docker/lib/docker.go
+++ b/mackerel-plugin-docker/lib/docker.go
@@ -223,8 +223,11 @@ func guessMethod(docker string) (string, error) {
 
 	re := regexp.MustCompile(`Server API version: ([0-9]+)(?:\.([0-9]+))?`)
 	res := re.FindAllStringSubmatch(out.String(), 1)
+
+	// Recent docker does not provide server api version info in the form,
+	// But in case it's apparently newer than 1.17.
 	if len(res) < 1 || len(res[0]) < 2 {
-		log.Printf("Use API because of failing to recognize version")
+		// log.Printf("Use API because of failing to recognize version")
 		return "API", nil
 	}
 


### PR DESCRIPTION
Legacy docker command reports server api version as `Server API version: x.yy` form:
```
$ sudo docker version
Client version: 1.6.0
Client API version: 1.18
Go version (client): go1.4.2
Git commit (client): 4749651
OS/Arch (client): linux/amd64
Server version: 1.6.0
Server API version: 1.18
Go version (server): go1.4.2
Git commit (server): 4749651
OS/Arch (server): linux/amd64
```

But recently it does not report in the form:
```
$ docker version
Client:
 Version:      17.09.0-ce
 API version:  1.32
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:40:09 2017
 OS/Arch:      darwin/amd64

Server:
 Version:      17.09.0-ce
 API version:  1.32 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:45:38 2017
 OS/Arch:      linux/amd64
 Experimental: true
```

This p-r just stops logging when Old-style regexp does not match the response from `docker version`.  