### PR TITLE
Redis Plugin supports custom CONFIG command

### DIFF
--- a/mackerel-plugin-redis/README.md
+++ b/mackerel-plugin-redis/README.md
@@ -6,7 +6,7 @@ Redis custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-redis [-host=<hostname>] [-port=<port>] [-password=<password>] [-socket=<unix socket>] [-timeout=<time>] [-metric-key-prefix=<prefix>]
+mackerel-plugin-redis [-host=<hostname>] [-port=<port>] [-password=<password>] [-socket=<unix socket>] [-timeout=<time>] [-metric-key-prefix=<prefix>] [-config-command=<CONFIG command name>]
 ```
 
 ## Example of mackerel-agent.conf

--- a/mackerel-plugin-redis/lib/redis.go
+++ b/mackerel-plugin-redis/lib/redis.go
@@ -377,7 +377,7 @@ func Do() {
 	optPrefix := flag.String("metric-key-prefix", "redis", "Metric key prefix")
 	optTimeout := flag.Int("timeout", 5, "Timeout")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
-	optConfigCommand := flag.String("config-command", "CONFIG", "custom CONFIG command. disable CONFIG command when passed \"\"")
+	optConfigCommand := flag.String("config-command", "CONFIG", "Custom CONFIG command. Disable CONFIG command when passed \"\".")
 
 	flag.Parse()
 

--- a/mackerel-plugin-redis/lib/redis_test.go
+++ b/mackerel-plugin-redis/lib/redis_test.go
@@ -41,9 +41,10 @@ func TestFetchMetricsUnixSocket(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	redis := RedisPlugin{
-		Timeout: 5,
-		Prefix:  "redis",
-		Socket:  s.Config["unixsocket"],
+		Timeout:       5,
+		Prefix:        "redis",
+		Socket:        s.Config["unixsocket"],
+		ConfigCommand: "CONFIG",
 	}
 	stat, err := redis.FetchMetrics()
 
@@ -77,9 +78,10 @@ func TestFetchMetricsPercentageOfMemory(t *testing.T) {
 	defer s.Stop()
 
 	rp := RedisPlugin{
-		Timeout: 5,
-		Prefix:  "redis",
-		Socket:  s.Config["unixsocket"],
+		Timeout:       5,
+		Prefix:        "redis",
+		Socket:        s.Config["unixsocket"],
+		ConfigCommand: "CONFIG",
 	}
 
 	conn, err := redis.Dial("unix", s.Config["unixsocket"])
@@ -133,9 +135,10 @@ func TestFetchMetrics(t *testing.T) {
 	}
 	defer s.Stop()
 	redis := RedisPlugin{
-		Timeout: 5,
-		Prefix:  "redis",
-		Port:    portStr,
+		Timeout:       5,
+		Prefix:        "redis",
+		Port:          portStr,
+		ConfigCommand: "CONFIG",
 	}
 	stat, err := redis.FetchMetrics()
 


### PR DESCRIPTION
This patch is useful when CONFIG command has renamed or disabled for failsafe or security reasons.

If `-config-command=""` is specified, the metric acquisition with the CONFIG command is skipped.