### PR TITLE
[aws-s3-requests] CloudWatch GetMetricStatics parameters

### DIFF
--- a/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
+++ b/mackerel-plugin-aws-s3-requests/lib/aws-s3-requests.go
@@ -97,10 +97,10 @@ func getLastPointFromCloudWatch(cw cloudwatchiface.CloudWatchAPI, bucketName str
 		statsInput[i] = aws.String(typ.Type)
 	}
 	input := &cloudwatch.GetMetricStatisticsInput{
-		StartTime:  aws.Time(now.Add(time.Duration(180) * time.Second * -1)), // 3 min
+		StartTime:  aws.Time(now.Add(time.Duration(300) * time.Second * -1)), // 5 min
 		EndTime:    aws.Time(now),
 		MetricName: aws.String(metric.CloudWatchName),
-		Period:     aws.Int64(600),
+		Period:     aws.Int64(60),
 		Statistics: statsInput,
 		Namespace:  aws.String(namespace),
 	}


### PR DESCRIPTION
Adjust s3 CloudWatch GetMetricStaticsInput.
- CloudWatch metrics sometimes delays more than 3 minutes, therefore increase the duration
- S3 requests statistics are available with 1 min resolution, so set period to 60