### PR TITLE
[aws-rds]add BurstBalance metric

### DIFF
--- a/mackerel-plugin-aws-rds/lib/aws-rds.go
+++ b/mackerel-plugin-aws-rds/lib/aws-rds.go
@@ -189,6 +189,13 @@ func (p RDSPlugin) baseGraphDefs() map[string]mp.Graphs {
 				{Name: "NetworkReceiveThroughput", Label: "Receive"},
 			},
 		},
+		p.Prefix + ".BurstBalance": {
+			Label: p.LabelPrefix + " Burst Balance",
+			Unit:  "percentage",
+			Metrics: []mp.Metrics{
+				{Name: "BurstBalance", Label: "BurstBalance"},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html

> BurstBalance
> The percent of General Purpose SSD (gp2) burst-bucket I/O credits available.
> Units: Percent