### PR TITLE
add MSSQL plugin

### DIFF
--- a/mackerel-plugin-mssql/README.md
+++ b/mackerel-plugin-mssql/README.md
@@ -16,3 +16,9 @@ mackerel-plugin-mssql [-metric-key-prefix=<PREFIX>] [-instance=<SQLSERVER|SQLEXP
 command = "/path/to/mackerel-plugin-mssql"
 ```
 
+## Supported Version
+
+This plugin support following version (or later) of SQL servers.
+
+* Microsoft SQL Server 2017
+* Microsoft SQL Express 2017

--- a/mackerel-plugin-mssql/README.md
+++ b/mackerel-plugin-mssql/README.md
@@ -6,7 +6,7 @@ MSSQL custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-mssql [-prefix=<PREFIX>] [-instance=<SQLSERVER|SQLEXPRESS>] [-tempfile=<tempfile>]
+mackerel-plugin-mssql [-metric-key-prefix=<PREFIX>] [-instance=<SQLSERVER|SQLEXPRESS>] [-tempfile=<tempfile>]
 ```
 
 ## Example of mackerel-agent.conf

--- a/mackerel-plugin-mssql/README.md
+++ b/mackerel-plugin-mssql/README.md
@@ -22,3 +22,7 @@ This plugin support following version (or later) of SQL servers.
 
 * Microsoft SQL Server 2017
 * Microsoft SQL Express 2017
+
+## Development
+
+To update lib/wmi.go, you need to install [mattn/wmi2struct](https://github.com/mattn/wmi2struct) on Windows.

--- a/mackerel-plugin-mssql/README.md
+++ b/mackerel-plugin-mssql/README.md
@@ -1,0 +1,18 @@
+mackerel-plugin-mssql
+=====================
+
+MSSQL custom metrics plugin for mackerel.io agent.
+
+## Synopsis
+
+```shell
+mackerel-plugin-mssql [-prefix=<PREFIX>] [-instance=<SQLSERVER|SQLEXPRESS>] [-tempfile=<tempfile>]
+```
+
+## Example of mackerel-agent.conf
+
+```
+[plugin.metrics.mssql]
+command = "/path/to/mackerel-plugin-mssql"
+```
+

--- a/mackerel-plugin-mssql/lib/mssql_other.go
+++ b/mackerel-plugin-mssql/lib/mssql_other.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package mpmssql
+
+// Do the plugin
+func Do() {
+	panic("The mackerel-plugin-mssql does not work on non Windows environment, of course.")
+}

--- a/mackerel-plugin-mssql/lib/mssql_test.go
+++ b/mackerel-plugin-mssql/lib/mssql_test.go
@@ -1,0 +1,48 @@
+// +build windows
+
+package mpmssql
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func instance() (string, error) {
+	b, err := exec.Command("wmi2struct", "-l").CombinedOutput()
+	if err != nil {
+		return "", nil
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.Contains(line, "SQLEXPRESS") {
+			return "SQLEXPRESS", nil
+		}
+		if strings.Contains(line, "SQLServer") {
+			return "SQLSERVER", nil
+		}
+	}
+	return "", nil
+}
+
+func TestGraphDefinition(t *testing.T) {
+	var mssql MSSQLPlugin
+
+	name, err := instance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name == "" {
+		t.Skip("SQLServer/SQLEXPRESS is not installed")
+	}
+	graphdef := mssql.GraphDefinition()
+	if len(graphdef) != 3 {
+		t.Errorf("GraphDefinition: %d definitions should be exists", len(graphdef))
+	}
+	values, err := mssql.FetchMetrics()
+	if err != nil {
+		t.Errorf("FetchMetrics: %v", err)
+	}
+	if len(values) != 10 {
+		t.Errorf("FetchMetrics: %d metrics must be exists", len(values))
+	}
+}

--- a/mackerel-plugin-mssql/lib/mssql_windows.go
+++ b/mackerel-plugin-mssql/lib/mssql_windows.go
@@ -1,0 +1,183 @@
+// +build windows
+
+package mpmssql
+
+//go:generate wmi2struct -n -p mpmssql -o wmi.go Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSBufferManager Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSSQLStatistics Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSGeneralStatistics Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSAccessMethods
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/StackExchange/wmi"
+	mp "github.com/mackerelio/go-mackerel-plugin"
+	"github.com/mackerelio/golib/logging"
+)
+
+var logger = logging.GetLogger("metrics.plugin.mssql")
+
+// MSSQLPlugin store the name of servers
+type MSSQLPlugin struct {
+	prefix   string
+	instance string
+}
+
+// MetricKeyPrefix retruns the metrics key prefix
+func (m MSSQLPlugin) MetricKeyPrefix() string {
+	if m.prefix == "" {
+		m.prefix = "mssql"
+	}
+	return m.prefix
+}
+
+func (m MSSQLPlugin) name(n string) string {
+	if m.instance == "SQLSERVER" {
+		return "Win32_PerfRawData_MSSQLSERVER_SQLServer" + n
+	} else {
+		return "Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESS" + n
+	}
+}
+
+// FetchMetrics interface for mackerelplugin
+func (m MSSQLPlugin) FetchMetrics() (map[string]float64, error) {
+	var bufferManager []Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSBufferManager
+	var sqlStatistics []Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSSQLStatistics
+	var generalStatistics []Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSGeneralStatistics
+	var accessMethods []Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSAccessMethods
+
+	var err error
+	err = wmi.Query("select * from "+m.name("BufferManager"), &bufferManager)
+	if err != nil {
+		return nil, err
+	}
+	err = wmi.Query("select * from "+m.name("SQLStatistics"), &sqlStatistics)
+	if err != nil {
+		return nil, err
+	}
+	err = wmi.Query("select * from "+m.name("GeneralStatistics"), &generalStatistics)
+	if err != nil {
+		return nil, err
+	}
+	err = wmi.Query("select * from "+m.name("AccessMethods"), &accessMethods)
+	if err != nil {
+		return nil, err
+	}
+
+	stat := make(map[string]float64)
+	stat["buffer_cache_hit_ratio"] = float64(bufferManager[0].Buffercachehitratio)
+	stat["buffer_page_life_expectancy"] = float64(bufferManager[0].Pagelifeexpectancy)
+	stat["buffer_checkpoint_pages"] = float64(bufferManager[0].CheckpointpagesPersec)
+	stat["stats_batch_requests"] = float64(sqlStatistics[0].BatchRequestsPersec)
+	stat["stats_sql_compilations"] = float64(sqlStatistics[0].SQLCompilationsPersec)
+	stat["stats_sql_recompilations"] = float64(sqlStatistics[0].SQLReCompilationsPersec)
+	stat["stats_connections"] = float64(generalStatistics[0].UserConnections)
+	stat["stats_lock_waits"] = float64(generalStatistics[0].SQLTraceIOProviderLockWaits)
+	stat["stats_procs_blocked"] = float64(generalStatistics[0].Processesblocked)
+	stat["access_page_splits"] = float64(accessMethods[0].PageSplitsPersec)
+	return stat, nil
+}
+
+// GraphDefinition interface for mackerelplugin
+func (m MSSQLPlugin) GraphDefinition() map[string](mp.Graphs) {
+	labelPrefix := strings.Title(strings.Replace(m.MetricKeyPrefix(), "mssql", "MSSQL", -1))
+	return map[string](mp.Graphs){
+		"buffer": mp.Graphs{
+			Label: labelPrefix + " Buffer",
+			Unit:  mp.UnitInteger,
+			Metrics: []mp.Metrics{
+				{
+					Name:    "buffer_cache_hit_ratio",
+					Label:   "Cache Hit Ratio",
+					Diff:    false,
+					Stacked: true,
+				},
+				{
+					Name:    "buffer_page_life_expectancy",
+					Label:   "Page Life Expectancy",
+					Diff:    false,
+					Stacked: true,
+				},
+				{
+					Name:    "buffer_checkpoint_pages",
+					Label:   "Checkpoint Pages",
+					Diff:    false,
+					Stacked: true,
+				},
+			},
+		},
+		"stats": mp.Graphs{
+			Label: labelPrefix + " Stats",
+			Unit:  mp.UnitInteger,
+			Metrics: []mp.Metrics{
+				{
+					Name:    "stats_batch_requests",
+					Label:   "Batch Requests",
+					Diff:    false,
+					Stacked: true,
+				},
+				{
+					Name:    "stats_sql_compilations",
+					Label:   "SQL Compilations",
+					Diff:    false,
+					Stacked: true,
+				},
+				{
+					Name:    "stats_sql_recompilations",
+					Label:   "SQL Re-Compilations",
+					Diff:    false,
+					Stacked: true,
+				},
+				{
+					Name:    "stats_connections",
+					Label:   "Connections",
+					Diff:    false,
+					Stacked: true,
+				},
+				{
+					Name:    "stats_lock_waits",
+					Label:   "Lock Waits",
+					Diff:    false,
+					Stacked: true,
+				},
+				{
+					Name:    "stats_procs_blocked",
+					Label:   "Procs Blocked",
+					Diff:    false,
+					Stacked: true,
+				},
+			},
+		},
+		"access": mp.Graphs{
+			Label: labelPrefix + " Access",
+			Unit:  mp.UnitInteger,
+			Metrics: []mp.Metrics{
+				{
+					Name:    "access_page_splits",
+					Label:   "Page Splits",
+					Diff:    false,
+					Stacked: true,
+				},
+			},
+		},
+	}
+}
+
+// Do the plugin
+func Do() {
+	optPrefix := flag.String("metric-key-prefix", "mssql", "Metric key prefix")
+	optInstance := flag.String("instance", "SQLSERVER", "Instance name of MSSQL(SQLSERVER or SQLEXPRESS)")
+	optTempfile := flag.String("tempfile", "", "Temp file name")
+	flag.Parse()
+
+	var plugin MSSQLPlugin
+	plugin.prefix = *optPrefix
+	plugin.instance = strings.ToUpper(*optInstance)
+	helper := mp.NewMackerelPlugin(plugin)
+
+	if *optTempfile != "" {
+		helper.Tempfile = *optTempfile
+	} else {
+		helper.Tempfile = "/tmp/mackerel-plugin-mssql"
+	}
+
+	helper.Run()
+}

--- a/mackerel-plugin-mssql/lib/mssql_windows.go
+++ b/mackerel-plugin-mssql/lib/mssql_windows.go
@@ -6,6 +6,7 @@ package mpmssql
 
 import (
 	"flag"
+	"os"
 	"strings"
 
 	"github.com/StackExchange/wmi"
@@ -168,9 +169,14 @@ func Do() {
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
 
+	instance := strings.ToUpper(*optInstance)
+	if instance != "SQLSERVER" && instance != "SQLEXPRESS" {
+		flag.Usage()
+		os.Exit(2)
+	}
 	plugin := MSSQLPlugin{
 		prefix:   *optPrefix,
-		instance: strings.ToUpper(*optInstance),
+		instance: instance,
 	}
 	helper := mp.NewMackerelPlugin(plugin)
 	helper.Tempfile = *optTempfile

--- a/mackerel-plugin-mssql/lib/mssql_windows.go
+++ b/mackerel-plugin-mssql/lib/mssql_windows.go
@@ -168,16 +168,11 @@ func Do() {
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
 
-	var plugin MSSQLPlugin
-	plugin.prefix = *optPrefix
-	plugin.instance = strings.ToUpper(*optInstance)
-	helper := mp.NewMackerelPlugin(plugin)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = "/tmp/mackerel-plugin-mssql"
+	plugin := MSSQLPlugin{
+		prefix:   *optPrefix,
+		instance: strings.ToUpper(*optInstance),
 	}
-
+	helper := mp.NewMackerelPlugin(plugin)
+	helper.Tempfile = *optTempfile
 	helper.Run()
 }

--- a/mackerel-plugin-mssql/lib/mssql_windows.go
+++ b/mackerel-plugin-mssql/lib/mssql_windows.go
@@ -94,7 +94,7 @@ func (m MSSQLPlugin) GraphDefinition() map[string](mp.Graphs) {
 				{
 					Name:    "buffer_page_life_expectancy",
 					Label:   "Page Life Expectancy",
-					Diff:    false,
+					Diff:    true,
 					Stacked: true,
 				},
 				{
@@ -112,19 +112,19 @@ func (m MSSQLPlugin) GraphDefinition() map[string](mp.Graphs) {
 				{
 					Name:    "stats_batch_requests",
 					Label:   "Batch Requests",
-					Diff:    false,
+					Diff:    true,
 					Stacked: true,
 				},
 				{
 					Name:    "stats_sql_compilations",
 					Label:   "SQL Compilations",
-					Diff:    false,
+					Diff:    true,
 					Stacked: true,
 				},
 				{
 					Name:    "stats_sql_recompilations",
 					Label:   "SQL Re-Compilations",
-					Diff:    false,
+					Diff:    true,
 					Stacked: true,
 				},
 				{
@@ -154,7 +154,7 @@ func (m MSSQLPlugin) GraphDefinition() map[string](mp.Graphs) {
 				{
 					Name:    "access_page_splits",
 					Label:   "Page Splits",
-					Diff:    false,
+					Diff:    true,
 					Stacked: true,
 				},
 			},

--- a/mackerel-plugin-mssql/lib/wmi.go
+++ b/mackerel-plugin-mssql/lib/wmi.go
@@ -1,0 +1,145 @@
+// +build windows
+
+package mpmssql
+
+// Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSBufferManager is struct for WMI
+type Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSBufferManager struct {
+	BackgroundwriterpagesPersec   uint16
+	Buffercachehitratio           uint16
+	Buffercachehitratio_Base      uint16
+	CheckpointpagesPersec         uint16
+	Databasepages                 uint16
+	Extensionallocatedpages       uint16
+	Extensionfreepages            uint16
+	Extensioninuseaspercentage    uint16
+	ExtensionoutstandingIOcounter uint16
+	ExtensionpageevictionsPersec  uint16
+	ExtensionpagereadsPersec      uint16
+	Extensionpageunreferencedtime uint16
+	ExtensionpagewritesPersec     uint16
+	FreeliststallsPersec          uint16
+	Frequency_Object              uint16
+	Frequency_PerfTime            uint16
+	Frequency_Sys100NS            uint16
+	IntegralControllerSlope       uint16
+	LazywritesPersec              uint16
+	Pagelifeexpectancy            uint16
+	PagelookupsPersec             uint16
+	PagereadsPersec               uint16
+	PagewritesPersec              uint16
+	ReadaheadpagesPersec          uint16
+	ReadaheadtimePersec           uint16
+	Targetpages                   uint16
+	Timestamp_Object              uint16
+	Timestamp_PerfTime            uint16
+	Timestamp_Sys100NS            uint16
+}
+
+// Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSSQLStatistics is struct for WMI
+type Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSSQLStatistics struct {
+	AutoParamAttemptsPersec       uint16
+	BatchRequestsPersec           uint16
+	FailedAutoParamsPersec        uint16
+	ForcedParameterizationsPersec uint16
+	Frequency_Object              uint16
+	Frequency_PerfTime            uint16
+	Frequency_Sys100NS            uint16
+	GuidedplanexecutionsPersec    uint16
+	MisguidedplanexecutionsPersec uint16
+	SafeAutoParamsPersec          uint16
+	SQLAttentionrate              uint16
+	SQLCompilationsPersec         uint16
+	SQLReCompilationsPersec       uint16
+	Timestamp_Object              uint16
+	Timestamp_PerfTime            uint16
+	Timestamp_Sys100NS            uint16
+	UnsafeAutoParamsPersec        uint16
+}
+
+// Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSGeneralStatistics is struct for WMI
+type Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSGeneralStatistics struct {
+	ActiveTempTables              uint16
+	ConnectionResetPersec         uint16
+	EventNotificationsDelayedDrop uint16
+	Frequency_Object              uint16
+	Frequency_PerfTime            uint16
+	Frequency_Sys100NS            uint16
+	HTTPAuthenticatedRequests     uint16
+	LogicalConnections            uint16
+	LoginsPersec                  uint16
+	LogoutsPersec                 uint16
+	MarsDeadlocks                 uint16
+	Nonatomicyieldrate            uint16
+	Processesblocked              uint16
+	SOAPEmptyRequests             uint16
+	SOAPMethodInvocations         uint16
+	SOAPSessionInitiateRequests   uint16
+	SOAPSessionTerminateRequests  uint16
+	SOAPSQLRequests               uint16
+	SOAPWSDLRequests              uint16
+	SQLTraceIOProviderLockWaits   uint16
+	Tempdbrecoveryunitid          uint16
+	Tempdbrowsetid                uint16
+	TempTablesCreationRate        uint16
+	TempTablesForDestruction      uint16
+	Timestamp_Object              uint16
+	Timestamp_PerfTime            uint16
+	Timestamp_Sys100NS            uint16
+	TraceEventNotificationQueue   uint16
+	Transactions                  uint16
+	UserConnections               uint16
+}
+
+// Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSAccessMethods is struct for WMI
+type Win32_PerfRawData_MSSQLSQLEXPRESS_MSSQLSQLEXPRESSAccessMethods struct {
+	AUcleanupbatchesPersec        uint16
+	AUcleanupsPersec              uint16
+	ByreferenceLobCreateCount     uint16
+	ByreferenceLobUseCount        uint16
+	CountLobReadahead             uint16
+	CountPullInRow                uint16
+	CountPushOffRow               uint16
+	DeferreddroppedAUs            uint16
+	DeferredDroppedrowsets        uint16
+	DroppedrowsetcleanupsPersec   uint16
+	DroppedrowsetsskippedPersec   uint16
+	ExtentDeallocationsPersec     uint16
+	ExtentsAllocatedPersec        uint16
+	FailedAUcleanupbatchesPersec  uint16
+	Failedleafpagecookie          uint16
+	Failedtreepagecookie          uint16
+	ForwardedRecordsPersec        uint16
+	FreeSpacePageFetchesPersec    uint16
+	FreeSpaceScansPersec          uint16
+	Frequency_Object              uint16
+	Frequency_PerfTime            uint16
+	Frequency_Sys100NS            uint16
+	FullScansPersec               uint16
+	IndexSearchesPersec           uint16
+	InSysXactwaitsPersec          uint16
+	LobHandleCreateCount          uint16
+	LobHandleDestroyCount         uint16
+	LobSSProviderCreateCount      uint16
+	LobSSProviderDestroyCount     uint16
+	LobSSProviderTruncationCount  uint16
+	MixedpageallocationsPersec    uint16
+	PagecompressionattemptsPersec uint16
+	PageDeallocationsPersec       uint16
+	PagesAllocatedPersec          uint16
+	PagescompressedPersec         uint16
+	PageSplitsPersec              uint16
+	ProbeScansPersec              uint16
+	RangeScansPersec              uint16
+	ScanPointRevalidationsPersec  uint16
+	SkippedGhostedRecordsPersec   uint16
+	TableLockEscalationsPersec    uint16
+	Timestamp_Object              uint16
+	Timestamp_PerfTime            uint16
+	Timestamp_Sys100NS            uint16
+	Usedleafpagecookie            uint16
+	Usedtreepagecookie            uint16
+	WorkfilesCreatedPersec        uint16
+	WorktablesCreatedPersec       uint16
+	WorktablesFromCacheRatio      uint16
+	WorktablesFromCacheRatio_Base uint16
+}

--- a/mackerel-plugin-mssql/main.go
+++ b/mackerel-plugin-mssql/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-mssql/lib"
+
+func main() {
+	mpmssql.Do()
+}


### PR DESCRIPTION
This add MSSQL plugin that support SQL Server and SQL Express both. Below is usage of this plugin.

```
mackerel-plugin-mssql [-instance=<SQLSERVER|SQLEXPRESS>] [-tempfile=<tempfile>]
```

![MSSQL plugin](https://user-images.githubusercontent.com/10111/42694724-47c243b2-86ee-11e8-996a-6572f3e9b57a.png)
