### PR TITLE
[aws-ec2-cpucredit] Add T2 unlimited CPU credit metrics

### DIFF
--- a/mackerel-plugin-aws-ec2-cpucredit/lib/aws-ec2-cpucredit.go
+++ b/mackerel-plugin-aws-ec2-cpucredit/lib/aws-ec2-cpucredit.go
@@ -20,6 +20,8 @@ var graphdef = map[string]mp.Graphs{
 		Metrics: []mp.Metrics{
 			{Name: "usage", Label: "Usage", Diff: false},
 			{Name: "balance", Label: "Balance", Diff: false},
+			{Name: "surplus_balance", Label: "Surplus Usage", Diff: false},
+			{Name: "surplus_charged", Label: "Surplus Charged", Diff: false},
 		},
 	},
 }
@@ -101,6 +103,16 @@ func (p CPUCreditPlugin) FetchMetrics() (map[string]float64, error) {
 	}
 
 	stat["balance"], err = getLastPointAverage(cw, dimension, "CPUCreditBalance")
+	if err != nil {
+		return nil, err
+	}
+
+	stat["surplus_balance"], err = getLastPointAverage(cw, dimension, "CPUSurplusCreditBalance")
+	if err != nil {
+		return nil, err
+	}
+
+	stat["surplus_charged"], err = getLastPointAverage(cw, dimension, "CPUSurplusCreditsCharged")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ref: https://aws.amazon.com/jp/blogs/aws/new-t2-unlimited-going-beyond-the-burst-with-high-performance/

Example output using surplus balance:
```
$ ./mackerel-plugin-aws-ec2-cpucredit
ec2.cpucredit.usage	5.849346	1522223184
ec2.cpucredit.balance	0	1522223184
ec2.cpucredit.surplus_balance	2.166543	1522223184
ec2.cpucredit.surplus_charged	0	1522223184
```