### PR TITLE
[postgres] Add amount of xlog_location change

### DIFF
--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -408,7 +408,7 @@ func (p PostgresPlugin) GraphDefinition() map[string]mp.Graphs {
 		},
 		"xlog_location": {
 			Label: (labelPrefix + " Amount of Transaction location change"),
-			Unit:  "integer",
+			Unit:  "bytes",
 			Metrics: []mp.Metrics{
 				{Name: "xlog_location_bytes", Label: "Amount of Transaction location change (byte)", Diff: true, Stacked: false},
 			},


### PR DESCRIPTION
This PR adds amount of transaction location change metric as `xlog_location.xlog_location_bytes` in postgresql plugin. When postgres is in recovery, this metric is offered with `0`.
