### PR TITLE
[haproxy] fix example of haproxy.cfg in README.md

### DIFF
--- a/mackerel-plugin-haproxy/README.md
+++ b/mackerel-plugin-haproxy/README.md
@@ -17,16 +17,17 @@ For Basic Auth, set username.
 
 ```
 [plugin.metrics.haproxy]
-command = "/path/to/mackerel-plugin-haproxy -port=8000"
+command = ["mackerel-plugin-haproxy", "-port=8088", "-path=/haproxy?hastats"]
 ```
 
-## Example of haproxy.conf
+## Example of haproxy.cfg
 
 This plugin requires to enable stats of haproxy.
 Example configuration is as follow.
 
 ```
-listen hastats *:8088
+listen hastats
+    bind *:8088
     mode http
     maxconn 64
     timeout connect 5000
@@ -39,5 +40,3 @@ listen hastats *:8088
     # basic auth
     stats auth admin:adminadmin
 ```
-
-See haproxy_test.go for example configuration.


### PR DESCRIPTION
fix #498 

The current sample configuration in README.md is old style and does not work in the newer version (1.6 or later), with raising errors as following. So I fixed it.

```
[ALERT] 071/105745 (54631) : parsing [/usr/local/etc/haproxy.cfg:1] : 'listen' cannot handle unexpected argument '*:8088'.
[ALERT] 071/105745 (54631) : parsing [/usr/local/etc/haproxy.cfg:1] : please use the 'bind' keyword for listening addresses.
[ALERT] 071/105745 (54631) : Error(s) found in configuration file : /usr/local/etc/haproxy.cfg
[ALERT] 071/105745 (54631) : Fatal errors found in configuration.
```