### PR TITLE
fix for collectiong ioDrive(FusionIO) diskstats

### DIFF
--- a/mackerel-plugin-linux/lib/linux.go
+++ b/mackerel-plugin-linux/lib/linux.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -21,6 +22,8 @@ const (
 	pathStat   = "/proc/stat"
 	pathSysfs  = "/sys"
 )
+
+var collectVirtualDevice = regexp.MustCompile("^fio[a-z]+$") // ioDrive(FusionIO)
 
 // metric value structure
 // note: all metrics are add dynamic at collect*().
@@ -280,7 +283,9 @@ func collectDiskStats(path string, p *map[string]interface{}) error {
 
 		// exclude virtual device
 		if strings.Index(realPath, "/devices/virtual/") != -1 {
-			continue
+			if !collectVirtualDevice.Match([]byte(name)) {
+				continue
+			}
 		}
 
 		// exclude removable device

--- a/mackerel-plugin-linux/lib/linux_test.go
+++ b/mackerel-plugin-linux/lib/linux_test.go
@@ -167,3 +167,35 @@ func TestParseDiskStat(t *testing.T) {
 	assert.EqualValues(t, stat[fmt.Sprintf("tsreading_%s", name)], 36470)
 	assert.EqualValues(t, stat[fmt.Sprintf("tswriting_%s", name)], 1648460)
 }
+
+func TestCollectVirtualDevice(t *testing.T) {
+	cases := []struct {
+		name     string
+		expected bool
+	}{
+		{
+			name:     "loop0",
+			expected: false,
+		},
+		{
+			name:     "dm-3",
+			expected: false,
+		},
+		{
+			name:     "fioa", // ioDrive(FusionIO) #1
+			expected: true,
+		},
+		{
+			name:     "fioz", // ioDrive(FusionIO) #26
+			expected: true,
+		},
+		{
+			name:     "fioaa", // ioDrive(FusionIO) #27
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		assert.EqualValues(t, c.expected, collectVirtualDevice.Match([]byte(c.name)))
+	}
+}


### PR DESCRIPTION
Fix for collectiong ioDrive(FusionIO) diskstats.

- ioDrive device name is "fioa", "fiob", ...

```
$ ls -l /sys/block/
total 0
...
lrwxrwxrwx 1 root root 0 Sep 29  2017 fioa -> ../devices/virtual/block/fioa
...
```