### PR TITLE
Add mackerel-plugin-aws-s3-requests

### DIFF
--- a/mackerel-plugin-aws-s3-requests/README.md
+++ b/mackerel-plugin-aws-s3-requests/README.md
@@ -1,0 +1,25 @@
+mackerel-plugin-aws-s3-requests
+=================================
+
+AWS S3 requests metrics plugin for mackerel.io agent.
+
+## Requirement
+
+You need a metrics configuration FilterID for the target S3 bucket to get CloudWatch metrics for the bucket. If you haven't created any configurations yet, you can create by AWS CLI or AWS API. (ref: https://docs.aws.amazon.com/AmazonS3/latest/dev/metrics-configurations.html)
+
+## Synopsis
+
+```shell
+mackerel-plugin-aws-s3-requests -bucket-name=<bucket-name> -filter-id=<filter-id> -region=<aws-region> -access-key-id=<id> -secret-access-key=<key> [-tempfile=<tempfile>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<prefix>]
+```
+* `filter-id` is the id for the metrics configuration, described in "Requirement" section.
+* you can set some parameters by environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`.
+  * If both of those environment variables and command line parameters are passed, command line parameters are used.
+* You may omit `region` parameter if you're running this plugin on an EC2 instance running in same region with the target Lambda function
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.aws-s3-requests]
+command = "/path/to/mackerel-plugin-aws-s3-requests -bucket-name=MyBucket -filter-id=SomeFilterId -region=ap-northeast-1"
+```

--- a/mackerel-plugin-aws-s3-requests/README.md
+++ b/mackerel-plugin-aws-s3-requests/README.md
@@ -21,7 +21,7 @@ mackerel-plugin-aws-s3-requests -bucket-name=<bucket-name> -filter-id=<filter-id
 
 ```
 [plugin.metrics.aws-s3-requests]
-command = "/path/to/mackerel-plugin-aws-s3-requests -bucket-name=MyBucket -filter-id=SomeFilterId -region=ap-northeast-1"
+command = "mackerel-plugin-aws-s3-requests -bucket-name=MyBucket -filter-id=SomeFilterId -region=ap-northeast-1"
 ```
 
 ## List of Metrics

--- a/mackerel-plugin-aws-s3-requests/README.md
+++ b/mackerel-plugin-aws-s3-requests/README.md
@@ -26,7 +26,7 @@ command = "mackerel-plugin-aws-s3-requests -bucket-name=MyBucket -filter-id=Some
 
 ## List of Metrics
 
-You can customize graph labels and metric names by command line parameters `--metric-label-prefix` and `--metric-key-prefix`.
+You can customize graph labels and metric names by command line parameters `-metric-label-prefix` and `-metric-key-prefix`.
 
 | Graph Label | Metric Label | Metric (Full) Name | CloudWatch Name | CloudWatch Stastics |
 |-----------------------------------|--------------|----------------------------------------------------------------|---------------------|:-------------------:|

--- a/mackerel-plugin-aws-s3-requests/README.md
+++ b/mackerel-plugin-aws-s3-requests/README.md
@@ -5,7 +5,7 @@ AWS S3 requests metrics plugin for mackerel.io agent.
 
 ## Requirement
 
-You need a metrics configuration FilterID for the target S3 bucket to get CloudWatch metrics for the bucket. If you haven't created any configurations yet, you can create by AWS CLI or AWS API. (ref: https://docs.aws.amazon.com/AmazonS3/latest/dev/metrics-configurations.html)
+You need a metrics configuration FilterID for the target S3 bucket to get CloudWatch metrics. If you haven't created any configurations yet, you can create by AWS CLI or AWS API. (ref: https://docs.aws.amazon.com/AmazonS3/latest/dev/metrics-configurations.html)
 
 ## Synopsis
 
@@ -15,7 +15,7 @@ mackerel-plugin-aws-s3-requests -bucket-name=<bucket-name> -filter-id=<filter-id
 * `filter-id` is the id for the metrics configuration, described in "Requirement" section.
 * you can set some parameters by environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`.
   * If both of those environment variables and command line parameters are passed, command line parameters are used.
-* You may omit `region` parameter if you're running this plugin on an EC2 instance running in same region with the target Lambda function
+* You may omit `region` parameter if you're running this plugin on an EC2 instance running in same region with the target bucket.
 
 ## Example of mackerel-agent.conf
 
@@ -23,3 +23,27 @@ mackerel-plugin-aws-s3-requests -bucket-name=<bucket-name> -filter-id=<filter-id
 [plugin.metrics.aws-s3-requests]
 command = "/path/to/mackerel-plugin-aws-s3-requests -bucket-name=MyBucket -filter-id=SomeFilterId -region=ap-northeast-1"
 ```
+
+## List of Metrics
+
+You can customize graph labels and metric names by command line parameters `--metric-label-prefix` and `--metric-key-prefix`.
+
+| Graph Label | Metric Label | Metric (Full) Name | CloudWatch Name | CloudWatch Stastics |
+|-----------------------------------|--------------|----------------------------------------------------------------|---------------------|:-------------------:|
+| S3 Requests | All | `custom.s3-requests.requests.AllRequests` | AllRequests | Sum |
+| S3 Requests | Get | `custom.s3-requests.requests.GetRequests` | GetRequests | Sum |
+| S3 Requests | Put | `custom.s3-requests.requests.PutRequests` | PutRequests | Sum |
+| S3 Requests | Delete | `custom.s3-requests.requests.DeleteRequests` | DeleteRequests | Sum |
+| S3 Requests | Head | `custom.s3-requests.requests.HeadRequests` | HeadRequests | Sum |
+| S3 Requests | Post | `custom.s3-requests.requests.PostRequests` | PostRequests | Sum |
+| S3 Requests | Listt | `custom.s3-requests.requests.ListRequests` | ListRequests | Sum |
+| S3 Errors | 4xx | `custom.s3-requests.errors.4xxErrors` | 4xxErrors | Sum |
+| S3 Errors | 5xx | `custom.s3-requests.errors.5xxErrors` | 5xxErrors | Sum |
+| S3 Bytes | Downloaded | `custom.s3-requests.bytes.BytesDownloaded` | BytesDownloaded | Sum |
+| S3 Bytes | Uploaded | `custom.s3-requests.bytes.BytesUploaded` | BytesUploaded | Sum |
+| S3 FirstByteLatency [ms] | Average | `custom.s3-requests.first_byte_latency.FirstByteLatencyAvg` | FirstBytesLatency | Average |
+| S3 FirstByteLatency [ms] | Maximum | `custom.s3-requests.first_byte_latency.FirstByteLatencyMax` | FirstBytesLatency | Maximum |
+| S3 FirstByteLatency [ms] | Minimum | `custom.s3-requests.first_byte_latency.FirstByteLatencyMin` | FirstBytesLatency | Minimum |
+| S3 TotalRequestLatency [ms] | Average | `custom.s3-requests.total_request_latency.TotalRequestLatencyAvg` | TotalRequestLatency | Average |
+| S3 TotalRequestLatency [ms] | Maximum | `custom.s3-requests.total_request_latency.TotalRequestLatencyMax` | TotalRequestLatency | Maximum |
+| S3 TotalRequestLatency [ms] | Minimum | `custom.s3-requests.total_request_latency.TotalRequestLatencyMin` | TotalRequestLatency | Minimum |

--- a/mackerel-plugin-aws-s3-requests/README.md
+++ b/mackerel-plugin-aws-s3-requests/README.md
@@ -10,7 +10,7 @@ You need a metrics configuration FilterID for the target S3 bucket to get CloudW
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-s3-requests -bucket-name=<bucket-name> -filter-id=<filter-id> -region=<aws-region> -access-key-id=<id> -secret-access-key=<key> [-tempfile=<tempfile>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<prefix>]
+mackerel-plugin-aws-s3-requests -bucket-name=<bucket-name> -filter-id=<filter-id> -region=<aws-region> -access-key-id=<id> -secret-access-key=<key> [-metric-key-prefix=<prefix>] [-metric-label-prefix=<prefix>]
 ```
 * `filter-id` is the id for the metrics configuration, described in "Requirement" section.
 * you can set some parameters by environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`.

--- a/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
+++ b/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
@@ -278,7 +278,6 @@ func Do() {
 	optRegion := flag.String("region", "", "AWS Region")
 	optBucketName := flag.String("bucket-name", "", "S3 bucket Name")
 	optFilterID := flag.String("filter-id", "", "S3 FilterId in metrics configuration")
-	optTempfile := flag.String("tempfile", "", "Temp file name")
 	optKeyPrefix := flag.String("metric-key-prefix", "s3-requests", "Metric key prefix")
 	optLabelPrefix := flag.String("metric-label-prefix", "S3", "Metric label prefix")
 	flag.Parse()
@@ -299,8 +298,5 @@ func Do() {
 		log.Fatalln(err)
 	}
 
-	helper := mp.NewMackerelPlugin(plugin)
-	helper.Tempfile = *optTempfile
-
-	helper.Run()
+	mp.NewMackerelPlugin(plugin).Run()
 }

--- a/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
+++ b/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
@@ -55,7 +55,7 @@ func (p S3RequestsPlugin) MetricKeyPrefix() string {
 	return p.KeyPrefix
 }
 
-// MetricLabelPrefix
+// MetricLabelPrefix ...
 func (p S3RequestsPlugin) MetricLabelPrefix() string {
 	if p.LabelPrefix == "" {
 		return "S3"

--- a/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
+++ b/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
@@ -1,0 +1,306 @@
+package mpawss3requests
+
+import (
+	"errors"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+	mp "github.com/mackerelio/go-mackerel-plugin"
+)
+
+const (
+	namespace          = "AWS/S3"
+	metricsTypeAverage = "Average"
+	metricsTypeSum     = "Sum"
+	metricsTypeMaximum = "Maximum"
+	metricsTypeMinimum = "Minimum"
+)
+
+// has 1 CloudWatch MetricName and corresponding N Mackerel Metrics
+type metricsGroup struct {
+	CloudWatchName string
+	Metrics        []metric
+}
+
+type metric struct {
+	MackerelName string
+	Type         string
+}
+
+// S3RequestsPlugin is mackerel plugin for aws s3 with metric configuration
+type S3RequestsPlugin struct {
+	BucketName  string
+	FilterID    string
+	KeyPrefix   string
+	LabelPrefix string
+
+	AccessKeyID     string
+	SecretAccessKey string
+	Region          string
+
+	CloudWatch *cloudwatch.CloudWatch
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (p S3RequestsPlugin) MetricKeyPrefix() string {
+	if p.KeyPrefix == "" {
+		return "s3-requests"
+	}
+	return p.KeyPrefix
+}
+
+// MetricLabelPrefix
+func (p S3RequestsPlugin) MetricLabelPrefix() string {
+	if p.LabelPrefix == "" {
+		return "S3"
+	}
+	return p.LabelPrefix
+}
+
+// prepare creates CloudWatch instance
+func (p *S3RequestsPlugin) prepare() error {
+	// validate params
+	// apparently we need BucketName and FilterID
+	if p.BucketName == "" || p.FilterID == "" {
+		return errors.New("Both --bucket-name and --filter-id are necessary")
+	}
+
+	sess, err := session.NewSession()
+	if err != nil {
+		return err
+	}
+
+	config := aws.NewConfig()
+	if p.AccessKeyID != "" && p.SecretAccessKey != "" {
+		config = config.WithCredentials(credentials.NewStaticCredentials(p.AccessKeyID, p.SecretAccessKey, ""))
+	}
+	if p.Region != "" {
+		config = config.WithRegion(p.Region)
+	}
+
+	p.CloudWatch = cloudwatch.New(sess, config)
+
+	return nil
+}
+
+// getLastPoint fetches a CloudWatch metric and parse
+func getLastPointFromCloudWatch(cw cloudwatchiface.CloudWatchAPI, bucketName string, filterID string, metric metricsGroup) (*cloudwatch.Datapoint, error) {
+	now := time.Now()
+	statsInput := make([]*string, len(metric.Metrics))
+	for i, typ := range metric.Metrics {
+		statsInput[i] = aws.String(typ.Type)
+	}
+	input := &cloudwatch.GetMetricStatisticsInput{
+		StartTime:  aws.Time(now.Add(time.Duration(180) * time.Second * -1)), // 3 min
+		EndTime:    aws.Time(now),
+		MetricName: aws.String(metric.CloudWatchName),
+		Period:     aws.Int64(600),
+		Statistics: statsInput,
+		Namespace:  aws.String(namespace),
+	}
+	input.Dimensions = []*cloudwatch.Dimension{
+		{
+			Name:  aws.String("BucketName"),
+			Value: aws.String(bucketName),
+		},
+		{
+			Name:  aws.String("FilterId"),
+			Value: aws.String(filterID),
+		},
+	}
+	response, err := cw.GetMetricStatistics(input)
+	if err != nil {
+		return nil, err
+	}
+
+	datapoints := response.Datapoints
+	if len(datapoints) == 0 {
+		return nil, nil
+	}
+
+	latest := new(time.Time)
+	var latestDp *cloudwatch.Datapoint
+	for _, dp := range datapoints {
+		if dp.Timestamp.Before(*latest) {
+			continue
+		}
+
+		latest = dp.Timestamp
+		latestDp = dp
+	}
+
+	return latestDp, nil
+}
+
+func mergeStatsFromDatapoint(stats map[string]float64, dp *cloudwatch.Datapoint, mg metricsGroup) map[string]float64 {
+	for _, met := range mg.Metrics {
+		switch met.Type {
+		case metricsTypeAverage:
+			stats[met.MackerelName] = *dp.Average
+		case metricsTypeSum:
+			stats[met.MackerelName] = *dp.Sum
+		case metricsTypeMaximum:
+			stats[met.MackerelName] = *dp.Maximum
+		case metricsTypeMinimum:
+			stats[met.MackerelName] = *dp.Minimum
+		}
+	}
+	return stats
+}
+
+var s3RequestMetricsGroup = []metricsGroup{
+	{CloudWatchName: "AllRequests", Metrics: []metric{
+		{MackerelName: "AllRequests", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "GetRequests", Metrics: []metric{
+		{MackerelName: "GetRequests", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "PutRequests", Metrics: []metric{
+		{MackerelName: "PutRequests", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "DeleteRequests", Metrics: []metric{
+		{MackerelName: "DeleteRequests", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "HeadRequests", Metrics: []metric{
+		{MackerelName: "HeadRequests", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "PostRequests", Metrics: []metric{
+		{MackerelName: "PostRequests", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "ListRequests", Metrics: []metric{
+		{MackerelName: "ListRequests", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "4xxErrors", Metrics: []metric{
+		{MackerelName: "4xxErrors", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "5xxErrors", Metrics: []metric{
+		{MackerelName: "5xxErrors", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "BytesDownloaded", Metrics: []metric{
+		{MackerelName: "BytesDownloaded", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "BytesUploaded", Metrics: []metric{
+		{MackerelName: "BytesUploaded", Type: metricsTypeSum},
+	}},
+	{CloudWatchName: "FirstByteLatency", Metrics: []metric{
+		{MackerelName: "FirstByteLatencyAvg", Type: metricsTypeAverage},
+		{MackerelName: "FirstByteLatencyMax", Type: metricsTypeMaximum},
+		{MackerelName: "FirstByteLatencyMin", Type: metricsTypeMinimum},
+	}},
+	{CloudWatchName: "TotalRequestLatency", Metrics: []metric{
+		{MackerelName: "TotalRequestLatencyAvg", Type: metricsTypeAverage},
+		{MackerelName: "TotalRequestLatencyMax", Type: metricsTypeMaximum},
+		{MackerelName: "TotalRequestLatencyMin", Type: metricsTypeMinimum},
+	}},
+}
+
+// FetchMetrics fetch the metrics
+func (p S3RequestsPlugin) FetchMetrics() (map[string]float64, error) {
+	stats := make(map[string]float64)
+
+	for _, met := range s3RequestMetricsGroup {
+		v, err := getLastPointFromCloudWatch(p.CloudWatch, p.BucketName, p.FilterID, met)
+		if err != nil {
+			log.Printf("%s: %s", met, err)
+		} else if v != nil {
+			stats = mergeStatsFromDatapoint(stats, v, met)
+		}
+	}
+	return stats, nil
+}
+
+// GraphDefinition of S3RequestsPlugin
+func (p S3RequestsPlugin) GraphDefinition() map[string]mp.Graphs {
+	labelPrefix := p.MetricLabelPrefix()
+
+	graphdef := map[string]mp.Graphs{
+		"requests": {
+			Label: (labelPrefix + " Requests"),
+			Unit:  mp.UnitInteger,
+			Metrics: []mp.Metrics{
+				{Name: "AllRequests", Label: "All", Stacked: false},
+				{Name: "GetRequests", Label: "Get", Stacked: true},
+				{Name: "PutRequests", Label: "Put", Stacked: true},
+				{Name: "DeleteRequests", Label: "Delete", Stacked: true},
+				{Name: "HeadRequests", Label: "Head", Stacked: true},
+				{Name: "PostRequests", Label: "Post", Stacked: true},
+				{Name: "ListRequests", Label: "List", Stacked: true},
+			},
+		},
+		"errors": {
+			Label: (labelPrefix + " Errors"),
+			Unit:  mp.UnitInteger,
+			Metrics: []mp.Metrics{
+				{Name: "4xxErrors", Label: "4xx"},
+				{Name: "5xxErrors", Label: "5xx"},
+			},
+		},
+		"bytes": {
+			Label: (labelPrefix + " Bytes"),
+			Unit:  mp.UnitBytes,
+			Metrics: []mp.Metrics{
+				{Name: "BytesDownloaded", Label: "Downloaded"},
+				{Name: "BytesUploaded", Label: "Uploaded"},
+			},
+		},
+		"first_byte_latency": {
+			Label: (labelPrefix + " FirstByteLatency [ms]"),
+			Unit:  mp.UnitFloat,
+			Metrics: []mp.Metrics{
+				{Name: "FirstByteLatencyAvg", Label: "Average"},
+				{Name: "FirstByteLatencyMax", Label: "Maximum"},
+				{Name: "FirstByteLatencyMin", Label: "Minimum"},
+			},
+		},
+		"total_request_latency": {
+			Label: (labelPrefix + " TotalRequestLatency [ms]"),
+			Unit:  mp.UnitFloat,
+			Metrics: []mp.Metrics{
+				{Name: "TotalRequestLatencyAvg", Label: "Average"},
+				{Name: "TotalRequestLatencyMax", Label: "Maximum"},
+				{Name: "TotalRequestLatencyMin", Label: "Minimum"},
+			},
+		},
+	}
+	return graphdef
+}
+
+// Do the plugin
+func Do() {
+	optAccessKeyID := flag.String("access-key-id", "", "AWS Access Key ID")
+	optSecretAccessKey := flag.String("secret-access-key", "", "AWS Secret Access Key")
+	optRegion := flag.String("region", "", "AWS Region")
+	optBucketName := flag.String("bucket-name", "", "S3 bucket Name")
+	optFilterID := flag.String("filter-id", "", "S3 FilterId in metrics configuration")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	optKeyPrefix := flag.String("metric-key-prefix", "s3-requests", "Metric key prefix")
+	optLabelPrefix := flag.String("metric-label-prefix", "S3", "Metric label prefix")
+	flag.Parse()
+
+	var plugin S3RequestsPlugin
+
+	plugin.AccessKeyID = *optAccessKeyID
+	plugin.SecretAccessKey = *optSecretAccessKey
+	plugin.Region = *optRegion
+
+	plugin.BucketName = *optBucketName
+	plugin.FilterID = *optFilterID
+	plugin.KeyPrefix = *optKeyPrefix
+	plugin.LabelPrefix = *optLabelPrefix
+
+	err := plugin.prepare()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	helper := mp.NewMackerelPlugin(plugin)
+	helper.Tempfile = *optTempfile
+
+	helper.Run()
+}

--- a/mackerel-plugin-aws-s3-requests/main.go
+++ b/mackerel-plugin-aws-s3-requests/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-aws-s3-requests/lib"
+
+func main() {
+	mpawss3requests.Do()
+}

--- a/mackerel-plugin_gen.go
+++ b/mackerel-plugin_gen.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-aws-kinesis-streams/lib"
 	"github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-aws-lambda/lib"
 	"github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-aws-rds/lib"
+	"github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-aws-s3-requests/lib"
 	"github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-aws-ses/lib"
 	"github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-conntrack/lib"
 	"github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker/lib"
@@ -87,6 +88,8 @@ func runPlugin(plug string) error {
 		mpawslambda.Do()
 	case "aws-rds":
 		mpawsrds.Do()
+	case "aws-s3-requests":
+		mpawss3requests.Do()
 	case "aws-ses":
 		mpawsses.Do()
 	case "conntrack":
@@ -192,6 +195,7 @@ var plugins = []string{
 	"aws-kinesis-streams",
 	"aws-lambda",
 	"aws-rds",
+	"aws-s3-requests",
 	"aws-ses",
 	"conntrack",
 	"docker",

--- a/packaging/config.json
+++ b/packaging/config.json
@@ -12,6 +12,7 @@
        "aws-lambda",
        "aws-rds",
        "aws-ses",
+       "aws-s3-requests",
        "conntrack",
        "elasticsearch",
        "flume",


### PR DESCRIPTION
AWS S3 Requests metrics plugin.
Initial implementation is available at https://github.com/astj/mackerel-plugin-aws-s3-requests.