### PR TITLE
[mysql] Fix some InnoDB stats

### DIFF
--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -297,10 +297,6 @@ func (m *MySQLPlugin) convertInnodbStats(stat map[string]float64) {
 		"file_reads":        "Innodb_data_reads",
 		"file_writes":       "Innodb_data_writes",
 		"modified_pages":    "Innodb_buffer_pool_pages_dirty",
-		"rows_deleted":      "Innodb_rows_deleted",
-		"rows_inserted":     "Innodb_rows_inserted",
-		"rows_read":         "Innodb_rows_read",
-		"rows_updated":      "Innodb_rows_updated",
 		"pool_size":         "Innodb_buffer_pool_pages_total",
 		"pages_created":     "Innodb_pages_created",
 		"pages_read":        "Innodb_pages_read",
@@ -986,20 +982,6 @@ func parseInnodbStatus(str string, p *map[string]float64) {
 			setIfEmpty(p, "pages_created", v)
 			v, _ = atof(record[6])
 			setIfEmpty(p, "pages_written", v)
-			continue
-		}
-
-		// Row Operations
-		if strings.Index(line, "Number of rows inserted") == 0 {
-			(*p)["rows_inserted"], _ = atof(record[4])
-			(*p)["rows_updated"], _ = atof(record[6])
-			(*p)["rows_deleted"], _ = atof(record[8])
-			(*p)["rows_read"], _ = atof(record[10])
-			continue
-		}
-		if strings.Index(line, " queries inside InnoDB, ") == 0 {
-			(*p)["queries_inside"], _ = atof(record[0])
-			(*p)["queries_queued"], _ = atof(record[4])
 			continue
 		}
 

--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -288,7 +288,8 @@ func (m *MySQLPlugin) fetchProcesslist(db mysql.Conn, stat map[string]float64) e
 	return nil
 }
 
-func (m *MySQLPlugin) pseudoFetchShowInnodbStatus(stat map[string]float64) {
+// for backward compatibility, convert stat names
+func (m *MySQLPlugin) convertInnodbStats(stat map[string]float64) {
 	for dst, src := range map[string]string{
 		"database_pages":    "Innodb_buffer_pool_pages_data",
 		"free_pages":        "Innodb_buffer_pool_pages_free",
@@ -341,9 +342,8 @@ func (m *MySQLPlugin) FetchMetrics() (map[string]interface{}, error) {
 	m.fetchShowVariables(db, stat)
 
 	if m.DisableInnoDB != true {
-		if m.isAuroraReader {
-			m.pseudoFetchShowInnodbStatus(stat)
-		} else {
+		m.convertInnodbStats(stat)
+		if !m.isAuroraReader {
 			err := m.fetchShowInnodbStatus(db, stat)
 			if err != nil {
 				log.Println("FetchMetrics (InnoDB Status): ", err)

--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -795,12 +795,6 @@ func parseInnodbStatus(str string, p *map[string]float64) {
 		}
 
 		// File I/O
-		if strings.Index(line, " OS file reads, ") > 0 {
-			(*p)["file_reads"], _ = atof(record[0])
-			(*p)["file_writes"], _ = atof(record[4])
-			(*p)["file_fsyncs"], _ = atof(record[8])
-			continue
-		}
 		if strings.Index(line, "Pending normal aio reads:") == 0 {
 			(*p)["pending_normal_aio_reads"], _ = atof(record[4])
 			(*p)["pending_normal_aio_writes"], _ = atof(record[7])
@@ -944,44 +938,6 @@ func parseInnodbStatus(str string, p *map[string]float64) {
 		if strings.Index(line, "innodb_io_pattern   ") == 0 {
 			v, _ := atof(record[1])
 			setIfEmpty(p, "innodb_io_pattern_memory", v)
-			continue
-		}
-		if strings.Index(line, "Buffer pool size ") == 0 {
-			v, _ := atof(record[3])
-			setIfEmpty(p, "pool_size", v)
-			continue
-		}
-		if strings.Index(line, "Free buffers") == 0 {
-			v, _ := atof(record[2])
-			setIfEmpty(p, "free_pages", v)
-			continue
-		}
-		if strings.Index(line, "Database pages") == 0 {
-			v, _ := atof(record[2])
-			setIfEmpty(p, "database_pages", v)
-			continue
-		}
-		if strings.Index(line, "Modified db pages") == 0 {
-			v, _ := atof(record[3])
-			setIfEmpty(p, "modified_pages", v)
-			continue
-		}
-		if strings.Index(line, "Pages read ahead") == 0 {
-			v, _ := atof(record[3])
-			setIfEmpty(p, "read_ahead", v)
-			v, _ = atof(record[7])
-			setIfEmpty(p, "read_evicted", v)
-			v, _ = atof(record[11])
-			setIfEmpty(p, "read_random_ahead", v)
-			continue
-		}
-		if strings.Index(line, "Pages read") == 0 {
-			v, _ := atof(record[2])
-			setIfEmpty(p, "pages_read", v)
-			v, _ = atof(record[4])
-			setIfEmpty(p, "pages_created", v)
-			v, _ = atof(record[6])
-			setIfEmpty(p, "pages_written", v)
 			continue
 		}
 

--- a/mackerel-plugin-mysql/lib/mysql_test.go
+++ b/mackerel-plugin-mysql/lib/mysql_test.go
@@ -174,9 +174,6 @@ END OF INNODB MONITOR OUTPUT`
 	assert.EqualValues(t, stat["locked_transactions"], 0)   // empty
 	assert.EqualValues(t, stat["innodb_lock_structs"], 0)   // empty
 	// File I/O
-	assert.EqualValues(t, stat["file_reads"], 124669)
-	assert.EqualValues(t, stat["file_writes"], 4457)
-	assert.EqualValues(t, stat["file_fsyncs"], 3498)
 	assert.EqualValues(t, stat["pending_normal_aio_reads"], 0)
 	assert.EqualValues(t, stat["pending_normal_aio_writes"], 0)
 	assert.EqualValues(t, stat["pending_ibuf_aio_reads"], 0)
@@ -211,23 +208,6 @@ END OF INNODB MONITOR OUTPUT`
 	assert.EqualValues(t, stat["recovery_system_memory"], 0)   // empty
 	assert.EqualValues(t, stat["thread_hash_memory"], 0)       // empty
 	assert.EqualValues(t, stat["innodb_io_pattern_memory"], 0) // empty
-	assert.EqualValues(t, stat["pool_size"], 1024)
-	assert.EqualValues(t, stat["free_pages"], 755)
-	assert.EqualValues(t, stat["database_pages"], 256)
-	assert.EqualValues(t, stat["modified_pages"], 0)
-	assert.EqualValues(t, stat["read_ahead"], 0.00)
-	assert.EqualValues(t, stat["read_evicted"], 0.00)
-	assert.EqualValues(t, stat["read_random_ahead"], 0.00)
-	assert.EqualValues(t, stat["pages_read"], 124617)
-	assert.EqualValues(t, stat["pages_created"], 40)
-	assert.EqualValues(t, stat["pages_written"], 1020)
-	// Row Operations
-	assert.EqualValues(t, stat["rows_inserted"], 3089)
-	assert.EqualValues(t, stat["rows_updated"], 220)
-	assert.EqualValues(t, stat["rows_deleted"], 212)
-	assert.EqualValues(t, stat["rows_read"], 2099881)
-	assert.EqualValues(t, stat["queries_inside"], 0)
-	assert.EqualValues(t, stat["queries_queued"], 0)
 	// etc
 	assert.EqualValues(t, stat["unflushed_log"], 0)
 	assert.EqualValues(t, stat["uncheckpointed_bytes"], 0)
@@ -364,9 +344,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["locked_transactions"], 0)  // empty
 	assert.EqualValues(t, stat["innodb_lock_structs"], 0)  // empty
 	// File I/O
-	assert.EqualValues(t, stat["file_reads"], 80654072)
-	assert.EqualValues(t, stat["file_writes"], 816873637)
-	assert.EqualValues(t, stat["file_fsyncs"], 575117750)
 	assert.EqualValues(t, stat["pending_normal_aio_reads"], 0)
 	assert.EqualValues(t, stat["pending_normal_aio_writes"], 0)
 	assert.EqualValues(t, stat["pending_ibuf_aio_reads"], 0)
@@ -401,23 +378,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["recovery_system_memory"], 0)   // empty
 	assert.EqualValues(t, stat["thread_hash_memory"], 0)       // empty
 	assert.EqualValues(t, stat["innodb_io_pattern_memory"], 0) // empty
-	assert.EqualValues(t, stat["pool_size"], 1310719)
-	assert.EqualValues(t, stat["free_pages"], 1)
-	assert.EqualValues(t, stat["database_pages"], 1206903)
-	assert.EqualValues(t, stat["modified_pages"], 180)
-	assert.EqualValues(t, stat["read_ahead"], 0.00)
-	assert.EqualValues(t, stat["read_evicted"], 0.00)
-	assert.EqualValues(t, stat["read_random_ahead"], 0.00)
-	assert.EqualValues(t, stat["pages_read"], 80651165)
-	assert.EqualValues(t, stat["pages_created"], 15602833)
-	assert.EqualValues(t, stat["pages_written"], 276352840)
-	// Row Operations
-	assert.EqualValues(t, stat["rows_inserted"], 686919123)
-	assert.EqualValues(t, stat["rows_updated"], 623703731)
-	assert.EqualValues(t, stat["rows_deleted"], 24439131)
-	assert.EqualValues(t, stat["rows_read"], 13570264742306)
-	assert.EqualValues(t, stat["queries_inside"], 0)
-	assert.EqualValues(t, stat["queries_queued"], 0)
 	// etc
 	assert.EqualValues(t, stat["unflushed_log"], 0)
 	assert.EqualValues(t, stat["uncheckpointed_bytes"], 138000)
@@ -557,9 +517,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["locked_transactions"], 0)  // empty
 	assert.EqualValues(t, stat["innodb_lock_structs"], 0)  // empty
 	// File I/O
-	assert.EqualValues(t, stat["file_reads"], 613992)
-	assert.EqualValues(t, stat["file_writes"], 134400134)
-	assert.EqualValues(t, stat["file_fsyncs"], 83130666)
 	assert.EqualValues(t, stat["pending_normal_aio_reads"], 0)
 	assert.EqualValues(t, stat["pending_normal_aio_writes"], 0)
 	assert.EqualValues(t, stat["pending_ibuf_aio_reads"], 0)
@@ -594,23 +551,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["recovery_system_memory"], 0)   // empty
 	assert.EqualValues(t, stat["thread_hash_memory"], 0)       // empty
 	assert.EqualValues(t, stat["innodb_io_pattern_memory"], 0) // empty
-	assert.EqualValues(t, stat["pool_size"], 458751)
-	assert.EqualValues(t, stat["free_pages"], 1)
-	assert.EqualValues(t, stat["database_pages"], 452570)
-	assert.EqualValues(t, stat["modified_pages"], 0)
-	assert.EqualValues(t, stat["read_ahead"], 0.00)
-	assert.EqualValues(t, stat["read_evicted"], 0.00)
-	assert.EqualValues(t, stat["read_random_ahead"], 0.00)
-	assert.EqualValues(t, stat["pages_read"], 1203250)
-	assert.EqualValues(t, stat["pages_created"], 1230474)
-	assert.EqualValues(t, stat["pages_written"], 83593763)
-	// Row Operations
-	assert.EqualValues(t, stat["rows_inserted"], 24090641)
-	assert.EqualValues(t, stat["rows_updated"], 8332796)
-	assert.EqualValues(t, stat["rows_deleted"], 18513402)
-	assert.EqualValues(t, stat["rows_read"], 139771797310)
-	assert.EqualValues(t, stat["queries_inside"], 0)
-	assert.EqualValues(t, stat["queries_queued"], 0)
 	// etc
 	assert.EqualValues(t, stat["unflushed_log"], 0)
 	assert.EqualValues(t, stat["uncheckpointed_bytes"], 0)
@@ -712,9 +652,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["locked_transactions"], 0)  // empty
 	assert.EqualValues(t, stat["innodb_lock_structs"], 0)  // empty
 	// File I/O
-	assert.EqualValues(t, stat["file_reads"], 332)
-	assert.EqualValues(t, stat["file_writes"], 7564)
-	assert.EqualValues(t, stat["file_fsyncs"], 4398)
 	assert.EqualValues(t, stat["pending_normal_aio_reads"], 0)
 	assert.EqualValues(t, stat["pending_normal_aio_writes"], 0)
 	assert.EqualValues(t, stat["pending_ibuf_aio_reads"], 0)
@@ -749,23 +686,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["recovery_system_memory"], 0)   // empty
 	assert.EqualValues(t, stat["thread_hash_memory"], 0)       // empty
 	assert.EqualValues(t, stat["innodb_io_pattern_memory"], 0) // empty
-	assert.EqualValues(t, stat["pool_size"], 512)
-	assert.EqualValues(t, stat["free_pages"], 1)
-	assert.EqualValues(t, stat["database_pages"], 472)
-	assert.EqualValues(t, stat["modified_pages"], 0)
-	assert.EqualValues(t, stat["read_ahead"], 0.00)
-	assert.EqualValues(t, stat["read_evicted"], 0.00)
-	assert.EqualValues(t, stat["read_random_ahead"], 0.00)
-	assert.EqualValues(t, stat["pages_read"], 467)
-	assert.EqualValues(t, stat["pages_created"], 9)
-	assert.EqualValues(t, stat["pages_written"], 5185)
-	// Row Operations
-	assert.EqualValues(t, stat["rows_inserted"], 835)
-	assert.EqualValues(t, stat["rows_updated"], 104)
-	assert.EqualValues(t, stat["rows_deleted"], 2)
-	assert.EqualValues(t, stat["rows_read"], 226461457)
-	assert.EqualValues(t, stat["queries_inside"], 0)
-	assert.EqualValues(t, stat["queries_queued"], 0)
 	// etc
 	assert.EqualValues(t, stat["unflushed_log"], 0)
 	assert.EqualValues(t, stat["uncheckpointed_bytes"], 0)
@@ -964,9 +884,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["locked_transactions"], 0)  // empty
 	assert.EqualValues(t, stat["innodb_lock_structs"], 0)  // empty
 	// File I/O
-	assert.EqualValues(t, stat["file_reads"], 516)
-	assert.EqualValues(t, stat["file_writes"], 55)
-	assert.EqualValues(t, stat["file_fsyncs"], 9)
 	assert.EqualValues(t, stat["pending_normal_aio_reads"], 0)
 	assert.EqualValues(t, stat["pending_normal_aio_writes"], 0)
 	assert.EqualValues(t, stat["pending_ibuf_aio_reads"], 0)
@@ -1001,23 +918,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["recovery_system_memory"], 0)   // empty
 	assert.EqualValues(t, stat["thread_hash_memory"], 0)       // empty
 	assert.EqualValues(t, stat["innodb_io_pattern_memory"], 0) // empty
-	assert.EqualValues(t, stat["pool_size"], 65528)
-	assert.EqualValues(t, stat["free_pages"], 64999)
-	assert.EqualValues(t, stat["database_pages"], 521)
-	assert.EqualValues(t, stat["modified_pages"], 0)
-	assert.EqualValues(t, stat["read_ahead"], 0.00)
-	assert.EqualValues(t, stat["read_evicted"], 0.00)
-	assert.EqualValues(t, stat["read_random_ahead"], 0.00)
-	assert.EqualValues(t, stat["pages_read"], 487)
-	assert.EqualValues(t, stat["pages_created"], 34)
-	assert.EqualValues(t, stat["pages_written"], 36)
-	// Row Operations
-	assert.EqualValues(t, stat["rows_inserted"], 0)
-	assert.EqualValues(t, stat["rows_updated"], 0)
-	assert.EqualValues(t, stat["rows_deleted"], 0)
-	assert.EqualValues(t, stat["rows_read"], 8)
-	assert.EqualValues(t, stat["queries_inside"], 0)
-	assert.EqualValues(t, stat["queries_queued"], 0)
 	// etc
 	assert.EqualValues(t, stat["unflushed_log"], 0)
 	assert.EqualValues(t, stat["uncheckpointed_bytes"], 9)
@@ -1174,9 +1074,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["locked_transactions"], 1)
 	assert.EqualValues(t, stat["innodb_lock_structs"], 4)
 	// File I/O
-	assert.EqualValues(t, stat["file_reads"], 310)
-	assert.EqualValues(t, stat["file_writes"], 174)
-	assert.EqualValues(t, stat["file_fsyncs"], 22)
 	assert.EqualValues(t, stat["pending_normal_aio_reads"], 0)
 	assert.EqualValues(t, stat["pending_normal_aio_writes"], 0)
 	assert.EqualValues(t, stat["pending_ibuf_aio_reads"], 0)
@@ -1211,23 +1108,6 @@ END OF INNODB MONITOR OUTPUT
 	assert.EqualValues(t, stat["recovery_system_memory"], 0)   // empty
 	assert.EqualValues(t, stat["thread_hash_memory"], 0)       // empty
 	assert.EqualValues(t, stat["innodb_io_pattern_memory"], 0) // empty
-	assert.EqualValues(t, stat["pool_size"], 8191)
-	assert.EqualValues(t, stat["free_pages"], 8039)
-	assert.EqualValues(t, stat["database_pages"], 151)
-	assert.EqualValues(t, stat["modified_pages"], 0)
-	assert.EqualValues(t, stat["read_ahead"], 0.00)
-	assert.EqualValues(t, stat["read_evicted"], 0.00)
-	assert.EqualValues(t, stat["read_random_ahead"], 0.00)
-	assert.EqualValues(t, stat["pages_read"], 147)
-	assert.EqualValues(t, stat["pages_created"], 4)
-	assert.EqualValues(t, stat["pages_written"], 156)
-	// Row Operations
-	assert.EqualValues(t, stat["rows_inserted"], 2)
-	assert.EqualValues(t, stat["rows_updated"], 0)
-	assert.EqualValues(t, stat["rows_deleted"], 1)
-	assert.EqualValues(t, stat["rows_read"], 2)
-	assert.EqualValues(t, stat["queries_inside"], 0)
-	assert.EqualValues(t, stat["queries_queued"], 0)
 	// etc
 	assert.EqualValues(t, stat["unflushed_log"], 0)
 	assert.EqualValues(t, stat["uncheckpointed_bytes"], 0)


### PR DESCRIPTION
ref: #462 

During review of #462, I realized some stats parsed from `show engine innodb status` can be taken from `show status` actually.  Since parsing InnoDB status are complicated and difficult, imo it's better to obtain those stats from `show status`.

And also, some stats are parsed but not used, so I removed them, (`rows_{deleted,inserted,read,updated}`).