### PR TITLE
[nit] Upgrade Go version to 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9
+- 1.9.x
 env:
   global:
   - PATH=~/gopath/bin:$PATH DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This pull request upgrades the version of Go on TravisCI. 1.9.x is resolved by https://github.com/travis-ci/travis-build.