### PR TITLE
[redis] expired_keys change to diff true

### DIFF
--- a/mackerel-plugin-redis/lib/redis.go
+++ b/mackerel-plugin-redis/lib/redis.go
@@ -270,7 +270,7 @@ func (m RedisPlugin) GraphDefinition() map[string]mp.Graphs {
 			Metrics: []mp.Metrics{
 				{Name: "keys", Label: "Keys", Diff: false},
 				{Name: "expires", Label: "Keys with expiration", Diff: false},
-				{Name: "expired", Label: "Expired Keys", Diff: false},
+				{Name: "expired", Label: "Expired Keys", Diff: true},
 			},
 		},
 		"keyspace": {


### PR DESCRIPTION
> - expired_keys: Total number of key expiration events
>
> https://redis.io/commands/INFO

`expired_keys` is total value.

It seems better to take the difference between the previous value.