### PR TITLE
Migrate from `go-mgo/mgo` to `globalsign/mgo`

### DIFF
--- a/mackerel-plugin-mongodb/lib/mongodb.go
+++ b/mackerel-plugin-mongodb/lib/mongodb.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 	"github.com/mackerelio/golib/logging"
-	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
 )
 
 var logger = logging.GetLogger("metrics.plugin.mongodb")

--- a/mackerel-plugin-mongodb/lib/mongodb_docker_test.go
+++ b/mackerel-plugin-mongodb/lib/mongodb_docker_test.go
@@ -1,0 +1,102 @@
+// +build docker
+
+package mpmongodb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+func TestFetchMetrics(t *testing.T) {
+	port := "27017"
+
+	opts := createContainerOptions("latest", port)
+
+	err := invokeFunctionWithContainer(func() {
+		var mongodb MongoDBPlugin = MongoDBPlugin{URL: "localhost:" + port}
+		_, err := mongodb.FetchMetrics()
+		if err != nil {
+			t.Errorf("Error: %s", err.Error())
+		}
+	}, opts)
+
+	if err != nil {
+		t.Errorf("Error: %s", err.Error())
+	}
+}
+
+func invokeFunctionWithContainer(f func(), opts docker.CreateContainerOptions) (err error) {
+	cl, err := docker.NewClientFromEnv()
+	if err != nil {
+		return err
+	}
+
+	// Pull Docker Image if not exists.
+	_, err = cl.InspectImage(opts.Config.Image)
+	image := strings.Split(opts.Config.Image, ":")
+	if len(image) < 2 {
+		image = append(image, "latest")
+	}
+	if err != nil {
+		err = cl.PullImage(
+			docker.PullImageOptions{
+				Repository: image[0],
+				Tag:        image[1],
+			},
+			docker.AuthConfiguration{},
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	c, err := cl.CreateContainer(opts)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		errRemoveContainer := cl.RemoveContainer(docker.RemoveContainerOptions{
+			ID:    c.ID,
+			Force: true,
+		})
+		if errRemoveContainer != nil {
+			if err != nil {
+				err = fmt.Errorf("%s; %s", err, errRemoveContainer)
+			} else {
+				err = errRemoveContainer
+			}
+		}
+	}()
+
+	if err = cl.StartContainer(c.ID, &docker.HostConfig{}); err != nil {
+		return err
+	}
+
+	f()
+
+	return nil
+}
+
+func createContainerOptions(tag, hostPort string) docker.CreateContainerOptions {
+	opts := docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Image: "mongo:" + tag,
+			ExposedPorts: map[docker.Port]struct{}{
+				"27017/tcp": struct{}{},
+			},
+		},
+		HostConfig: &docker.HostConfig{
+			PortBindings: map[docker.Port][]docker.PortBinding{
+				"27017/tcp": {
+					{HostIP: "", HostPort: hostPort},
+				},
+			},
+		},
+	}
+
+	return opts
+}

--- a/mackerel-plugin-mongodb/lib/mongodb_test.go
+++ b/mackerel-plugin-mongodb/lib/mongodb_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/mgo.v2/bson"
+	"github.com/globalsign/mgo/bson"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
- [go\-mgo/mgo](https://github.com/go-mgo/mgo) is unmainted
    - https://twitter.com/gniemeyer/status/951846808061448192
- migrate to [globalsign/mgo](https://github.com/globalsign/mgo)