### PR TITLE
[aws-rds]fix unit for some metrics

### DIFF
--- a/mackerel-plugin-aws-rds/lib/aws-rds.go
+++ b/mackerel-plugin-aws-rds/lib/aws-rds.go
@@ -100,8 +100,8 @@ func (p RDSPlugin) FetchMetrics() (map[string]float64, error) {
 func (p RDSPlugin) baseGraphDefs() map[string]mp.Graphs {
 	return map[string]mp.Graphs{
 		p.Prefix + ".DiskQueueDepth": {
-			Label: p.LabelPrefix + " BinLogDiskUsage",
-			Unit:  "bytes",
+			Label: p.LabelPrefix + " Disk Queue Depth",
+			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "DiskQueueDepth", Label: "Depth"},
 			},

--- a/mackerel-plugin-aws-rds/lib/metrics.go
+++ b/mackerel-plugin-aws-rds/lib/metrics.go
@@ -147,8 +147,8 @@ func (p RDSPlugin) auroraGraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		p.Prefix + ".Throughput": {
-			Label: p.LabelPrefix + " Throughput",
-			Unit:  "bytes/sec",
+			Label: p.LabelPrefix + " Throughput [ops/sec]",
+			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "SelectThroughput", Label: "Select"},
 				{Name: "InsertThroughput", Label: "Insert"},


### PR DESCRIPTION
DiskQueueDepth: fixed typo

> DiskQueueDepth
> The number of outstanding IOs (read/write requests) waiting to access the disk.
> Units: Count

*Throughput(aurora): fixed unit

> SelectThroughput: The average number of select queries per second.
> InsertThroughput: The average number of insert queries per second.
> UpdateThroughput: The average number of update queries per second.
> DeleteThroughput: The average number of delete queries per second.
> CommitThroughput: The average number of commit operations per second.
> DDLThroughput: The average number of DDL requests per second.
> DMLThroughput: The average number of inserts, updates, and deletes per second.

cf https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/rds-metricscollected.html