### PR TITLE
Add redash api-key option

### DIFF
--- a/mackerel-plugin-redash/README.md
+++ b/mackerel-plugin-redash/README.md
@@ -6,8 +6,10 @@ redash stats custom metrics plugin for [mackerel-agent](https://github.com/macke
 ## Synopsis
 
 ```shell
-mackerel-plugin-redash [-metric-key-prefix=redash] [-timeout=5] [-uri=http://localhost/api/admin/queries/tasks?api_key=hoge]
+mackerel-plugin-redash [-metric-key-prefix=redash] [-timeout=5] [-uri=http://localhost/api/admin/queries/tasks?api_key=hoge] [-api-key=YOUR_REDASH_API_KEY]
 ```
+
+`REDASH_API_KEY` environment variable is used as `api_key` query in uri if it is set.
 
 ## Example of mackerel-agent.conf
 

--- a/mackerel-plugin-redash/README.md
+++ b/mackerel-plugin-redash/README.md
@@ -6,7 +6,7 @@ redash stats custom metrics plugin for [mackerel-agent](https://github.com/macke
 ## Synopsis
 
 ```shell
-mackerel-plugin-redash [-metric-key-prefix=redash] [-timeout=5] [-uri=http://localhost/api/admin/queries/tasks?api_key=hoge] [-api-key=YOUR_REDASH_API_KEY]
+mackerel-plugin-redash -api-key=YOUR_REDASH_API_KEY [-metric-key-prefix=redash] [-timeout=5] [-uri=http://localhost/api/admin/queries/tasks]
 ```
 
 `REDASH_API_KEY` environment variable is used as `api_key` query in uri if it is set.

--- a/mackerel-plugin-redash/lib/redash.go
+++ b/mackerel-plugin-redash/lib/redash.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
+	"github.com/mackerelio/golib/logging"
 )
+
+var logger = logging.GetLogger("metrics.plugin.redash")
 
 // RedashPlugin mackerel plugin
 type RedashPlugin struct {
@@ -94,14 +97,18 @@ func (p RedashPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 // Do the plugin
 func Do() {
-	optURI := flag.String("uri", "http://localhost/api/admin/queries/tasks?api_key=hoge", "stats URI")
+	optURI := flag.String("uri", "http://localhost/api/admin/queries/tasks", "stats URI")
 	apiKey := flag.String("api-key", os.Getenv("REDASH_API_KEY"), "API key")
 	optPrefix := flag.String("metric-key-prefix", "redash", "Metric key prefix")
 	optTimeout := flag.Uint("timeout", 5, "Timeout")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
 
-	if *apiKey != "" {
+	if *apiKey == "" {
+		logger.Errorf("api-key is required")
+		flag.PrintDefaults()
+		os.Exit(1)
+	} else {
 		u, _ := url.Parse(*optURI)
 		query := u.Query()
 		query.Set("api_key", *apiKey)

--- a/mackerel-plugin-redash/lib/redash.go
+++ b/mackerel-plugin-redash/lib/redash.go
@@ -3,6 +3,8 @@ package mpredash
 import (
 	"flag"
 	"fmt"
+	"net/url"
+	"os"
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
@@ -93,10 +95,20 @@ func (p RedashPlugin) FetchMetrics() (map[string]interface{}, error) {
 // Do the plugin
 func Do() {
 	optURI := flag.String("uri", "http://localhost/api/admin/queries/tasks?api_key=hoge", "stats URI")
+	apiKey := flag.String("api-key", os.Getenv("REDASH_API_KEY"), "API key")
 	optPrefix := flag.String("metric-key-prefix", "redash", "Metric key prefix")
 	optTimeout := flag.Uint("timeout", 5, "Timeout")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	flag.Parse()
+
+	if *apiKey != "" {
+		u, _ := url.Parse(*optURI)
+		query := u.Query()
+		query.Set("api_key", *apiKey)
+		u.RawQuery = query.Encode()
+		newURIString := u.String()
+		optURI = &newURIString
+	}
 
 	p := RedashPlugin{
 		URI:     *optURI,


### PR DESCRIPTION
Add `-api-key` option.

Synopsis:

```
mackerel-plugin-redash [-metric-key-prefix=redash] [-timeout=5] \
 [-uri=http://localhost/api/admin/queries/tasks?api_key=hoge] \
 [-api-key=YOUR_REDASH_API_KEY]
```

The value of `-api_key` is used as uri's one if the option is presented or `REDASH_API_KEY` environment variable is set. 

Specially, an admin's API key of Redash is strong. I want to remove it in config file to prevent reading it from other users who are in the host.