### PR TITLE
Improve jvm error handling

### DIFF
--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -70,7 +70,7 @@ func (m JVMPlugin) fetchJstatMetrics(option string) (map[string]float64, error) 
 	if err == nil && exitStatus.IsTimedOut() {
 		err = fmt.Errorf("jstat command timed out")
 	}
-	if err != nil {
+	if err != nil || exitStatus.GetChildExitCode() != 0 {
 		logger.Errorf("Failed to run exec jstat. %s. Please run with the java process user.", err)
 		return nil, err
 	}

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -76,6 +76,10 @@ func (m JVMPlugin) fetchJstatMetrics(option string) (map[string]float64, error) 
 	}
 
 	lines := strings.Split(string(stdout), "\n")
+	if len(lines) < 2 {
+		logger.Warningf("Failed to parse output. output has only %d lines.", len(lines))
+		return nil, fmt.Errorf("output of jstat command does not have enough lines")
+	}
 	keys := strings.Fields(lines[0])
 	values := strings.Fields(lines[1])
 


### PR DESCRIPTION
- Avoid panic which happens when jstat could not fetch stats
    - In that case jstat exits with non-zero exit status
- Ensure output of jstat has >= 2 (actually 2) lines