### PR TITLE
Set (default) User-Agent header to HTTP requests

### DIFF
--- a/mackerel-plugin-apache2/lib/apache2.go
+++ b/mackerel-plugin-apache2/lib/apache2.go
@@ -205,6 +205,12 @@ func getApache2Metrics(host string, port uint16, path string, header []string) (
 			req.Header.Set(k, v)
 		}
 	}
+
+	// set default User-Agent unless specified by header
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", "mackerel-plugin-apache2")
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err

--- a/mackerel-plugin-elasticsearch/lib/elasticsearch.go
+++ b/mackerel-plugin-elasticsearch/lib/elasticsearch.go
@@ -96,7 +96,13 @@ type ElasticsearchPlugin struct {
 
 // FetchMetrics interface for mackerelplugin
 func (p ElasticsearchPlugin) FetchMetrics() (map[string]float64, error) {
-	resp, err := http.Get(p.URI + "/_nodes/_local/stats")
+	req, err := http.NewRequest(http.MethodGet, p.URI+"/_nodes/_local/stats", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-elasticsearch")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -87,7 +87,13 @@ func (f *FluentdMetrics) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
 
 // FetchMetrics interface for mackerelplugin
 func (f FluentdMetrics) FetchMetrics() (map[string]interface{}, error) {
-	resp, err := http.Get(f.Target)
+	req, err := http.NewRequest(http.MethodGet, f.Target, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-fluentd")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-flume/lib/flume.go
+++ b/mackerel-plugin-flume/lib/flume.go
@@ -139,7 +139,13 @@ func (p *FlumePlugin) FetchMetrics() (map[string]float64, error) {
 }
 
 func (p *FlumePlugin) getMetrics() (map[string]interface{}, error) {
-	res, err := http.Get(p.URI)
+	req, err := http.NewRequest(http.MethodGet, p.URI, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-flume")
+
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-gostats/lib/mackerel-plugin-gostats.go
+++ b/mackerel-plugin-gostats/lib/mackerel-plugin-gostats.go
@@ -104,7 +104,13 @@ func (m GostatsPlugin) GraphDefinition() map[string]mp.Graphs {
 
 // FetchMetrics interface for mackerelplugin
 func (m GostatsPlugin) FetchMetrics() (map[string]float64, error) {
-	resp, err := http.Get(m.URI)
+	req, err := http.NewRequest(http.MethodGet, m.URI, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-gostats")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-graphite/lib/graphite.go
+++ b/mackerel-plugin-graphite/lib/graphite.go
@@ -170,7 +170,13 @@ func printValue(w io.Writer, key string, value interface{}, now uint64, unit str
 
 // fetchData fetches metrics data from -15min
 func (p GraphitePlugin) fetchData() ([]metrics, error) {
-	res, err := http.Get(p.URL)
+	req, err := http.NewRequest(http.MethodGet, p.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-graphite")
+
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-h2o/lib/h2o.go
+++ b/mackerel-plugin-h2o/lib/h2o.go
@@ -234,6 +234,11 @@ func (h2o H2OPlugin) FetchMetrics() (map[string]float64, error) {
 			req.Header.Set(k, v)
 		}
 	}
+	// set default User-Agent unless specified by h2o.Header
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", "mackerel-plugin-h2o")
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/mackerel-plugin-haproxy/lib/haproxy.go
+++ b/mackerel-plugin-haproxy/lib/haproxy.go
@@ -74,6 +74,7 @@ func (p HAProxyPlugin) fetchMetricsFromTCP() (map[string]float64, error) {
 	if p.Username != "" {
 		req.SetBasicAuth(p.Username, p.Password)
 	}
+	req.Header.Set("User-Agent", "mackerel-plugin-haproxy")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/mackerel-plugin-jmx-jolokia/lib/jmx-jolokia.go
+++ b/mackerel-plugin-jmx-jolokia/lib/jmx-jolokia.go
@@ -154,7 +154,13 @@ func (j JmxJolokiaPlugin) fetchOperatingSystem(stat map[string]interface{}) erro
 }
 
 func (j JmxJolokiaPlugin) executeGetRequest(mbean string) (*JmxJolokiaResponse, error) {
-	resp, err := http.Get(j.Target + mbean)
+	req, err := http.NewRequest(http.MethodGet, j.Target+mbean, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-jmx-jolokia")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-nginx/lib/nginx.go
+++ b/mackerel-plugin-nginx/lib/nginx.go
@@ -85,6 +85,12 @@ func (n NginxPlugin) FetchMetrics() (map[string]interface{}, error) {
 			req.Header.Set(k, v)
 		}
 	}
+
+	// set default User-Agent unless specified by n.Header
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", "mackerel-plugin-nginx")
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/mackerel-plugin-php-apc/lib/php-apc.go
+++ b/mackerel-plugin-php-apc/lib/php-apc.go
@@ -119,7 +119,13 @@ func parsePhpApcStatus(str string, p *map[string]float64) error {
 // Getting php-apc status from server-status module data.
 func getPhpApcMetrics(host string, port uint16, path string) (string, error) {
 	uri := "http://" + host + ":" + strconv.FormatUint(uint64(port), 10) + path
-	resp, err := http.Get(uri)
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-php-apc")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/mackerel-plugin-php-fpm/lib/php-fpm.go
+++ b/mackerel-plugin-php-fpm/lib/php-fpm.go
@@ -120,7 +120,13 @@ func getStatus(p PhpFpmPlugin) (*PhpFpmStatus, error) {
 		Timeout: timeout,
 	}
 
-	res, err := client.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-php-fpm")
+
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-php-opcache/lib/php-opcache.go
+++ b/mackerel-plugin-php-opcache/lib/php-opcache.go
@@ -103,7 +103,13 @@ func parsePhpOpcacheStatus(str string, p *map[string]float64) error {
 
 func getPhpOpcacheMetrics(host string, port uint16, path string) (string, error) {
 	uri := "http://" + host + ":" + strconv.FormatUint(uint64(port), 10) + path
-	resp, err := http.Get(uri)
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-php-opcache")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/mackerel-plugin-plack/lib/plack.go
+++ b/mackerel-plugin-plack/lib/plack.go
@@ -76,7 +76,13 @@ type PlackServerStatus struct {
 
 // FetchMetrics interface for mackerelplugin
 func (p PlackPlugin) FetchMetrics() (map[string]interface{}, error) {
-	resp, err := http.Get(p.URI)
+	req, err := http.NewRequest(http.MethodGet, p.URI, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-plack")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-rack-stats/lib/rack.go
+++ b/mackerel-plugin-rack-stats/lib/rack.go
@@ -62,10 +62,11 @@ func parseBody(r io.Reader, index string) (stats map[string]interface{}, err err
 
 func parseBodyHTTP(uri, port string) (stats map[string]interface{}, err error) {
 	var req *http.Request
-	req, err = http.NewRequest("GET", uri, nil)
+	req, err = http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return stats, err
 	}
+	req.Header.Set("User-Agent", "mackerel-plugin-rack-status")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return stats, err
@@ -87,7 +88,12 @@ func parseBodyUnix(path string) (stats map[string]interface{}, err error) {
 	}
 
 	client := &http.Client{Transport: tr}
-	resp, err := client.Get(fmt.Sprintf("http://dummy/%s", strings.TrimLeft(path, "/")))
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://dummy/%s", strings.TrimLeft(path, "/")), nil)
+	if err != nil {
+		return stats, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-rack-status")
+	resp, err := client.Do(req)
 
 	if err != nil {
 		return stats, err

--- a/mackerel-plugin-redash/lib/unsafe_stats.go
+++ b/mackerel-plugin-redash/lib/unsafe_stats.go
@@ -36,7 +36,13 @@ func getUnsafeStats(p RedashPlugin) (*UnsafeRedashStats, error) {
 	client := http.Client{
 		Timeout: timeout,
 	}
-	resp, err := client.Get(p.URI)
+	req, err := http.NewRequest(http.MethodGet, p.URI, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-redash")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -39,7 +39,13 @@ type SolrPlugin struct {
 }
 
 func (s *SolrPlugin) getStats(url string) (map[string]interface{}, error) {
-	resp, err := http.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mackerel-plugin-solr")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Errorf("Failed to %s", err)
 		return nil, err

--- a/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
+++ b/mackerel-plugin-uwsgi-vassal/lib/uwsgi_vassal.go
@@ -137,7 +137,13 @@ func (p UWSGIVassalPlugin) FetchMetrics() (map[string]float64, error) {
 		defer conn.Close()
 		decoder = json.NewDecoder(conn)
 	} else if strings.HasPrefix(p.Socket, "http://") {
-		resp, err := http.Get(p.Socket)
+		req, err := http.NewRequest(http.MethodGet, p.Socket, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", "mackerel-plugin-uwsgi-vessal")
+
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously they're all `Go-http-client/x.y`.
(Probably we should announce this change)