### PR TITLE
[mysql] set Diff: true for some stats which are actually counter values

### DIFF
--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -414,9 +414,9 @@ func (m *MySQLPlugin) addGraphdefWithInnoDBMetrics(graphdef map[string]mp.Graphs
 		Label: labelPrefix + " innodb Buffer Pool Read (/sec)",
 		Unit:  "float",
 		Metrics: []mp.Metrics{
-			{Name: "read_ahead", Label: "Pages Read Ahead", Diff: false, Stacked: false},
-			{Name: "read_evicted", Label: "Evicted Without Access", Diff: false, Stacked: false},
-			{Name: "read_random_ahead", Label: "Random Read Ahead", Diff: false, Stacked: false},
+			{Name: "read_ahead", Label: "Pages Read Ahead", Diff: true, Stacked: false},
+			{Name: "read_evicted", Label: "Evicted Without Access", Diff: true, Stacked: false},
+			{Name: "read_random_ahead", Label: "Random Read Ahead", Diff: true, Stacked: false},
 		},
 	}
 	graphdef["innodb_buffer_pool_activity"] = mp.Graphs{

--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -414,9 +414,9 @@ func (m *MySQLPlugin) addGraphdefWithInnoDBMetrics(graphdef map[string]mp.Graphs
 		Label: labelPrefix + " innodb Buffer Pool Read (/sec)",
 		Unit:  "float",
 		Metrics: []mp.Metrics{
-			{Name: "read_ahead", Label: "Pages Read Ahead", Diff: true, Stacked: false},
-			{Name: "read_evicted", Label: "Evicted Without Access", Diff: true, Stacked: false},
-			{Name: "read_random_ahead", Label: "Random Read Ahead", Diff: true, Stacked: false},
+			{Name: "read_ahead", Label: "Pages Read Ahead", Diff: true, Stacked: false, Scale: (1.0 / 60.0)},
+			{Name: "read_evicted", Label: "Evicted Without Access", Diff: true, Stacked: false, Scale: (1.0 / 60.0)},
+			{Name: "read_random_ahead", Label: "Random Read Ahead", Diff: true, Stacked: false, Scale: (1.0 / 60.0)},
 		},
 	}
 	graphdef["innodb_buffer_pool_activity"] = mp.Graphs{


### PR DESCRIPTION
Those stats has been obtained as current value from `show engine innodb status`.
With #469, mackerel-plugin-mysql obtains those stats from `show status`, but those in `show status` are counter value and needs to be set `Diff: true`, and to be scaled `*(1/60)`.