### PR TITLE
[plugin-jvm] prefer ${JAVA_HOME}/bin/j** if JAVA_HOME is set

### DIFF
--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -349,7 +349,7 @@ func Do() {
 	optHost := flag.String("host", "", "jps/jstat target hostname [deprecated]")
 	optPort := flag.Int("port", 0, "jps/jstat target port [deprecated]")
 	optRemote := flag.String("remote", "", "jps/jstat remote target. hostname[:port][/servername]")
-	optJstatPath := flag.String("jstatpath", pathBase+"/jstat", "jstat path ")
+	optJstatPath := flag.String("jstatpath", pathBase+"/jstat", "jstat path")
 	optJinfoPath := flag.String("jinfopath", pathBase+"/jinfo", "jinfo path")
 	optJpsPath := flag.String("jpspath", pathBase+"/jps", "jps path")
 	optJavaName := flag.String("javaname", "", "Java app name")

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -341,12 +341,17 @@ func generateRemote(remote, host string, port int) string {
 
 // Do the plugin
 func Do() {
+	// Prefer ${JAVA_HOME}/bin if JAVA_HOME presents
+	pathBase := "/usr/bin"
+	if javaHome := os.Getenv("JAVA_HOME"); javaHome != "" {
+		pathBase = javaHome + "/bin"
+	}
 	optHost := flag.String("host", "", "jps/jstat target hostname [deprecated]")
 	optPort := flag.Int("port", 0, "jps/jstat target port [deprecated]")
 	optRemote := flag.String("remote", "", "jps/jstat remote target. hostname[:port][/servername]")
-	optJstatPath := flag.String("jstatpath", "/usr/bin/jstat", "jstat path")
-	optJinfoPath := flag.String("jinfopath", "/usr/bin/jinfo", "jinfo path")
-	optJpsPath := flag.String("jpspath", "/usr/bin/jps", "jps path")
+	optJstatPath := flag.String("jstatpath", pathBase+"/jstat", "jstat path ")
+	optJinfoPath := flag.String("jinfopath", pathBase+"/jinfo", "jinfo path")
+	optJpsPath := flag.String("jpspath", pathBase+"/jps", "jps path")
 	optJavaName := flag.String("javaname", "", "Java app name")
 	optPidFile := flag.String("pidfile", "", "pidfile path")
 	optTempfile := flag.String("tempfile", "", "Temp file name")


### PR DESCRIPTION
# Breaking change

This p-r introduces a breaking change of default behavior, but I believe in most cases the change does not matter.

# description

When jstat and other commands are placed somewhere else (like `/opt/java/bin/jstat`), currently we have to specify executable paths 3 times:
```
mackerel-plugin-jvm -jstatpath=/opt/java/bin/jstat -jpspath=/opt/java/bin/jps -jinfopath=/opt/java/bin/jinfo
```
Considering following two cases, I'd like to change default path of jstat and its friends from `/usr/bin/jXXX` to `${JAVA_HOME}/bin/jXXX`. when `JAVA_HOME` is not empty.

considerations:
- in many cases users set preferred `JAVA_HOME` 
- users can override `JAVA_HOME` by  `env` option of mackerel-agent.conf
