### PR TITLE
make `make build` works for some plugins which moved out from this repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ BINDIR  = build/$(GOOS)/$(GOARCH)
 
 all: lint cover testconvention rpm deb
 
-$(BINDIR)/mackerel-plugin-%: mackerel-plugin-%/lib/*.go
+.SECONDEXPANSION:
+$(BINDIR)/mackerel-plugin-%: mackerel-plugin-%/main.go $$(wildcard mackerel-plugin-%/lib/*.go)
 	@if [ ! -d $(BINDIR) ]; then mkdir -p $(BINDIR); fi
 	go build -ldflags="-s -w" -o $@ ./`basename $@`
 


### PR DESCRIPTION
Fix #484

In gnumake rules, `*.go` will resolved to proper files when ANY file exists, but will be resolved to a (non-exists) file `*.go` itself when NO files found.

To avoid this, 
  - add main.go to dependency
  - use `wildcard` function to avoid `*.go`
    - ref: https://www.gnu.org/software/make/manual/html_node/Wildcard-Function.html#Wildcard-Function
  - add `.SECONDEXPANSION` to resolve `wildcard` after `%` resolved
    - ref: https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html