### PR TITLE
[aws-ec2-ebs] Do not log "fetched no datapoints" error

### DIFF
--- a/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
+++ b/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
@@ -217,7 +217,7 @@ func (p *EBSPlugin) prepare() error {
 	return nil
 }
 
-var noDatapointErr = errors.New("fetched no datapoints")
+var errNoDataPoint = errors.New("fetched no datapoints")
 
 func (p EBSPlugin) getLastPoint(vol *ec2.Volume, metricName string, statType string) (float64, int, error) {
 	now := time.Now()
@@ -248,7 +248,7 @@ func (p EBSPlugin) getLastPoint(vol *ec2.Volume, metricName string, statType str
 
 	datapoints := resp.Datapoints
 	if len(datapoints) == 0 {
-		return 0, 0, noDatapointErr
+		return 0, 0, errNoDataPoint
 	}
 
 	latest := time.Unix(0, 0)
@@ -289,7 +289,7 @@ func (p EBSPlugin) FetchMetrics() (map[string]interface{}, error) {
 				val, period, err := p.getLastPoint(vol, cloudwatchdef.MetricName, cloudwatchdef.Statistics)
 				if err != nil {
 					retErr := errors.New(volumeID + " " + err.Error() + ":" + cloudwatchdef.MetricName)
-					if err == noDatapointErr {
+					if err == errNoDataPoint {
 						// nop
 					} else {
 						return nil, retErr

--- a/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
+++ b/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
@@ -290,7 +290,7 @@ func (p EBSPlugin) FetchMetrics() (map[string]interface{}, error) {
 				if err != nil {
 					retErr := errors.New(volumeID + " " + err.Error() + ":" + cloudwatchdef.MetricName)
 					if err == NoDatapointErr {
-						getStderrLogger().Println(retErr)
+						// nop
 					} else {
 						return nil, retErr
 					}
@@ -306,13 +306,6 @@ func (p EBSPlugin) FetchMetrics() (map[string]interface{}, error) {
 // GraphDefinition for plugin
 func (p EBSPlugin) GraphDefinition() map[string]mp.Graphs {
 	return graphdef
-}
-
-func getStderrLogger() *log.Logger {
-	if stderrLogger == nil {
-		stderrLogger = log.New(os.Stderr, "", log.LstdFlags)
-	}
-	return stderrLogger
 }
 
 func normalizeVolumeID(volumeID string) string {

--- a/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
+++ b/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"log"
-	"os"
 	"strings"
 	"time"
 

--- a/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
+++ b/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go
@@ -217,7 +217,7 @@ func (p *EBSPlugin) prepare() error {
 	return nil
 }
 
-var NoDatapointErr = errors.New("fetched no datapoints")
+var noDatapointErr = errors.New("fetched no datapoints")
 
 func (p EBSPlugin) getLastPoint(vol *ec2.Volume, metricName string, statType string) (float64, int, error) {
 	now := time.Now()
@@ -248,7 +248,7 @@ func (p EBSPlugin) getLastPoint(vol *ec2.Volume, metricName string, statType str
 
 	datapoints := resp.Datapoints
 	if len(datapoints) == 0 {
-		return 0, 0, NoDatapointErr
+		return 0, 0, noDatapointErr
 	}
 
 	latest := time.Unix(0, 0)
@@ -289,7 +289,7 @@ func (p EBSPlugin) FetchMetrics() (map[string]interface{}, error) {
 				val, period, err := p.getLastPoint(vol, cloudwatchdef.MetricName, cloudwatchdef.Statistics)
 				if err != nil {
 					retErr := errors.New(volumeID + " " + err.Error() + ":" + cloudwatchdef.MetricName)
-					if err == NoDatapointErr {
+					if err == noDatapointErr {
 						// nop
 					} else {
 						return nil, retErr


### PR DESCRIPTION
Some metrics does not have datapoints when the volume is idle, therefore do not output such error to Stderr, to keep clean mackerel-agent.log

BEFORE:
```
$ mackerel-plugin-aws-ec2-ebs
2017/11/16 21:26:13 vol-DUMMY fetched no datapoints:VolumeReadBytes
2017/11/16 21:26:13 vol-DUMMY fetched no datapoints:VolumeReadBytes
2017/11/16 21:26:13 vol-DUMMY fetched no datapoints:VolumeTotalReadTime
ec2.ebs.queue_length.vol-DUMMY.queue_length	0.000100	1510835172
ec2.ebs.idle_time.vol-DUMMY.idle_time	99.990000	1510835172
ec2.ebs.bandwidth.vol-DUMMY.write	3973.120000	1510835172
ec2.ebs.latency.vol-DUMMY.write	0.215827	1510835172
ec2.ebs.burst_balance.vol-DUMMY.burst_balance	100.000000	1510835172
ec2.ebs.throughput.vol-DUMMY.read	0.000000	1510835172
ec2.ebs.throughput.vol-DUMMY.write	0.463333	1510835172
ec2.ebs.size_per_op.vol-DUMMY.write	8575.079137	1510835172
```

AFTER:
```
$ ./mackerel-plugin-aws-ec2-ebs
ec2.ebs.bandwidth.vol-DUMMY.write	3973.120000	1510835159
ec2.ebs.throughput.vol-DUMMY.read	0.000000	1510835159
ec2.ebs.throughput.vol-DUMMY.write	0.463333	1510835159
ec2.ebs.size_per_op.vol-DUMMY.write	8575.079137	1510835159
ec2.ebs.queue_length.vol-DUMMY.queue_length	0.000100	1510835159
ec2.ebs.idle_time.vol-DUMMY.idle_time	99.990000	1510835159
ec2.ebs.burst_balance.vol-DUMMY.burst_balance	100.000000	1510835159
ec2.ebs.latency.vol-DUMMY.write	0.215827	1510835159
```