### PR TITLE
[aws-kinesis-streams] Collect (Write|Read)ProvisionedThroughputExceeded metrics correctly

### DIFF
--- a/mackerel-plugin-aws-kinesis-streams/lib/aws-kinesis-streams.go
+++ b/mackerel-plugin-aws-kinesis-streams/lib/aws-kinesis-streams.go
@@ -141,8 +141,8 @@ func (p KinesisStreamsPlugin) FetchMetrics() (map[string]interface{}, error) {
 		{CloudWatchName: "PutRecords.Latency", MackerelName: "PutRecordsLatency", Type: metricsTypeAverage},
 		{CloudWatchName: "PutRecords.Records", MackerelName: "PutRecordsRecords", Type: metricsTypeSum},
 		{CloudWatchName: "PutRecords.Success", MackerelName: "PutRecordsSuccess", Type: metricsTypeSum},
-		{CloudWatchName: "ReadProvidionedThroughputExceeded", MackerelName: "ReadThroughputExceeded", Type: metricsTypeAverage},
-		{CloudWatchName: "WriteProvidionedThroughputExceeded", MackerelName: "WriteThroughputExceeded", Type: metricsTypeAverage},
+		{CloudWatchName: "ReadProvisionedThroughputExceeded", MackerelName: "ReadThroughputExceeded", Type: metricsTypeAverage},
+		{CloudWatchName: "WriteProvisionedThroughputExceeded", MackerelName: "WriteThroughputExceeded", Type: metricsTypeAverage},
 	} {
 		v, err := p.getLastPoint(met)
 		if err == nil {


### PR DESCRIPTION
We have mistaken metric names of aws kinesis stream, so we failed to collect following metrics

- ReadProvisionedThroughputExceeded
- WriteProvisionedThroughputExceeded

This pull request fixes these names.