### PR TITLE
[mysql] add a hint for -disable_innodb

### DIFF
--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -181,7 +181,8 @@ func (m *MySQLPlugin) fetchShowStatus(db mysql.Conn, stat map[string]float64) er
 func (m *MySQLPlugin) fetchShowInnodbStatus(db mysql.Conn, stat map[string]float64) error {
 	row, _, err := db.QueryFirst("SHOW /*!50000 ENGINE*/ INNODB STATUS")
 	if err != nil {
-		log.Fatalln("FetchMetrics (InnoDB Status): ", err)
+		log.Println("FetchMetrics (InnoDB Status): ", err)
+		log.Fatalln("Hint: If you don't use InnoDB and see InnoDB Status error, you should set -disable_innodb")
 	}
 
 	if len(row) > 0 {


### PR DESCRIPTION
delivered from #470.

Message will be following:
```
$ ./mackerel-plugin-mysql -username nagios -password nagios
2017/12/20 19:16:35 FetchMetrics (InnoDB Status):  Received #1286 error from MySQL server: "Unknown table engine 'INNODB'"
2017/12/20 19:16:35 Hint: If you don't use InnoDB and see InnoDB Status error, you should set -disable_innodb
```