### PR TITLE
Support BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(BINDIR)/mackerel-plugin-%: mackerel-plugin-%/main.go $$(wildcard mackerel-plug
 
 build: deps
 	for i in mackerel-plugin-*; do \
-	  make $(BINDIR)/$$i; \
+	  $(MAKE) $(BINDIR)/$$i; \
 	done
 
 build/mackerel-plugin: deps
@@ -63,17 +63,17 @@ cover: testdeps
 rpm: rpm-v1 rpm-v2
 
 rpm-v1:
-	make build GOOS=linux GOARCH=386
+	$(MAKE) build GOOS=linux GOARCH=386
 	rpmbuild --define "_sourcedir `pwd`" --define "_bindir build/linux/386" \
 	  --define "_version ${VERSION}" --define "buildarch noarch" \
 	  -bb packaging/rpm/mackerel-agent-plugins.spec
-	make build GOOS=linux GOARCH=amd64
+	$(MAKE) build GOOS=linux GOARCH=amd64
 	rpmbuild --define "_sourcedir `pwd`" --define "_bindir build/linux/amd64" \
 	  --define "_version ${VERSION}" --define "buildarch x86_64" \
 	  -bb packaging/rpm/mackerel-agent-plugins.spec
 
 rpm-v2:
-	make build/mackerel-plugin GOOS=linux GOARCH=amd64
+	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=amd64
 	rpmbuild --define "_sourcedir `pwd`"  --define "_version ${VERSION}" \
 	  --define "buildarch x86_64" --define "dist .el7.centos" \
 	  -bb packaging/rpm/mackerel-agent-plugins-v2.spec
@@ -81,14 +81,14 @@ rpm-v2:
 deb: deb-v1 deb-v2
 
 deb-v1:
-	make build GOOS=linux GOARCH=386
+	$(MAKE) build GOOS=linux GOARCH=386
 	for i in `cat packaging/deb/debian/source/include-binaries`; do \
 	  cp build/linux/386/`basename $$i` packaging/deb/debian/; \
 	done
 	cd packaging/deb && debuild --no-tgz-check -rfakeroot -uc -us
 
 deb-v2:
-	make build/mackerel-plugin GOOS=linux GOARCH=amd64
+	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=amd64
 	cp build/mackerel-plugin packaging/deb-v2/debian/
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us
 


### PR DESCRIPTION
[[ ISSUE ]]
1. On BSD(NetBSD, FreeBSD, OpenBSD), 'make' is 'BSD make'.
so 'make build' will use 'BSD make', on BSD.

2. 'BSD make' is not support 'The shell Function'
see. https://www.gnu.org/software/make/manual/make.html#Shell-Function

in Makefile:
  GOOS   ?= $(shell go env GOOS)
  GOARCH ?= $(shell go env GOARCH)

this is not support BSD make.
==> BSD need to use 'gmake'.
'gmake' is 'GNU make'. 'gmake' is provided package, on BSD.

3. 'make' written directry (so used 'BSD make' on BSD)
in Makefile:
  make $(BINDIR)/$$i;
  etc..

4. 'BSD make' is not support 'Pattern rules'
see. Features of GNU make
https://www.gnu.org/software/make/manual/html_node/Features.html

in Makefile:
  $(BINDIR)/mackerel-plugin-%: mackerel-plugin-%/main.go $$(wildcard mackerel-plugin-%/lib/*.go)

'BSD make' is not support 'mackerel-plugin-%'.

[[ SOLUTION ]]
'make' replace to '$(MAKE)'

see. How the MAKE Variable Works
https://www.gnu.org/software/make/manual/make.html#MAKE-Variable

In this way, '$(MAKE)' is called from the command is used.
e.g.
  'make build' => $(MAKE) is 'make'. (for Linux, this is ok.)
  'gmake build' => $(MAKE) is 'gmake'. (This is necessary for BSD.)