### PR TITLE
[nit] Fix "go get" path for golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ deps:
 
 testdeps:
 	go get -d -v -t ./...
-	go get github.com/golang/lint/golint
-	go get golang.org/x/tools/cmd/cover
-	go get github.com/pierrre/gotestcover
-	go get github.com/mattn/goveralls
+	go get golang.org/x/lint/golint  \
+	  golang.org/x/tools/cmd/cover   \
+	  github.com/pierrre/gotestcover \
+	  github.com/mattn/goveralls
 
 check-release-deps:
 	@have_error=0; \


### PR DESCRIPTION
resolve the following error.

> can't load package: package github.com/golang/lint/golint: code in directory
> /path/to/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"