### PR TITLE
Jvm remote

### DIFF
--- a/mackerel-plugin-jvm/README.md
+++ b/mackerel-plugin-jvm/README.md
@@ -6,7 +6,7 @@ JVM(jstat) custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-jvm -javaname=<javaname> [-pidfile=</path/to/pidfile>] [-jstatpath=</path/to/jstat] [-jpspath=/path/to/jps] [-jinfopath=/path/to/jinfo] [-host=<host>] [-port=<port>]
+mackerel-plugin-jvm -javaname=<javaname> [-pidfile=</path/to/pidfile>] [-jstatpath=</path/to/jstat] [-jpspath=/path/to/jps] [-jinfopath=/path/to/jinfo] [-remote=<host:port>]
 ```
 
 ## Requirements

--- a/mackerel-plugin-jvm/README.md
+++ b/mackerel-plugin-jvm/README.md
@@ -21,6 +21,13 @@ command = "/path/to/mackerel-plugin-jvm -javaname=NettyServer -jstatpath=/usr/bi
 user = "SOME_USER_NAME"
 ```
 
+## Monitoring remote JVM
+
+This plugin can retrieve metrics from remote jstatd with rmi protocol by setting `-remote` option.
+In this case, following limitations are applied:
+- jps and jstat commands must be executable localy from this plugin
+- 'CMS Initiating Occupancy Fraction' metric cannot be retrieved remotely
+
 ## About javaname
 
 You can check javaname by jps command.

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -106,6 +106,10 @@ func (m JVMPlugin) calculateMemorySpaceRate(gcStat map[string]float64) (map[stri
 }
 
 func (m JVMPlugin) checkCMSGC() bool {
+	// jinfo does not work on remote
+	if m.Remote != "" {
+		return false
+	}
 	stdout, _, exitStatus, err := runTimeoutCommand(m.JinfoPath, "-flag", "UseConcMarkSweepGC", m.Lvmid)
 
 	if err == nil && exitStatus.IsTimedOut() {

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -343,7 +343,11 @@ func Do() {
 		os.Exit(1)
 	}
 
-	if *optPidFile == "" {
+	if *optPidFile != "" && jvm.Remote != nil {
+		logger.Warningf("both '-pidfile' and '-remote' specified, but '-pidfile' does not work with '-remote' therefore ignored")
+	}
+
+	if *optPidFile == "" || jvm.Remote != nil {
 		lvmid, err := fetchLvmidByAppname(*optJavaName, generateVmid(jvm.Remote, nil), *optJpsPath)
 		if err != nil {
 			logger.Errorf("Failed to fetch lvmid. %s. Please run with the java process user when monitoring local JVM, or set proper 'remote' option when monitorint remote one.", err)

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -309,8 +309,7 @@ func generateVmid(remote, lvmid string) string {
 		if lvmid == "" {
 			return remote
 		}
-		vmid := fmt.Sprintf("%s@%s", lvmid, remote)
-		return vmid
+		return fmt.Sprintf("%s@%s", lvmid, remote)
 	}
 	return lvmid
 }
@@ -320,16 +319,14 @@ func generateRemote(remote, host string, port int) string {
 		if host == "" {
 			if port != 0 {
 				// for backward compatibility
-				hostPort := fmt.Sprintf("localhost:%d", port)
-				return hostPort
+				return fmt.Sprintf("localhost:%d", port)
 			}
 			return ""
 		}
 		if port == 0 {
 			return host
 		}
-		hostPort := fmt.Sprintf("%s:%d", host, port)
-		return hostPort
+		return fmt.Sprintf("%s:%d", host, port)
 	}
 
 	if host != "" || port != 0 {

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -341,7 +341,7 @@ func generateRemote(remote, host string, port int) string {
 // Do the plugin
 func Do() {
 	optHost := flag.String("host", "", "jps/jstat target hostname [deprecated]")
-	optPort := flag.Int("port", 0, "jps/jstat target port [deprecarted]")
+	optPort := flag.Int("port", 0, "jps/jstat target port [deprecated]")
 	optRemote := flag.String("remote", "", "jps/jstat remote target. hostname[:port][/servername]")
 	optJstatPath := flag.String("jstatpath", "/usr/bin/jstat", "jstat path")
 	optJinfoPath := flag.String("jinfopath", "/usr/bin/jinfo", "jinfo path")

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -107,7 +107,7 @@ func (m JVMPlugin) calculateMemorySpaceRate(gcStat map[string]float64) (map[stri
 
 func (m JVMPlugin) checkCMSGC() bool {
 	// jinfo does not work on remote
-	if m.Remote == nil {
+	if m.Remote != nil {
 		return false
 	}
 	stdout, _, exitStatus, err := runTimeoutCommand(m.JinfoPath, "-flag", "UseConcMarkSweepGC", m.Lvmid)

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -346,7 +346,7 @@ func Do() {
 	if *optPidFile == "" {
 		lvmid, err := fetchLvmidByAppname(*optJavaName, generateVmid(jvm.Remote, nil), *optJpsPath)
 		if err != nil {
-			logger.Errorf("Failed to fetch lvmid. %s. Please run with the java process user.", err)
+			logger.Errorf("Failed to fetch lvmid. %s. Please run with the java process user when monitoring local JVM, or set proper 'remote' option when monitorint remote one.", err)
 			os.Exit(1)
 		}
 		jvm.Lvmid = lvmid

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -308,15 +308,14 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 }
 
 func generateVmid(remote, lvmid *string) *string {
-	if remote == nil {
-		return lvmid
-	} else {
+	if remote != nil {
 		if lvmid == nil {
 			return remote
 		}
 		vmid := fmt.Sprintf("%s@%s", *lvmid, *remote)
 		return &vmid
 	}
+	return lvmid
 }
 
 // Do the plugin

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -94,7 +94,7 @@ func (m JVMPlugin) fetchJstatMetrics(option string) (map[string]float64, error) 
 	return stat, nil
 }
 
-func calculateMemorySpaceRate(gcStat map[string]float64, m JVMPlugin) (map[string]float64, error) {
+func (m JVMPlugin) calculateMemorySpaceRate(gcStat map[string]float64) (map[string]float64, error) {
 	ret := make(map[string]float64)
 	ret["oldSpaceRate"] = gcStat["OU"] / gcStat["OC"] * 100
 	ret["newSpaceRate"] = (gcStat["S0U"] + gcStat["S1U"] + gcStat["EU"]) / (gcStat["S0C"] + gcStat["S1C"] + gcStat["EC"]) * 100
@@ -201,7 +201,7 @@ func (m JVMPlugin) FetchMetrics() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	gcSpaceRate, err := calculateMemorySpaceRate(gcStat, m)
+	gcSpaceRate, err := m.calculateMemorySpaceRate(gcStat)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -98,15 +98,15 @@ func (m JVMPlugin) calculateMemorySpaceRate(gcStat map[string]float64) (map[stri
 	ret := make(map[string]float64)
 	ret["oldSpaceRate"] = gcStat["OU"] / gcStat["OC"] * 100
 	ret["newSpaceRate"] = (gcStat["S0U"] + gcStat["S1U"] + gcStat["EU"]) / (gcStat["S0C"] + gcStat["S1C"] + gcStat["EC"]) * 100
-	if checkCMSGC(m.Lvmid, m.JinfoPath) {
+	if m.checkCMSGC() {
 		ret["CMSInitiatingOccupancyFraction"] = fetchCMSInitiatingOccupancyFraction(m.Lvmid, m.JinfoPath)
 	}
 
 	return ret, nil
 }
 
-func checkCMSGC(lvmid, JinfoPath string) bool {
-	stdout, _, exitStatus, err := runTimeoutCommand(JinfoPath, "-flag", "UseConcMarkSweepGC", lvmid)
+func (m JVMPlugin) checkCMSGC() bool {
+	stdout, _, exitStatus, err := runTimeoutCommand(m.JinfoPath, "-flag", "UseConcMarkSweepGC", m.Lvmid)
 
 	if err == nil && exitStatus.IsTimedOut() {
 		err = fmt.Errorf("jinfo command timed out")

--- a/mackerel-plugin-jvm/lib/jvm_test.go
+++ b/mackerel-plugin-jvm/lib/jvm_test.go
@@ -10,28 +10,23 @@ func TestGenerateVmid(t *testing.T) {
 	lvmid := "12345"
 
 	expected = "12345@remotehost.local"
-	if id := generateVmid(&remote, &lvmid); id == nil {
-		t.Errorf("vmid should not be nil, but got nil")
-	} else if *id != expected {
-		t.Errorf("vmid should be %s, but %v", expected, *id)
+	if id := generateVmid(remote, lvmid); id != expected {
+		t.Errorf("vmid should be %s, but %v", expected, id)
 	}
 
 	expected = "remotehost.local"
-	if id := generateVmid(&remote, nil); id == nil {
-		t.Errorf("vmid should not be nil, but got nil")
-	} else if *id != expected {
-		t.Errorf("vmid should be %s, but %v", expected, *id)
+	if id := generateVmid(remote, ""); id != expected {
+		t.Errorf("vmid should be %s, but %v", expected, id)
 	}
 
 	expected = "12345"
-	if id := generateVmid(nil, &lvmid); id == nil {
-		t.Errorf("vmid should not be nil, but got nil")
-	} else if *id != expected {
-		t.Errorf("vmid should be %s, but %v", expected, *id)
+	if id := generateVmid("", lvmid); id != expected {
+		t.Errorf("vmid should be %s, but %v", expected, id)
 	}
 
-	if id := generateVmid(nil, nil); id != nil {
-		t.Errorf("vmid should be nil, but non-nil %v", *id)
+	expected = ""
+	if id := generateVmid("", ""); id != expected {
+		t.Errorf("vmid should be %s, but %v", expected, id)
 	}
 }
 
@@ -42,41 +37,32 @@ func TestGenerateRemote(t *testing.T) {
 	port := 12345
 
 	expected = "remote.local:1099"
-	if r := generateRemote(remote, "", 0); r == nil {
-		t.Errorf("remote should not be nil, but got nil")
-	} else if *r != expected {
-		t.Errorf("remote should be %s, but %v", expected, *r)
+	if r := generateRemote(remote, "", 0); r != expected {
+		t.Errorf("remote should be %s, but %s", expected, r)
 	}
 
 	expected = "remote.local:1099"
-	if r := generateRemote(remote, host, port); r == nil {
-		t.Errorf("remote should not be nil, but got nil")
-	} else if *r != expected {
-		t.Errorf("remote should be %s, but %v", expected, *r)
+	if r := generateRemote(remote, host, port); r != expected {
+		t.Errorf("remote should be %s, but %s", expected, r)
 	}
 
 	expected = "host.local:12345"
-	if r := generateRemote("", host, port); r == nil {
-		t.Errorf("remote should not be nil, but got nil")
-	} else if *r != expected {
-		t.Errorf("remote should be %s, but %v", expected, *r)
+	if r := generateRemote("", host, port); r != expected {
+		t.Errorf("remote should be %s, but %s", expected, r)
 	}
 
 	expected = "host.local"
-	if r := generateRemote("", host, 0); r == nil {
-		t.Errorf("remote should not be nil, but got nil")
-	} else if *r != expected {
-		t.Errorf("remote should be %s, but %v", expected, *r)
+	if r := generateRemote("", host, 0); r != expected {
+		t.Errorf("remote should be %s, but %s", expected, r)
 	}
 
 	expected = "localhost:12345"
-	if r := generateRemote("", "", port); r == nil {
-		t.Errorf("remote should not be nil, but got nil")
-	} else if *r != expected {
-		t.Errorf("remote should be %s, but %v", expected, *r)
+	if r := generateRemote("", "", port); r != expected {
+		t.Errorf("remote should be %s, but %s", expected, r)
 	}
 
-	if r := generateRemote("", "", 0); r != nil {
-		t.Errorf("remote should be nil, but non-nil %v", *r)
+	expected = ""
+	if r := generateRemote("", "", 0); r != expected {
+		t.Errorf("remote should be %s, but %s", expected, r)
 	}
 }

--- a/mackerel-plugin-jvm/lib/jvm_test.go
+++ b/mackerel-plugin-jvm/lib/jvm_test.go
@@ -34,3 +34,49 @@ func TestGenerateVmid(t *testing.T) {
 		t.Errorf("vmid should be nil, but non-nil %v", *id)
 	}
 }
+
+func TestGenerateRemote(t *testing.T) {
+	var expected string
+	remote := "remote.local:1099"
+	host := "host.local"
+	port := 12345
+
+	expected = "remote.local:1099"
+	if r := generateRemote(remote, "", 0); r == nil {
+		t.Errorf("remote should not be nil, but got nil")
+	} else if *r != expected {
+		t.Errorf("remote should be %s, but %v", expected, *r)
+	}
+
+	expected = "remote.local:1099"
+	if r := generateRemote(remote, host, port); r == nil {
+		t.Errorf("remote should not be nil, but got nil")
+	} else if *r != expected {
+		t.Errorf("remote should be %s, but %v", expected, *r)
+	}
+
+	expected = "host.local:12345"
+	if r := generateRemote("", host, port); r == nil {
+		t.Errorf("remote should not be nil, but got nil")
+	} else if *r != expected {
+		t.Errorf("remote should be %s, but %v", expected, *r)
+	}
+
+	expected = "host.local"
+	if r := generateRemote("", host, 0); r == nil {
+		t.Errorf("remote should not be nil, but got nil")
+	} else if *r != expected {
+		t.Errorf("remote should be %s, but %v", expected, *r)
+	}
+
+	expected = "localhost:12345"
+	if r := generateRemote("", "", port); r == nil {
+		t.Errorf("remote should not be nil, but got nil")
+	} else if *r != expected {
+		t.Errorf("remote should be %s, but %v", expected, *r)
+	}
+
+	if r := generateRemote("", "", 0); r != nil {
+		t.Errorf("remote should be nil, but non-nil %v", *r)
+	}
+}

--- a/mackerel-plugin-jvm/lib/jvm_test.go
+++ b/mackerel-plugin-jvm/lib/jvm_test.go
@@ -1,0 +1,36 @@
+package mpjvm
+
+import (
+	"testing"
+)
+
+func TestGenerateVmid(t *testing.T) {
+	var expected string
+	remote := "remotehost.local"
+	lvmid := "12345"
+
+	expected = "12345@remotehost.local"
+	if id := generateVmid(&remote, &lvmid); id == nil {
+		t.Errorf("vmid should not be nil, but got nil")
+	} else if *id != expected {
+		t.Errorf("vmid should be %s, but %v", expected, *id)
+	}
+
+	expected = "remotehost.local"
+	if id := generateVmid(&remote, nil); id == nil {
+		t.Errorf("vmid should not be nil, but got nil")
+	} else if *id != expected {
+		t.Errorf("vmid should be %s, but %v", expected, *id)
+	}
+
+	expected = "12345"
+	if id := generateVmid(nil, &lvmid); id == nil {
+		t.Errorf("vmid should not be nil, but got nil")
+	} else if *id != expected {
+		t.Errorf("vmid should be %s, but %v", expected, *id)
+	}
+
+	if id := generateVmid(nil, nil); id != nil {
+		t.Errorf("vmid should be nil, but non-nil %v", *id)
+	}
+}


### PR DESCRIPTION
mackerel-plugin-jvm has `-host` and `-port` option but they don't work as expected.
I'd like change those options to `-remote` option and make it work with rmi protocol.

In target host
```
/tmp$ cat jstatd.policy
grant codebase "file:${java.home}/../lib/tools.jar" {
  permission java.security.AllPermission;
};
/tmp$ jstatd -J-Djava.security.policy=/tmp/jstatd.policy -p [Port] -J-Djava.rmi.server.hostname=[Hostname]
```

In monitoring host:

```
$ ./mackerel-plugin-jvm -javaname XXX -remote [targetHostName:targetPort]
```