### PR TITLE
[linux] consider the case where the width of the Netid column is only 5 in the output of ss

### DIFF
--- a/mackerel-plugin-linux/lib/linux.go
+++ b/mackerel-plugin-linux/lib/linux.go
@@ -381,8 +381,11 @@ func collectNetworkStat(p *map[string]interface{}) error {
 
 // parsing metrics from ss
 func parseSs(r io.Reader, p *map[string]interface{}) error {
-	status := 0
-	first := true
+	var (
+		status      = 0
+		first       = true
+		overstuffed = false
+	)
 	scanner := bufio.NewScanner(r)
 
 	for scanner.Scan() {
@@ -399,10 +402,18 @@ func parseSs(r io.Reader, p *map[string]interface{}) error {
 			} else if record[1] == "State" {
 				// for RHEL7
 				status = 1
+			} else if record[0] == "NetidState" {
+				status = 1
+				overstuffed = true
 			}
 		}
-		v, _ := (*p)[record[status]].(float64)
-		(*p)[record[status]] = v + 1
+		key := record[status]
+		if overstuffed && len(record[0]) > 5 {
+			key = record[0][5:]
+		}
+
+		v, _ := (*p)[key].(float64)
+		(*p)[key] = v + 1
 	}
 
 	return nil

--- a/mackerel-plugin-linux/lib/linux.go
+++ b/mackerel-plugin-linux/lib/linux.go
@@ -406,12 +406,12 @@ func parseSs(r io.Reader, p *map[string]interface{}) error {
 				status = 1
 				overstuffed = true
 			}
+			continue
 		}
 		key := record[status]
 		if overstuffed && len(record[0]) > 5 {
 			key = record[0][5:]
 		}
-
 		v, _ := (*p)[key].(float64)
 		(*p)[key] = v + 1
 	}

--- a/mackerel-plugin-linux/lib/linux_test.go
+++ b/mackerel-plugin-linux/lib/linux_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,54 +87,70 @@ func TestCollectNetworkStat(t *testing.T) {
 }
 
 func TestParseSs(t *testing.T) {
-	stub := `State      Recv-Q Send-Q                       Local Address:Port                         Peer Address:Port 
+	testCases := []struct {
+		name   string
+		input  string
+		expect map[string]interface{}
+	}{
+		{
+			name: "Cent6",
+			input: `State      Recv-Q Send-Q                       Local Address:Port                         Peer Address:Port 
 LISTEN     0      128                                     :::45103                                  :::*     
 LISTEN     0      128                                     :::111                                    :::* 
 TIME-WAIT  0      0                         ::ffff:127.0.0.1:80                       ::ffff:127.0.0.1:50082 
-ESTAB      0      0                              10.0.25.101:60826                         10.0.25.104:5672  `
-	stat := make(map[string]interface{})
-
-	err := parseSs(bytes.NewBufferString(stub), &stat)
-	assert.Nil(t, err)
-	assert.EqualValues(t, stat["LISTEN"], 2)
-	assert.EqualValues(t, stat["TIME-WAIT"], 1)
-	assert.EqualValues(t, stat["ESTAB"], 1)
-}
-
-func TestParseSs2(t *testing.T) {
-	stub := `Netid State      Recv-Q Send-Q                                      Local Address:Port                                        Peer Address:Port
+ESTAB      0      0                              10.0.25.101:60826                         10.0.25.104:5672  `,
+			expect: map[string]interface{}{
+				"LISTEN":    2.0,
+				"TIME-WAIT": 1.0,
+				"ESTAB":     1.0,
+			},
+		},
+		{
+			name: "Cent7",
+			input: `Netid State      Recv-Q Send-Q                                      Local Address:Port                                        Peer Address:Port
 nl    UNCONN     0      0                                                      18:0                                                       *
 p_raw UNCONN     0      0                                                       *:em2                                                     *
 u_dgr UNCONN     0      0                                                /dev/log 10549                                                  * 0
 u_dgr LISTEN     0      0                                       /run/udev/control 8552                                                   * 0
 u_str LISTEN     0      10                                  /var/run/acpid.socket 9649                                                   * 0
-u_str ESTAB      0      0                                    @/com/ubuntu/upstart 10582                                                  * 1887`
-	stat := make(map[string]interface{})
+u_str ESTAB      0      0                                    @/com/ubuntu/upstart 10582                                                  * 1887`,
 
-	err := parseSs(bytes.NewBufferString(stub), &stat)
-	assert.Nil(t, err)
-	assert.EqualValues(t, stat["LISTEN"], 2)
-	assert.EqualValues(t, stat["UNCONN"], 3)
-	assert.EqualValues(t, stat["ESTAB"], 1)
-}
-
-func TestParseSs3(t *testing.T) {
-	stub := `NetidState      Recv-Q Send-Q                                      Local Address:Port                                        Peer Address:Port
+			expect: map[string]interface{}{
+				"LISTEN": 2.0,
+				"UNCONN": 3.0,
+				"ESTAB":  1.0,
+			},
+		},
+		{
+			name: "Cent7 overstuffed",
+			input: `NetidState      Recv-Q Send-Q                                      Local Address:Port                                        Peer Address:Port
 nl   UNCONN     0      0                                                      18:0                                                       *
 p_rawUNCONN     0      0                                                       *:em2                                                     *
 u_dgrUNCONN     0      0                                                /dev/log 10549                                                  * 0
 u_dgrLISTEN     0      0                                       /run/udev/control 8552                                                   * 0
 u_strLISTEN     0      10                                  /var/run/acpid.socket 9649                                                   * 0
-u_strESTAB      0      0                                    @/com/ubuntu/upstart 10582                                                  * 1887`
-	stat := make(map[string]interface{})
+u_strESTAB      0      0                                    @/com/ubuntu/upstart 10582                                                  * 1887`,
+			expect: map[string]interface{}{
+				"LISTEN": 2.0,
+				"UNCONN": 3.0,
+				"ESTAB":  1.0,
+			},
+		},
+	}
 
-	err := parseSs(bytes.NewBufferString(stub), &stat)
-	assert.Nil(t, err)
-	assert.EqualValues(t, stat["LISTEN"], 2)
-	assert.EqualValues(t, stat["UNCONN"], 3)
-	assert.EqualValues(t, stat["ESTAB"], 1)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := make(map[string]interface{})
+			err := parseSs(bytes.NewBufferString(tc.input), &out)
+			if err != nil {
+				t.Errorf("error should be nil but: %s", err)
+			}
+			if !reflect.DeepEqual(out, tc.expect) {
+				t.Errorf("something went wrong:\n   out: %v\nexpect: %v", out, tc.expect)
+			}
+		})
+	}
 }
-
 func TestCollectProcVmstat(t *testing.T) {
 	path := "/proc/vmstat"
 	_, err := os.Stat(path)

--- a/mackerel-plugin-linux/lib/linux_test.go
+++ b/mackerel-plugin-linux/lib/linux_test.go
@@ -117,6 +117,23 @@ u_str ESTAB      0      0                                    @/com/ubuntu/upstar
 	assert.EqualValues(t, stat["ESTAB"], 1)
 }
 
+func TestParseSs3(t *testing.T) {
+	stub := `NetidState      Recv-Q Send-Q                                      Local Address:Port                                        Peer Address:Port
+nl   UNCONN     0      0                                                      18:0                                                       *
+p_rawUNCONN     0      0                                                       *:em2                                                     *
+u_dgrUNCONN     0      0                                                /dev/log 10549                                                  * 0
+u_dgrLISTEN     0      0                                       /run/udev/control 8552                                                   * 0
+u_strLISTEN     0      10                                  /var/run/acpid.socket 9649                                                   * 0
+u_strESTAB      0      0                                    @/com/ubuntu/upstart 10582                                                  * 1887`
+	stat := make(map[string]interface{})
+
+	err := parseSs(bytes.NewBufferString(stub), &stat)
+	assert.Nil(t, err)
+	assert.EqualValues(t, stat["LISTEN"], 2)
+	assert.EqualValues(t, stat["UNCONN"], 3)
+	assert.EqualValues(t, stat["ESTAB"], 1)
+}
+
 func TestCollectProcVmstat(t *testing.T) {
 	path := "/proc/vmstat"
 	_, err := os.Stat(path)


### PR DESCRIPTION
The width of ss's Netid column may be a minimum of 5.

https://github.com/sivasankariit/iproute2/blob/1179ab033c31d2c67f406be5bcd5e4c0685855fe/misc/ss.c#L3111-L3117