### PR TITLE
[mysql] add -debug option for troubleshooting

### DIFF
--- a/mackerel-plugin-mysql/README.md
+++ b/mackerel-plugin-mysql/README.md
@@ -6,7 +6,7 @@ MySQL custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-mysql [-host=<host>] [-port=<port>] [-username=<username>] [-password=<password>] [-tempfile=<tempfile>] [-disable_innodb=true] [-metric-key-prefix=<prefix>] [-enable_extended=true]
+mackerel-plugin-mysql [-host=<host>] [-port=<port>] [-username=<username>] [-password=<password>] [-tempfile=<tempfile>] [-disable_innodb=true] [-metric-key-prefix=<prefix>] [-enable_extended=true] [-debug=true]
 ```
 
 ## Example of mackerel-agent.conf


### PR DESCRIPTION
I added `-debug` option.

This option allows that prints debugging logs to stderr. For example, below logs is results of when `-debug` is enabled.

```
2019/05/08 11:48:23 [ 0 ->] Init packet:
2019/05/08 11:48:23         ProtVer=10, ServVer="8.0.16" Status=0x2
2019/05/08 11:48:23 [ 1 <-] Authentication packet
2019/05/08 11:48:23 [ 3 ->] OK packet:
2019/05/08 11:48:23         AffectedRows=0 InsertId=0x0 Status=0x2 WarningCount=0 Message=""
2019/05/08 11:48:23 [ 0 <-] Command packet: Cmd=0x3 show /*!50002 global */ status
2019/05/08 11:48:23 [ 1 ->] Result set header packet:
2019/05/08 11:48:23         FieldCount=2
2019/05/08 11:48:23 [ 2 ->] Field packet:
2019/05/08 11:48:23         Name="Variable_name" Type=0xfd
2019/05/08 11:48:23 [ 3 ->] Field packet:
2019/05/08 11:48:23         Name="Value" Type=0xfd
2019/05/08 11:48:23 [ 4 ->] EOF packet:
2019/05/08 11:48:23         WarningCount=0 Status=0x22
2019/05/08 11:48:23 [ 5 ->] Text row data packet
...
```