### PR TITLE
Don't add plugins README which has been moved

### DIFF
--- a/tool/create-release-pullrequest
+++ b/tool/create-release-pullrequest
@@ -29,7 +29,8 @@ my $PLUGIN_PREFIX = 'mackerel-plugin-';
 my $PACKAGE_NAME = 'mackerel-agent-plugins';
 
 sub retrieve_plugins {
-    sort map {s/^$PLUGIN_PREFIX//; $_} <$PLUGIN_PREFIX*>;
+    # exclude plugins which has been moved to other repositories
+    sort map {s/^$PLUGIN_PREFIX//; $_} grep { -e "$_/lib" } <$PLUGIN_PREFIX*>;
 }
 
 sub update_readme {


### PR DESCRIPTION
ref: #450 , etc.

With current master branch, `make release` attempts to add links to all plugins' README even if they've been moved to other repositories.
This patch adds simple filtering by checking existence of `mackerel-plugin-XXX/lib`.