### PR TITLE
[solr] Add version 7.x and 8.x support

### DIFF
--- a/mackerel-plugin-solr/README.md
+++ b/mackerel-plugin-solr/README.md
@@ -11,14 +11,12 @@ mackerel-plugin-solr [-host=<hostname>] [-port=<port>]
 
 ## Example of mackerel-agent.conf
 
-### Default
-
 ```
 [plugin.metrics.solr]
 command = "/path/to/mackerel-plugin-solr"
 ```
 
-### Custom
+You can explicitly specify a host IP address and a port number.
 
 ```
 [plugin.metrics.solr]
@@ -29,45 +27,63 @@ command = "/path/to/mackerel-plugin-solr -host=192.168.33.10 -port=8984"
 
 * `5.*.*`
 * `6.*.*`
+* `7.*.*`
+* `8.*.*`
 
-## Dependency Solr URL
+## Requirement APIs
 
-- http://{host}:{port}/solr/admin/cores
-- http://{host}:{port}/solr/{core name}/admin/mbeans
+* `http://{host}:{port}/solr/admin/info/system`
+* `http://{host}:{port}/solr/admin/cores`
+* `http://{host}:{port}/solr/{core name}/admin/mbeans`
 
-## Munin Solr plugin
-
-- https://github.com/munin-monitoring/contrib/tree/master/plugins/solr
-
-## Apache Solr official website
-
-- http://lucene.apache.org/solr/
-
-## Test
-
-### Run
+## Unit tests
 
 ```
 $ cd mackerel-plugin-solr/lib/
 $ go test
 ```
 
-### Add fixture json
+Prepare fixture files to `mackerel-plugin-solr/lib/stats/x.x.x/*` if you'd like to support new version.
 
 ```
 $ docker pull solr:x.x
 $ docker run --name solr_x -d -p 8983:8983 -t solr:x.x
 $ docker exec -it --user=solr solr_x bin/solr create_core -c testcore
 $ cd mackerel-plugin-solr/lib/
+```
+
+```
+$ curl -s -S 'http://localhost:8983/solr/admin/info/system?wt=json' | jq . > stats/x.x.x/system.json
+```
+
+```
 $ curl -s -S 'http://localhost:8983/solr/admin/cores?wt=json' | jq . > stats/x.x.x/cores.json
+```
+
+```
+### Solr5 or Solr6
 $ curl -s -S 'http://localhost:8983/solr/testcore/admin/mbeans?wt=json&stats=true&cat=QUERYHANDLER&key=/update/json&key=/select&key=/update/json/docs&key=/get&key=/update/csv&key=/replication&key=/update&key=/dataimport' | jq . > stats/x.x.x/query.json
 $ curl -s -S 'http://localhost:8983/solr/testcore/admin/mbeans?wt=json&stats=true&cat=UPDATEHANDLER&key=/update/json&key=/select&key=/update/json/docs&key=/get&key=/update/csv&key=/replication&key=/update&key=/dataimport' | jq . > stats/x.x.x/update.json
+
+### Solr7 or Solr8
+$ curl -s -S 'http://localhost:8983/solr/testcore/admin/mbeans?wt=json&stats=true&cat=QUERY&key=/update/json&key=/select&key=/update/json/docs&key=/get&key=/update/csv&key=/replication&key=/update&key=/dataimport' | jq . > stats/x.x.x/query.json
+$ curl -s -S 'http://localhost:8983/solr/testcore/admin/mbeans?wt=json&stats=true&cat=UPDATE&key=/update/json&key=/select&key=/update/json/docs&key=/get&key=/update/csv&key=/replication&key=/update&key=/dataimport' | jq . > stats/x.x.x/update.json
+```
+
+```
 $ curl -s -S 'http://localhost:8983/solr/testcore/admin/mbeans?wt=json&stats=true&cat=REPLICATION&key=/update/json&key=/select&key=/update/json/docs&key=/get&key=/update/csv&key=/replication&key=/update&key=/dataimport' | jq . > stats/x.x.x/replication.json
 $ curl -s -S 'http://localhost:8983/solr/testcore/admin/mbeans?wt=json&stats=true&cat=CACHE&key=filterCache&key=perSegFilter&key=queryResultCache&key=documentCache&key=fieldValueCache' | jq . > stats/x.x.x/cache.json
 ```
 
-### Documents
+## Documents
 
-* [MBean Request Handler](https://cwiki.apache.org/confluence/display/solr/MBean+Request+Handler)
-* [Performance Statistics Reference](https://cwiki.apache.org/confluence/display/solr/Performance+Statistics+Reference)
+* [Apache Solr official website](http://lucene.apache.org/solr/)
+* [MBean Request Handler](https://lucene.apache.org/solr/guide/8_1/mbean-request-handler.html)
+* [Performance Statistics Reference](https://lucene.apache.org/solr/guide/8_1/performance-statistics-reference.html)
 * [Docker Official Repository Solr](https://hub.docker.com/_/solr/)
+
+## Other softwares
+
+* [Prometheus Exporter](https://github.com/apache/lucene-solr/tree/master/solr/contrib/prometheus-exporter)
+* [DataDog Integration](https://github.com/DataDog/integrations-core/tree/master/solr)
+* [Munin Plugin](https://github.com/munin-monitoring/contrib/tree/master/plugins/solr)

--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -104,7 +104,7 @@ func (s *SolrPlugin) setStatsMbean(core string, stats map[string]interface{}, al
 						var keyParts []string
 						for k, v := range statValues {
 							keyParts = strings.Split(k, ".")
-							if len(keyParts) >= 3 {
+							if len(keyParts) > keyIndex {
 								keyConvertedStatValues[keyParts[keyIndex]] = v
 							}
 						}

--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
@@ -46,6 +47,15 @@ type SolrPlugin struct {
 	Prefix   string
 	Stats    map[string](map[string]float64)
 	Tempfile string
+}
+
+func (s *SolrPlugin) greaterThanOrEqualToMajorVersion(minVer int) bool {
+	currentVer, err := strconv.Atoi(strings.Split(s.Version, ".")[0])
+	if err != nil {
+		logger.Errorf("Failed to parse major version %s", err)
+	}
+
+	return currentVer >= minVer
 }
 
 func fetchJSONData(url string) (map[string]interface{}, error) {
@@ -99,7 +109,7 @@ func (s *SolrPlugin) setStatsMbean(core string, stats map[string]interface{}, al
 						continue
 					}
 					statValues := v.(map[string]interface{})
-					if s.Version >= "7.0.0" {
+					if s.greaterThanOrEqualToMajorVersion(7) {
 						keyConvertedStatValues := make(map[string]interface{})
 						var keyParts []string
 						for k, v := range statValues {
@@ -133,7 +143,7 @@ func (s *SolrPlugin) loadStatsMbeanHandler(core string, cat string) error {
 		return err
 	}
 	var sKeys []string
-	if s.Version >= "7.0.0" {
+	if s.greaterThanOrEqualToMajorVersion(7) {
 		sKeys = handlerStatKeys
 	} else {
 		sKeys = legacyHandlerStatKeys
@@ -185,7 +195,7 @@ func (s *SolrPlugin) loadStats() error {
 		}
 
 		var mKeys []string
-		if s.Version >= "7.0.0" {
+		if s.greaterThanOrEqualToMajorVersion(7) {
 			mKeys = mbeanHandlerKeys
 		} else {
 			mKeys = legacyMbeanHandlerKeys
@@ -246,7 +256,7 @@ func (s SolrPlugin) GraphDefinition() map[string]mp.Graphs {
 		}
 
 		var sKeys []string
-		if s.Version >= "7.0.0" {
+		if s.greaterThanOrEqualToMajorVersion(7) {
 			sKeys = handlerStatKeys
 		} else {
 			sKeys = legacyHandlerStatKeys

--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -15,15 +15,24 @@ import (
 
 var (
 	logger       = logging.GetLogger("metrics.plugin.solr")
-	coreStatKeys = []string{"numDocs", "deletedDocs", "indexHeapUsageBytes", "version", "segmentCount", "sizeInBytes"}
-	handlerPaths = []string{"/update/json", "/select", "/update/json/docs", "/get", "/update/csv", "/replication", "/update", "/dataimport"}
+	coreStatKeys = []string{"numDocs", "deletedDocs", "indexHeapUsageBytes", "version",
+		"segmentCount", "sizeInBytes"}
+	handlerPaths = []string{"/update/json", "/select", "/update/json/docs", "/get",
+		"/update/csv", "/replication", "/update", "/dataimport"}
 	// Solr5 ... "5minRateReqsPerSecond", "15minRateReqsPerSecond"
 	// Solr6 ... "5minRateRequestsPerSecond", "15minRateRequestsPerSecond"
-	handlerStatKeys = []string{"requests", "errors", "timeouts", "avgRequestsPerSecond", "5minRateReqsPerSecond", "5minRateRequestsPerSecond",
-		"15minRateReqsPerSecond", "15minRateRequestsPerSecond", "avgTimePerRequest", "medianRequestTime",
-		"75thPcRequestTime", "95thPcRequestTime", "99thPcRequestTime", "999thPcRequestTime"}
-	cacheTypes    = []string{"filterCache", "perSegFilter", "queryResultCache", "documentCache", "fieldValueCache"}
-	cacheStatKeys = []string{"lookups", "hits", "hitratio", "inserts", "evictions", "size", "warmupTime"}
+	legacyHandlerStatKeys = []string{"requests", "errors", "timeouts", "avgRequestsPerSecond",
+		"5minRateReqsPerSecond", "5minRateRequestsPerSecond", "15minRateReqsPerSecond",
+		"15minRateRequestsPerSecond", "avgTimePerRequest", "medianRequestTime", "75thPcRequestTime",
+		"95thPcRequestTime", "99thPcRequestTime", "999thPcRequestTime"}
+	handlerStatKeys = []string{"requests", "errors", "timeouts", "clientErrors",
+		"serverErrors", "requestTimes"}
+	cacheTypes = []string{"filterCache", "perSegFilter", "queryResultCache",
+		"documentCache", "fieldValueCache"}
+	cacheStatKeys = []string{"lookups", "hits", "hitratio", "inserts", "evictions",
+		"size", "warmupTime"}
+	legacyMbeanHandlerKeys = []string{"QUERYHANDLER", "UPDATEHANDLER", "REPLICATION"}
+	mbeanHandlerKeys       = []string{"QUERY", "UPDATE", "REPLICATION"}
 )
 
 // SolrPlugin mackerel plugin for Solr
@@ -32,13 +41,14 @@ type SolrPlugin struct {
 	Host     string
 	Port     string
 	BaseURL  string
+	Version  string
 	Cores    []string
 	Prefix   string
 	Stats    map[string](map[string]float64)
 	Tempfile string
 }
 
-func (s *SolrPlugin) getStats(url string) (map[string]interface{}, error) {
+func fetchJSONData(url string) (map[string]interface{}, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -74,7 +84,7 @@ func (s *SolrPlugin) loadStatsCore(core string, values interface{}) error {
 	return nil
 }
 
-func (s *SolrPlugin) setStatsMbean(core string, stats map[string]interface{}, allowKeys []string) {
+func (s *SolrPlugin) setStatsMbean(core string, stats map[string]interface{}, allowKeys []string, keyIndex int) {
 	for _, values := range stats["solr-mbeans"].([]interface{}) {
 		switch values.(type) {
 		case string:
@@ -88,12 +98,23 @@ func (s *SolrPlugin) setStatsMbean(core string, stats map[string]interface{}, al
 					if v == nil {
 						continue
 					}
-					v2 := v.(map[string]interface{})
+					statValues := v.(map[string]interface{})
+					if s.Version >= "7.0.0" {
+						keyConvertedStatValues := make(map[string]interface{})
+						var keyParts []string
+						for k, v := range statValues {
+							keyParts = strings.Split(k, ".")
+							if len(keyParts) >= 3 {
+								keyConvertedStatValues[keyParts[keyIndex]] = v
+							}
+						}
+						statValues = keyConvertedStatValues
+					}
 					for _, allowKey := range allowKeys {
-						if v2[allowKey] == nil {
+						if statValues[allowKey] == nil {
 							continue
 						}
-						s.Stats[core][allowKey+"_"+escapeSlash(key)] = v2[allowKey].(float64)
+						s.Stats[core][allowKey+"_"+escapeSlash(key)] = statValues[allowKey].(float64)
 					}
 				}
 			}
@@ -107,27 +128,50 @@ func (s *SolrPlugin) loadStatsMbeanHandler(core string, cat string) error {
 	for _, path := range handlerPaths {
 		uri += fmt.Sprintf("&key=%s", url.QueryEscape(path))
 	}
-	stats, err := s.getStats(uri)
+	stats, err := fetchJSONData(uri)
 	if err != nil {
 		return err
 	}
-	s.setStatsMbean(core, stats, handlerStatKeys)
+	var sKeys []string
+	if s.Version >= "7.0.0" {
+		sKeys = handlerStatKeys
+	} else {
+		sKeys = legacyHandlerStatKeys
+	}
+	s.setStatsMbean(core, stats, sKeys, 2)
 	return nil
 }
 
 func (s *SolrPlugin) loadStatsMbeanCache(core string) error {
-	stats, err := s.getStats(s.BaseURL + "/" + core + "/admin/mbeans?stats=true&wt=json&cat=CACHE&key=filterCache&key=perSegFilter&key=queryResultCache&key=documentCache&key=fieldValueCache")
+	stats, err := fetchJSONData(s.BaseURL + "/" + core + "/admin/mbeans?stats=true&wt=json&cat=CACHE&key=filterCache&key=perSegFilter&key=queryResultCache&key=documentCache&key=fieldValueCache")
 	if err != nil {
 		return err
 	}
-	s.setStatsMbean(core, stats, cacheStatKeys)
+	s.setStatsMbean(core, stats, cacheStatKeys, 3)
+	return nil
+}
+
+func (s *SolrPlugin) loadVersion() error {
+	stats, err := fetchJSONData(s.BaseURL + "/admin/info/system?wt=json")
+	if err != nil {
+		return err
+	}
+	lucene, ok := stats["lucene"].(map[string]interface{})
+	if !ok {
+		return errors.New("type assersion error")
+	}
+	solrVersion, ok := lucene["solr-spec-version"].(string)
+	if !ok {
+		return errors.New("type assersion error")
+	}
+	s.Version = solrVersion
 	return nil
 }
 
 func (s *SolrPlugin) loadStats() error {
 	s.Stats = map[string](map[string]float64){}
 
-	stats, err := s.getStats(s.BaseURL + "/admin/cores?wt=json")
+	stats, err := fetchJSONData(s.BaseURL + "/admin/cores?wt=json")
 	if err != nil {
 		return err
 	}
@@ -139,17 +183,18 @@ func (s *SolrPlugin) loadStats() error {
 		if err != nil {
 			return err
 		}
-		err = s.loadStatsMbeanHandler(core, "QUERYHANDLER")
-		if err != nil {
-			return err
+
+		var mKeys []string
+		if s.Version >= "7.0.0" {
+			mKeys = mbeanHandlerKeys
+		} else {
+			mKeys = legacyMbeanHandlerKeys
 		}
-		err = s.loadStatsMbeanHandler(core, "UPDATEHANDLER")
-		if err != nil {
-			return err
-		}
-		err = s.loadStatsMbeanHandler(core, "REPLICATION")
-		if err != nil {
-			return err
+		for _, mKey := range mKeys {
+			err = s.loadStatsMbeanHandler(core, mKey)
+			if err != nil {
+				return err
+			}
 		}
 		err = s.loadStatsMbeanCache(core)
 		if err != nil {
@@ -200,7 +245,13 @@ func (s SolrPlugin) GraphDefinition() map[string]mp.Graphs {
 			}
 		}
 
-		for _, key := range handlerStatKeys {
+		var sKeys []string
+		if s.Version >= "7.0.0" {
+			sKeys = handlerStatKeys
+		} else {
+			sKeys = legacyHandlerStatKeys
+		}
+		for _, key := range sKeys {
 			var metrics []mp.Metrics
 			for _, path := range handlerPaths {
 				path = escapeSlash(path)
@@ -263,6 +314,7 @@ func Do() {
 	}
 
 	solr.BaseURL = fmt.Sprintf("%s://%s:%s/solr", solr.Protocol, solr.Host, solr.Port)
+	solr.loadVersion()
 	solr.loadStats()
 
 	helper := mp.NewMackerelPlugin(solr)

--- a/mackerel-plugin-solr/lib/solr_test.go
+++ b/mackerel-plugin-solr/lib/solr_test.go
@@ -11,12 +11,14 @@ import (
 )
 
 var (
-	SolrVersions = []string{"5.5.4", "6.4.2"}
+	SolrVersions = []string{"5.5.4", "6.4.2", "7.7.2", "8.1.1"}
 	solrVersion  string
 )
 
 var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
+	case "/solr/admin/info/system":
+		fmt.Fprintf(w, fetchJSON("system"))
 	case "/solr/admin/cores":
 		fmt.Fprintf(w, fetchJSON("cores"))
 	case "/solr/testcore/admin/mbeans":
@@ -38,9 +40,9 @@ func fetchJSON(name string) string {
 
 func fetchJSONForMbeans(key string) string {
 	switch key {
-	case "QUERYHANDLER":
+	case "QUERYHANDLER", "QUERY":
 		return fetchJSON("query")
-	case "UPDATEHANDLER":
+	case "UPDATEHANDLER", "UPDATE":
 		return fetchJSON("update")
 	case "REPLICATION":
 		return fetchJSON("replication")
@@ -51,59 +53,78 @@ func fetchJSONForMbeans(key string) string {
 	}
 }
 
-func TestGraphDefinition(t *testing.T) {
-	solr := SolrPlugin{
-		Cores:  []string{"testcore"},
-		Prefix: "solr",
+func setupSolr(mockURL string, version string) (solr SolrPlugin) {
+	solrVersion = version
+	solr = SolrPlugin{
+		BaseURL: mockURL + "/solr",
+		Cores:   []string{"testcore"},
+		Prefix:  "solr",
 	}
-	graphdef := solr.GraphDefinition()
+	solr.loadVersion()
+	return
+}
 
-	assert.EqualValues(t, "testcore DocsCount", graphdef["solr.testcore.docsCount"].Label)
-	assert.EqualValues(t, "testcore_numDocs", graphdef["solr.testcore.docsCount"].Metrics[0].Name)
-	assert.EqualValues(t, "testcore_deletedDocs", graphdef["solr.testcore.docsCount"].Metrics[1].Name)
+func TestGraphDefinition(t *testing.T) {
+	ts := httptest.NewServer(testHandler)
+	defer ts.Close()
 
-	assert.EqualValues(t, "testcore IndexHeapUsageBytes", graphdef["solr.testcore.indexHeapUsageBytes"].Label)
-	assert.EqualValues(t, "testcore_indexHeapUsageBytes", graphdef["solr.testcore.indexHeapUsageBytes"].Metrics[0].Name)
-	assert.EqualValues(t, "testcore SegmentCount", graphdef["solr.testcore.segmentCount"].Label)
-	assert.EqualValues(t, "testcore_segmentCount", graphdef["solr.testcore.segmentCount"].Metrics[0].Name)
-	assert.EqualValues(t, "testcore SizeInBytes", graphdef["solr.testcore.sizeInBytes"].Label)
-	assert.EqualValues(t, "testcore_sizeInBytes", graphdef["solr.testcore.sizeInBytes"].Metrics[0].Name)
+	for _, version := range SolrVersions {
+		solr := setupSolr(ts.URL, version)
+		graphdef := solr.GraphDefinition()
 
-	assert.EqualValues(t, "testcore Requests", graphdef["solr.testcore.requests"].Label)
-	assert.EqualValues(t, "testcore_requests_updatejson", graphdef["solr.testcore.requests"].Metrics[0].Name)
-	assert.EqualValues(t, "testcore_requests_select", graphdef["solr.testcore.requests"].Metrics[1].Name)
-	assert.EqualValues(t, "testcore_requests_updatejsondocs", graphdef["solr.testcore.requests"].Metrics[2].Name)
-	assert.EqualValues(t, "testcore_requests_get", graphdef["solr.testcore.requests"].Metrics[3].Name)
-	assert.EqualValues(t, "testcore_requests_updatecsv", graphdef["solr.testcore.requests"].Metrics[4].Name)
-	assert.EqualValues(t, "testcore_requests_replication", graphdef["solr.testcore.requests"].Metrics[5].Name)
-	assert.EqualValues(t, "testcore_requests_update", graphdef["solr.testcore.requests"].Metrics[6].Name)
-	assert.EqualValues(t, "testcore_requests_dataimport", graphdef["solr.testcore.requests"].Metrics[7].Name)
+		assert.EqualValues(t, "testcore DocsCount", graphdef["solr.testcore.docsCount"].Label)
+		assert.EqualValues(t, "testcore_numDocs", graphdef["solr.testcore.docsCount"].Metrics[0].Name)
+		assert.EqualValues(t, "testcore_deletedDocs", graphdef["solr.testcore.docsCount"].Metrics[1].Name)
 
-	assert.EqualValues(t, "testcore Errors", graphdef["solr.testcore.errors"].Label)
-	assert.EqualValues(t, "testcore Timeouts", graphdef["solr.testcore.timeouts"].Label)
-	assert.EqualValues(t, "testcore AvgRequestsPerSecond", graphdef["solr.testcore.avgRequestsPerSecond"].Label)
-	assert.EqualValues(t, "testcore 5minRateRequestsPerSecond", graphdef["solr.testcore.5minRateRequestsPerSecond"].Label)
-	assert.EqualValues(t, "testcore 15minRateRequestsPerSecond", graphdef["solr.testcore.15minRateRequestsPerSecond"].Label)
-	assert.EqualValues(t, "testcore AvgTimePerRequest", graphdef["solr.testcore.avgTimePerRequest"].Label)
-	assert.EqualValues(t, "testcore MedianRequestTime", graphdef["solr.testcore.medianRequestTime"].Label)
-	assert.EqualValues(t, "testcore 75thPcRequestTime", graphdef["solr.testcore.75thPcRequestTime"].Label)
-	assert.EqualValues(t, "testcore 95thPcRequestTime", graphdef["solr.testcore.95thPcRequestTime"].Label)
-	assert.EqualValues(t, "testcore 99thPcRequestTime", graphdef["solr.testcore.99thPcRequestTime"].Label)
-	assert.EqualValues(t, "testcore 999thPcRequestTime", graphdef["solr.testcore.999thPcRequestTime"].Label)
+		assert.EqualValues(t, "testcore IndexHeapUsageBytes", graphdef["solr.testcore.indexHeapUsageBytes"].Label)
+		assert.EqualValues(t, "testcore_indexHeapUsageBytes", graphdef["solr.testcore.indexHeapUsageBytes"].Metrics[0].Name)
+		assert.EqualValues(t, "testcore SegmentCount", graphdef["solr.testcore.segmentCount"].Label)
+		assert.EqualValues(t, "testcore_segmentCount", graphdef["solr.testcore.segmentCount"].Metrics[0].Name)
+		assert.EqualValues(t, "testcore SizeInBytes", graphdef["solr.testcore.sizeInBytes"].Label)
+		assert.EqualValues(t, "testcore_sizeInBytes", graphdef["solr.testcore.sizeInBytes"].Metrics[0].Name)
 
-	assert.EqualValues(t, "testcore Lookups", graphdef["solr.testcore.lookups"].Label)
-	assert.EqualValues(t, "testcore_lookups_filterCache", graphdef["solr.testcore.lookups"].Metrics[0].Name)
-	assert.EqualValues(t, "testcore_lookups_perSegFilter", graphdef["solr.testcore.lookups"].Metrics[1].Name)
-	assert.EqualValues(t, "testcore_lookups_queryResultCache", graphdef["solr.testcore.lookups"].Metrics[2].Name)
-	assert.EqualValues(t, "testcore_lookups_documentCache", graphdef["solr.testcore.lookups"].Metrics[3].Name)
-	assert.EqualValues(t, "testcore_lookups_fieldValueCache", graphdef["solr.testcore.lookups"].Metrics[4].Name)
+		assert.EqualValues(t, "testcore Requests", graphdef["solr.testcore.requests"].Label)
+		assert.EqualValues(t, "testcore_requests_updatejson", graphdef["solr.testcore.requests"].Metrics[0].Name)
+		assert.EqualValues(t, "testcore_requests_select", graphdef["solr.testcore.requests"].Metrics[1].Name)
+		assert.EqualValues(t, "testcore_requests_updatejsondocs", graphdef["solr.testcore.requests"].Metrics[2].Name)
+		assert.EqualValues(t, "testcore_requests_get", graphdef["solr.testcore.requests"].Metrics[3].Name)
+		assert.EqualValues(t, "testcore_requests_updatecsv", graphdef["solr.testcore.requests"].Metrics[4].Name)
+		assert.EqualValues(t, "testcore_requests_replication", graphdef["solr.testcore.requests"].Metrics[5].Name)
+		assert.EqualValues(t, "testcore_requests_update", graphdef["solr.testcore.requests"].Metrics[6].Name)
+		assert.EqualValues(t, "testcore_requests_dataimport", graphdef["solr.testcore.requests"].Metrics[7].Name)
 
-	assert.EqualValues(t, "testcore Hits", graphdef["solr.testcore.hits"].Label)
-	assert.EqualValues(t, "testcore Hitratio", graphdef["solr.testcore.hitratio"].Label)
-	assert.EqualValues(t, "testcore Inserts", graphdef["solr.testcore.inserts"].Label)
-	assert.EqualValues(t, "testcore Evictions", graphdef["solr.testcore.evictions"].Label)
-	assert.EqualValues(t, "testcore Size", graphdef["solr.testcore.size"].Label)
-	assert.EqualValues(t, "testcore WarmupTime", graphdef["solr.testcore.warmupTime"].Label)
+		assert.EqualValues(t, "testcore Errors", graphdef["solr.testcore.errors"].Label)
+		assert.EqualValues(t, "testcore Timeouts", graphdef["solr.testcore.timeouts"].Label)
+		if version == "7.7.2" || version == "8.1.1" {
+			assert.EqualValues(t, "testcore ClientErrors", graphdef["solr.testcore.clientErrors"].Label)
+			assert.EqualValues(t, "testcore ServerErrors", graphdef["solr.testcore.serverErrors"].Label)
+			assert.EqualValues(t, "testcore RequestTimes", graphdef["solr.testcore.requestTimes"].Label)
+		} else {
+			assert.EqualValues(t, "testcore AvgRequestsPerSecond", graphdef["solr.testcore.avgRequestsPerSecond"].Label)
+			assert.EqualValues(t, "testcore 5minRateRequestsPerSecond", graphdef["solr.testcore.5minRateRequestsPerSecond"].Label)
+			assert.EqualValues(t, "testcore 15minRateRequestsPerSecond", graphdef["solr.testcore.15minRateRequestsPerSecond"].Label)
+			assert.EqualValues(t, "testcore AvgTimePerRequest", graphdef["solr.testcore.avgTimePerRequest"].Label)
+			assert.EqualValues(t, "testcore MedianRequestTime", graphdef["solr.testcore.medianRequestTime"].Label)
+			assert.EqualValues(t, "testcore 75thPcRequestTime", graphdef["solr.testcore.75thPcRequestTime"].Label)
+			assert.EqualValues(t, "testcore 95thPcRequestTime", graphdef["solr.testcore.95thPcRequestTime"].Label)
+			assert.EqualValues(t, "testcore 99thPcRequestTime", graphdef["solr.testcore.99thPcRequestTime"].Label)
+			assert.EqualValues(t, "testcore 999thPcRequestTime", graphdef["solr.testcore.999thPcRequestTime"].Label)
+		}
+
+		assert.EqualValues(t, "testcore Lookups", graphdef["solr.testcore.lookups"].Label)
+		assert.EqualValues(t, "testcore_lookups_filterCache", graphdef["solr.testcore.lookups"].Metrics[0].Name)
+		assert.EqualValues(t, "testcore_lookups_perSegFilter", graphdef["solr.testcore.lookups"].Metrics[1].Name)
+		assert.EqualValues(t, "testcore_lookups_queryResultCache", graphdef["solr.testcore.lookups"].Metrics[2].Name)
+		assert.EqualValues(t, "testcore_lookups_documentCache", graphdef["solr.testcore.lookups"].Metrics[3].Name)
+		assert.EqualValues(t, "testcore_lookups_fieldValueCache", graphdef["solr.testcore.lookups"].Metrics[4].Name)
+
+		assert.EqualValues(t, "testcore Hits", graphdef["solr.testcore.hits"].Label)
+		assert.EqualValues(t, "testcore Hitratio", graphdef["solr.testcore.hitratio"].Label)
+		assert.EqualValues(t, "testcore Inserts", graphdef["solr.testcore.inserts"].Label)
+		assert.EqualValues(t, "testcore Evictions", graphdef["solr.testcore.evictions"].Label)
+		assert.EqualValues(t, "testcore Size", graphdef["solr.testcore.size"].Label)
+		assert.EqualValues(t, "testcore WarmupTime", graphdef["solr.testcore.warmupTime"].Label)
+	}
 }
 
 func TestFetchMetrics(t *testing.T) {
@@ -111,12 +132,7 @@ func TestFetchMetrics(t *testing.T) {
 	defer ts.Close()
 
 	for _, version := range SolrVersions {
-		solrVersion = version
-		solr := SolrPlugin{
-			BaseURL: ts.URL + "/solr",
-			Cores:   []string{"testcore"},
-			Prefix:  "solr",
-		}
+		solr := setupSolr(ts.URL, version)
 		solr.loadStats()
 		stat, err := solr.FetchMetrics()
 		if err != nil {
@@ -135,7 +151,14 @@ func TestFetchMetrics(t *testing.T) {
 		assert.EqualValues(t, 111.0, stat["testcore_requests_select"], msgPrefix+"testcore_requests_select")
 		assert.EqualValues(t, 222.0, stat["testcore_errors_select"], msgPrefix+"testcore_errors_select")
 		assert.EqualValues(t, 333.0, stat["testcore_timeouts_select"], msgPrefix+"testcore_timeouts_select")
-		assert.EqualValues(t, 444.0, stat["testcore_avgRequestsPerSecond_select"], msgPrefix+"testcore_avgRequestsPerSecond_select")
+		if version == "7.7.2" || version == "8.1.1" {
+			assert.EqualValues(t, 432.0, stat["testcore_clientErrors_select"], msgPrefix+"testcore_clientErrors_select")
+			assert.EqualValues(t, 234.0, stat["testcore_serverErrors_select"], msgPrefix+"testcore_serverErrors_select")
+			assert.EqualValues(t, 0.123, stat["testcore_requestTimes_select"], msgPrefix+"testcore_requestTimes_select")
+		}
+		if version == "5.5.4" || version == "6.4.2" {
+			assert.EqualValues(t, 444.0, stat["testcore_avgRequestsPerSecond_select"], msgPrefix+"testcore_avgRequestsPerSecond_select")
+		}
 		switch version {
 		case "5.5.4":
 			assert.EqualValues(t, 555.0, stat["testcore_5minRateReqsPerSecond_select"], msgPrefix+"testcore_5minRateRequestsPerSecond_select")
@@ -145,17 +168,26 @@ func TestFetchMetrics(t *testing.T) {
 			assert.EqualValues(t, 666.0, stat["testcore_15minRateRequestsPerSecond_select"], msgPrefix+"testcore_15minRateRequestsPerSecond_select")
 		default:
 		}
-		assert.EqualValues(t, 777.0, stat["testcore_avgTimePerRequest_select"], msgPrefix+"testcore_avgTimePerRequest_select")
-		assert.EqualValues(t, 888.0, stat["testcore_medianRequestTime_select"], msgPrefix+"testcore_medianRequestTime_select")
-		assert.EqualValues(t, 999.0, stat["testcore_75thPcRequestTime_select"], msgPrefix+"testcore_75thPcRequestTime_select")
-		assert.EqualValues(t, 100.1, stat["testcore_95thPcRequestTime_select"], msgPrefix+"testcore_95thPcRequestTime_select")
-		assert.EqualValues(t, 100.2, stat["testcore_99thPcRequestTime_select"], msgPrefix+"testcore_99thPcRequestTime_select")
-		assert.EqualValues(t, 100.3, stat["testcore_999thPcRequestTime_select"], msgPrefix+"testcore_999thPcRequestTime_select")
+		if version == "5.5.4" || version == "6.4.2" {
+			assert.EqualValues(t, 777.0, stat["testcore_avgTimePerRequest_select"], msgPrefix+"testcore_avgTimePerRequest_select")
+			assert.EqualValues(t, 888.0, stat["testcore_medianRequestTime_select"], msgPrefix+"testcore_medianRequestTime_select")
+			assert.EqualValues(t, 999.0, stat["testcore_75thPcRequestTime_select"], msgPrefix+"testcore_75thPcRequestTime_select")
+			assert.EqualValues(t, 100.1, stat["testcore_95thPcRequestTime_select"], msgPrefix+"testcore_95thPcRequestTime_select")
+			assert.EqualValues(t, 100.2, stat["testcore_99thPcRequestTime_select"], msgPrefix+"testcore_99thPcRequestTime_select")
+			assert.EqualValues(t, 100.3, stat["testcore_999thPcRequestTime_select"], msgPrefix+"testcore_999thPcRequestTime_select")
+		}
 
 		assert.EqualValues(t, 1111.0, stat["testcore_requests_update"], msgPrefix+"testcore_requests_update")
 		assert.EqualValues(t, 2222.0, stat["testcore_errors_update"], msgPrefix+"testcore_errors_update")
 		assert.EqualValues(t, 3333.0, stat["testcore_timeouts_update"], msgPrefix+"testcore_timeouts_update")
-		assert.EqualValues(t, 4444.0, stat["testcore_avgRequestsPerSecond_update"], msgPrefix+"testcore_avgRequestsPerSecond_update")
+		if version == "7.7.2" || version == "8.1.1" {
+			assert.EqualValues(t, 4321.0, stat["testcore_clientErrors_update"], msgPrefix+"testcore_clientErrors_update")
+			assert.EqualValues(t, 1234.0, stat["testcore_serverErrors_update"], msgPrefix+"testcore_serverErrors_update")
+			assert.EqualValues(t, 0.1234, stat["testcore_requestTimes_update"], msgPrefix+"testcore_requestTimes_update")
+		}
+		if version == "5.5.4" || version == "6.4.2" {
+			assert.EqualValues(t, 4444.0, stat["testcore_avgRequestsPerSecond_update"], msgPrefix+"testcore_avgRequestsPerSecond_update")
+		}
 		switch version {
 		case "5.5.4":
 			assert.EqualValues(t, 5555.0, stat["testcore_5minRateReqsPerSecond_update"], msgPrefix+"testcore_5minRateRequestsPerSecond_update")
@@ -165,17 +197,26 @@ func TestFetchMetrics(t *testing.T) {
 			assert.EqualValues(t, 6666.0, stat["testcore_15minRateRequestsPerSecond_update"], msgPrefix+"testcore_15minRateRequestsPerSecond_update")
 		default:
 		}
-		assert.EqualValues(t, 7777.0, stat["testcore_avgTimePerRequest_update"], msgPrefix+"testcore_avgTimePerRequest_update")
-		assert.EqualValues(t, 8888.0, stat["testcore_medianRequestTime_update"], msgPrefix+"testcore_medianRequestTime_update")
-		assert.EqualValues(t, 9999.0, stat["testcore_75thPcRequestTime_update"], msgPrefix+"testcore_75thPcRequestTime_update")
-		assert.EqualValues(t, 1000.1, stat["testcore_95thPcRequestTime_update"], msgPrefix+"testcore_95thPcRequestTime_update")
-		assert.EqualValues(t, 1000.2, stat["testcore_99thPcRequestTime_update"], msgPrefix+"testcore_99thPcRequestTime_update")
-		assert.EqualValues(t, 1000.3, stat["testcore_999thPcRequestTime_update"], msgPrefix+"testcore_999thPcRequestTime_update")
+		if version == "5.5.4" || version == "6.4.2" {
+			assert.EqualValues(t, 7777.0, stat["testcore_avgTimePerRequest_update"], msgPrefix+"testcore_avgTimePerRequest_update")
+			assert.EqualValues(t, 8888.0, stat["testcore_medianRequestTime_update"], msgPrefix+"testcore_medianRequestTime_update")
+			assert.EqualValues(t, 9999.0, stat["testcore_75thPcRequestTime_update"], msgPrefix+"testcore_75thPcRequestTime_update")
+			assert.EqualValues(t, 1000.1, stat["testcore_95thPcRequestTime_update"], msgPrefix+"testcore_95thPcRequestTime_update")
+			assert.EqualValues(t, 1000.2, stat["testcore_99thPcRequestTime_update"], msgPrefix+"testcore_99thPcRequestTime_update")
+			assert.EqualValues(t, 1000.3, stat["testcore_999thPcRequestTime_update"], msgPrefix+"testcore_999thPcRequestTime_update")
+		}
 
 		assert.EqualValues(t, 11111.0, stat["testcore_requests_replication"], msgPrefix+"testcore_requests_replication")
 		assert.EqualValues(t, 22222.0, stat["testcore_errors_replication"], msgPrefix+"testcore_errors_replication")
 		assert.EqualValues(t, 33333.0, stat["testcore_timeouts_replication"], msgPrefix+"testcore_timeouts_replication")
-		assert.EqualValues(t, 44444.0, stat["testcore_avgRequestsPerSecond_replication"], msgPrefix+"testcore_avgRequestsPerSecond_replication")
+		if version == "7.7.2" || version == "8.1.1" {
+			assert.EqualValues(t, 54321.0, stat["testcore_clientErrors_replication"], msgPrefix+"testcore_clientErrors_replication")
+			assert.EqualValues(t, 12345.0, stat["testcore_serverErrors_replication"], msgPrefix+"testcore_serverErrors_replication")
+			assert.EqualValues(t, 0.12345, stat["testcore_requestTimes_replication"], msgPrefix+"testcore_requestTimes_replication")
+		}
+		if version == "5.5.4" || version == "6.4.2" {
+			assert.EqualValues(t, 44444.0, stat["testcore_avgRequestsPerSecond_replication"], msgPrefix+"testcore_avgRequestsPerSecond_replication")
+		}
 		switch version {
 		case "5.5.4":
 			assert.EqualValues(t, 55555.0, stat["testcore_5minRateReqsPerSecond_replication"], msgPrefix+"testcore_5minRateRequestsPerSecond_replication")
@@ -185,12 +226,14 @@ func TestFetchMetrics(t *testing.T) {
 			assert.EqualValues(t, 66666.0, stat["testcore_15minRateRequestsPerSecond_replication"], msgPrefix+"testcore_15minRateRequestsPerSecond_replication")
 		default:
 		}
-		assert.EqualValues(t, 77777.0, stat["testcore_avgTimePerRequest_replication"], msgPrefix+"testcore_avgTimePerRequest_replication")
-		assert.EqualValues(t, 88888.0, stat["testcore_medianRequestTime_replication"], msgPrefix+"testcore_medianRequestTime_replication")
-		assert.EqualValues(t, 99999.0, stat["testcore_75thPcRequestTime_replication"], msgPrefix+"testcore_75thPcRequestTime_replication")
-		assert.EqualValues(t, 10000.1, stat["testcore_95thPcRequestTime_replication"], msgPrefix+"testcore_95thPcRequestTime_replication")
-		assert.EqualValues(t, 10000.2, stat["testcore_99thPcRequestTime_replication"], msgPrefix+"testcore_99thPcRequestTime_replication")
-		assert.EqualValues(t, 10000.3, stat["testcore_999thPcRequestTime_replication"], msgPrefix+"testcore_999thPcRequestTime_replication")
+		if version == "5.5.4" || version == "6.4.2" {
+			assert.EqualValues(t, 77777.0, stat["testcore_avgTimePerRequest_replication"], msgPrefix+"testcore_avgTimePerRequest_replication")
+			assert.EqualValues(t, 88888.0, stat["testcore_medianRequestTime_replication"], msgPrefix+"testcore_medianRequestTime_replication")
+			assert.EqualValues(t, 99999.0, stat["testcore_75thPcRequestTime_replication"], msgPrefix+"testcore_75thPcRequestTime_replication")
+			assert.EqualValues(t, 10000.1, stat["testcore_95thPcRequestTime_replication"], msgPrefix+"testcore_95thPcRequestTime_replication")
+			assert.EqualValues(t, 10000.2, stat["testcore_99thPcRequestTime_replication"], msgPrefix+"testcore_99thPcRequestTime_replication")
+			assert.EqualValues(t, 10000.3, stat["testcore_999thPcRequestTime_replication"], msgPrefix+"testcore_999thPcRequestTime_replication")
+		}
 
 		assert.EqualValues(t, 135, stat["testcore_lookups_filterCache"], msgPrefix+"testcore_lookups_filterCache")
 		assert.EqualValues(t, 357, stat["testcore_lookups_perSegFilter"], msgPrefix+"testcore_lookups_perSegFilter")

--- a/mackerel-plugin-solr/lib/stats/5.5.4/system.json
+++ b/mackerel-plugin-solr/lib/stats/5.5.4/system.json
@@ -1,0 +1,8 @@
+{
+  "lucene": {
+    "solr-spec-version": "5.5.4",
+    "solr-impl-version": "5.5.4 b3441673c21c83762035dc21d3827ad16aa17b68 - sarowe - 2017-10-20 09:02:42",
+    "lucene-spec-version": "5.5.4",
+    "lucene-impl-version": "5.5.4 b3441673c21c83762035dc21d3827ad16aa17b68 - sarowe - 2017-10-20 08:57:09"
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/6.4.2/system.json
+++ b/mackerel-plugin-solr/lib/stats/6.4.2/system.json
@@ -1,0 +1,8 @@
+{
+  "lucene": {
+    "solr-spec-version": "6.4.2",
+    "solr-impl-version": "6.4.2 68fa249034ba8b273955f20097700dc2fbb7a800 - ishan - 2019-03-29 09:13:13",
+    "lucene-spec-version": "6.4.2",
+    "lucene-impl-version": "6.4.2 68fa249034ba8b273955f20097700dc2fbb7a800 - ishan - 2019-03-29 09:07:55"
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/7.7.2/cache.json
+++ b/mackerel-plugin-solr/lib/stats/7.7.2/cache.json
@@ -1,0 +1,101 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 6
+  },
+  "solr-mbeans": [
+    "CACHE",
+    {
+      "perSegFilter": {
+        "class": "org.apache.solr.search.LRUCache",
+        "description": "LRU Cache(maxSize=10, initialSize=0, autowarmCount=10, regenerator=org.apache.solr.search.NoOpRegenerator@1c76f4c3)",
+        "stats": {
+          "CACHE.searcher.perSegFilter.lookups": 357,
+          "CACHE.searcher.perSegFilter.hits": 0,
+          "CACHE.searcher.perSegFilter.hitratio": 0,
+          "CACHE.searcher.perSegFilter.warmupTime": 0,
+          "CACHE.searcher.perSegFilter.cumulative_lookups": 0,
+          "CACHE.searcher.perSegFilter.cumulative_inserts": 0,
+          "CACHE.searcher.perSegFilter.cumulative_hitratio": 0,
+          "CACHE.searcher.perSegFilter.size": 0,
+          "CACHE.searcher.perSegFilter.evictions": 0,
+          "CACHE.searcher.perSegFilter.cumulative_hits": 0,
+          "CACHE.searcher.perSegFilter.cumulative_evictions": 0,
+          "CACHE.searcher.perSegFilter.inserts": 0
+        }
+      },
+      "queryResultCache": {
+        "class": "org.apache.solr.search.LRUCache",
+        "description": "LRU Cache(maxSize=512, initialSize=512)",
+        "stats": {
+          "CACHE.searcher.queryResultCache.cumulative_inserts": 0,
+          "CACHE.searcher.queryResultCache.evictions": 0,
+          "CACHE.searcher.queryResultCache.lookups": 579,
+          "CACHE.searcher.queryResultCache.cumulative_lookups": 0,
+          "CACHE.searcher.queryResultCache.cumulative_evictions": 0,
+          "CACHE.searcher.queryResultCache.warmupTime": 0,
+          "CACHE.searcher.queryResultCache.inserts": 0,
+          "CACHE.searcher.queryResultCache.hitratio": 0,
+          "CACHE.searcher.queryResultCache.size": 0,
+          "CACHE.searcher.queryResultCache.cumulative_hitratio": 0,
+          "CACHE.searcher.queryResultCache.cumulative_hits": 0,
+          "CACHE.searcher.queryResultCache.hits": 0
+        }
+      },
+      "fieldValueCache": {
+        "class": "org.apache.solr.search.FastLRUCache",
+        "description": "Concurrent LRU Cache(maxSize=10000, initialSize=10, minSize=9000, acceptableSize=9500, cleanupThread=false)",
+        "stats": {
+          "CACHE.searcher.fieldValueCache.warmupTime": 0,
+          "CACHE.searcher.fieldValueCache.inserts": 0,
+          "CACHE.searcher.fieldValueCache.hits": 0,
+          "CACHE.searcher.fieldValueCache.lookups": 468,
+          "CACHE.searcher.fieldValueCache.cumulative_hitratio": 0,
+          "CACHE.searcher.fieldValueCache.hitratio": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_hits": 0,
+          "CACHE.searcher.fieldValueCache.size": 0,
+          "CACHE.searcher.fieldValueCache.evictions": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_lookups": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_inserts": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_evictions": 0
+        }
+      },
+      "filterCache": {
+        "class": "org.apache.solr.search.FastLRUCache",
+        "description": "Concurrent LRU Cache(maxSize=512, initialSize=512, minSize=460, acceptableSize=486, cleanupThread=false)",
+        "stats": {
+          "CACHE.searcher.filterCache.hits": 0,
+          "CACHE.searcher.filterCache.cumulative_evictions": 0,
+          "CACHE.searcher.filterCache.cumulative_inserts": 0,
+          "CACHE.searcher.filterCache.size": 0,
+          "CACHE.searcher.filterCache.hitratio": 0,
+          "CACHE.searcher.filterCache.warmupTime": 0,
+          "CACHE.searcher.filterCache.inserts": 0,
+          "CACHE.searcher.filterCache.evictions": 0,
+          "CACHE.searcher.filterCache.cumulative_hitratio": 0,
+          "CACHE.searcher.filterCache.lookups": 135,
+          "CACHE.searcher.filterCache.cumulative_lookups": 0,
+          "CACHE.searcher.filterCache.cumulative_hits": 0
+        }
+      },
+      "documentCache": {
+        "class": "org.apache.solr.search.LRUCache",
+        "description": "LRU Cache(maxSize=512, initialSize=512)",
+        "stats": {
+          "CACHE.searcher.documentCache.evictions": 0,
+          "CACHE.searcher.documentCache.cumulative_lookups": 0,
+          "CACHE.searcher.documentCache.hitratio": 0,
+          "CACHE.searcher.documentCache.size": 0,
+          "CACHE.searcher.documentCache.cumulative_hitratio": 0,
+          "CACHE.searcher.documentCache.lookups": 246,
+          "CACHE.searcher.documentCache.warmupTime": 0,
+          "CACHE.searcher.documentCache.inserts": 0,
+          "CACHE.searcher.documentCache.hits": 0,
+          "CACHE.searcher.documentCache.cumulative_hits": 0,
+          "CACHE.searcher.documentCache.cumulative_inserts": 0,
+          "CACHE.searcher.documentCache.cumulative_evictions": 0
+        }
+      }
+    }
+  ]
+}

--- a/mackerel-plugin-solr/lib/stats/7.7.2/cores.json
+++ b/mackerel-plugin-solr/lib/stats/7.7.2/cores.json
@@ -1,0 +1,34 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 9
+  },
+  "initFailures": {},
+  "status": {
+    "testcore": {
+      "name": "testcore",
+      "instanceDir": "/opt/solr/server/solr/testcore",
+      "dataDir": "/opt/solr/server/solr/testcore/data/",
+      "config": "solrconfig.xml",
+      "schema": "managed-schema",
+      "startTime": "2019-08-12T06:06:56.844Z",
+      "uptime": 162703,
+      "index": {
+        "numDocs": 12345,
+        "maxDoc": 0,
+        "deletedDocs": 54321,
+        "indexHeapUsageBytes": 128,
+        "version": 2,
+        "segmentCount": 256,
+        "current": true,
+        "hasDeletions": false,
+        "directory": "org.apache.lucene.store.NRTCachingDirectory:NRTCachingDirectory(MMapDirectory@/opt/solr/server/solr/testcore/data/index lockFactory=org.apache.lucene.store.NativeFSLockFactory@60d6d681; maxCacheMB=48.0 maxMergeSizeMB=4.0)",
+        "segmentsFile": "segments_1",
+        "segmentsFileSizeInBytes": 69,
+        "userData": {},
+        "sizeInBytes": 512,
+        "size": "69 bytes"
+      }
+    }
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/7.7.2/query.json
+++ b/mackerel-plugin-solr/lib/stats/7.7.2/query.json
@@ -1,0 +1,39 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 8
+  },
+  "solr-mbeans": [
+    "QUERY",
+    {
+      "/select": {
+        "class": "org.apache.solr.handler.component.SearchHandler",
+        "description": "Search using components: ",
+        "stats": {
+          "QUERY./select.errors.count": 222,
+          "QUERY./select.handlerStart": 1565590018289,
+          "QUERY./select.clientErrors.count": 432,
+          "QUERY./select.requestTimes.meanRate": 0.123,
+          "QUERY./select.serverErrors.count": 234,
+          "QUERY./select.timeouts.count": 333,
+          "QUERY./select.totalTime": 0,
+          "QUERY./select.requests": 111
+        }
+      },
+      "/get": {
+        "class": "org.apache.solr.handler.RealTimeGetHandler",
+        "description": "The realtime get handler",
+        "stats": {
+          "QUERY./get.handlerStart": 1565590017803,
+          "QUERY./get.errors.count": 0,
+          "QUERY./get.requests": 0,
+          "QUERY./get.totalTime": 0,
+          "QUERY./get.requestTimes.meanRate": 0,
+          "QUERY./get.clientErrors.count": 0,
+          "QUERY./get.serverErrors.count": 0,
+          "QUERY./get.timeouts.count": 0
+        }
+      }
+    }
+  ]
+}

--- a/mackerel-plugin-solr/lib/stats/7.7.2/replication.json
+++ b/mackerel-plugin-solr/lib/stats/7.7.2/replication.json
@@ -1,0 +1,36 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 5
+  },
+  "solr-mbeans": [
+    "REPLICATION",
+    {
+      "/replication": {
+        "class": "org.apache.solr.handler.ReplicationHandler",
+        "description": "ReplicationHandler provides replication of index and configuration files from Master to Slaves",
+        "stats": {
+          "REPLICATION./replication.handlerStart": 1565590017772,
+          "REPLICATION./replication.confFilesToReplicate": "",
+          "REPLICATION./replication.indexVersion": "generation=1,version=0",
+          "REPLICATION./replication.indexSize": "69 bytes",
+          "REPLICATION./replication.generation": 1,
+          "REPLICATION./replication.indexPath": "/opt/solr/server/solr/testcore/data/index/",
+          "REPLICATION./replication.replicateAfter": [
+            "commit"
+          ],
+          "REPLICATION./replication.isMaster": true,
+          "REPLICATION./replication.clientErrors.count": 54321,
+          "REPLICATION./replication.isSlave": false,
+          "REPLICATION./replication.requests": 11111,
+          "REPLICATION./replication.errors.count": 22222,
+          "REPLICATION./replication.requestTimes.meanRate": 0.12345,
+          "REPLICATION./replication.timeouts.count": 33333,
+          "REPLICATION./replication.serverErrors.count": 12345,
+          "REPLICATION./replication.replicationEnabled": true,
+          "REPLICATION./replication.totalTime": 0
+        }
+      }
+    }
+  ]
+}

--- a/mackerel-plugin-solr/lib/stats/7.7.2/system.json
+++ b/mackerel-plugin-solr/lib/stats/7.7.2/system.json
@@ -1,0 +1,8 @@
+{
+  "lucene": {
+    "solr-spec-version": "7.7.2",
+    "solr-impl-version": "7.7.2 d4c30fc2856154f2c1fefc589eb7cd070a415b94 - janhoy - 2019-05-28 23:37:48",
+    "lucene-spec-version": "7.7.2",
+    "lucene-impl-version": "7.7.2 d4c30fc2856154f2c1fefc589eb7cd070a415b94 - janhoy - 2019-05-28 23:30:25"
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/7.7.2/update.json
+++ b/mackerel-plugin-solr/lib/stats/7.7.2/update.json
@@ -1,0 +1,67 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1
+  },
+  "solr-mbeans": [
+    "UPDATE",
+    {
+      "/update/json": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update/json.errors.count": 0,
+          "UPDATE./update/json.requestTimes.meanRate": 0,
+          "UPDATE./update/json.requests": 0,
+          "UPDATE./update/json.clientErrors.count": 0,
+          "UPDATE./update/json.serverErrors.count": 0,
+          "UPDATE./update/json.totalTime": 0,
+          "UPDATE./update/json.handlerStart": 1565590017596,
+          "UPDATE./update/json.timeouts.count": 0
+        }
+      },
+      "/update/json/docs": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update/json/docs.serverErrors.count": 0,
+          "UPDATE./update/json/docs.requests": 0,
+          "UPDATE./update/json/docs.clientErrors.count": 0,
+          "UPDATE./update/json/docs.handlerStart": 1565590017613,
+          "UPDATE./update/json/docs.requestTimes.meanRate": 0,
+          "UPDATE./update/json/docs.timeouts.count": 0,
+          "UPDATE./update/json/docs.errors.count": 0,
+          "UPDATE./update/json/docs.totalTime": 0
+        }
+      },
+      "/update/csv": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update/csv.requestTimes.meanRate": 0,
+          "UPDATE./update/csv.errors.count": 0,
+          "UPDATE./update/csv.serverErrors.count": 0,
+          "UPDATE./update/csv.clientErrors.count": 0,
+          "UPDATE./update/csv.timeouts.count": 0,
+          "UPDATE./update/csv.requests": 0,
+          "UPDATE./update/csv.totalTime": 0,
+          "UPDATE./update/csv.handlerStart": 1565590017601
+        }
+      },
+      "/update": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update.clientErrors.count": 4321,
+          "UPDATE./update.serverErrors.count": 1234,
+          "UPDATE./update.requestTimes.meanRate": 0.1234,
+          "UPDATE./update.timeouts.count": 3333,
+          "UPDATE./update.errors.count": 2222,
+          "UPDATE./update.totalTime": 0,
+          "UPDATE./update.requests": 1111,
+          "UPDATE./update.handlerStart": 1565590017592
+        }
+      }
+    }
+  ]
+}

--- a/mackerel-plugin-solr/lib/stats/8.1.1/cache.json
+++ b/mackerel-plugin-solr/lib/stats/8.1.1/cache.json
@@ -1,0 +1,101 @@
+{
+  "solr-mbeans": [
+    "CACHE",
+    {
+      "fieldValueCache": {
+        "class": "org.apache.solr.search.FastLRUCache",
+        "description": "Concurrent LRU Cache(maxSize=10000, initialSize=10, minSize=9000, acceptableSize=9500, cleanupThread=false)",
+        "stats": {
+          "CACHE.searcher.fieldValueCache.warmupTime": 0,
+          "CACHE.searcher.fieldValueCache.inserts": 0,
+          "CACHE.searcher.fieldValueCache.hits": 0,
+          "CACHE.searcher.fieldValueCache.lookups": 468,
+          "CACHE.searcher.fieldValueCache.cumulative_hitratio": 0,
+          "CACHE.searcher.fieldValueCache.hitratio": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_hits": 0,
+          "CACHE.searcher.fieldValueCache.size": 0,
+          "CACHE.searcher.fieldValueCache.evictions": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_lookups": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_inserts": 0,
+          "CACHE.searcher.fieldValueCache.cumulative_evictions": 0
+        }
+      },
+      "documentCache": {
+        "class": "org.apache.solr.search.LRUCache",
+        "description": "LRU Cache(maxSize=512, initialSize=512)",
+        "stats": {
+          "CACHE.searcher.documentCache.evictions": 0,
+          "CACHE.searcher.documentCache.cumulative_lookups": 0,
+          "CACHE.searcher.documentCache.hitratio": 0,
+          "CACHE.searcher.documentCache.size": 0,
+          "CACHE.searcher.documentCache.cumulative_hitratio": 0,
+          "CACHE.searcher.documentCache.lookups": 246,
+          "CACHE.searcher.documentCache.warmupTime": 0,
+          "CACHE.searcher.documentCache.inserts": 0,
+          "CACHE.searcher.documentCache.hits": 0,
+          "CACHE.searcher.documentCache.cumulative_hits": 0,
+          "CACHE.searcher.documentCache.cumulative_inserts": 0,
+          "CACHE.searcher.documentCache.cumulative_evictions": 0
+        }
+      },
+      "queryResultCache": {
+        "class": "org.apache.solr.search.LRUCache",
+        "description": "LRU Cache(maxSize=512, initialSize=512)",
+        "stats": {
+          "CACHE.searcher.queryResultCache.cumulative_inserts": 1,
+          "CACHE.searcher.queryResultCache.evictions": 0,
+          "CACHE.searcher.queryResultCache.lookups": 579,
+          "CACHE.searcher.queryResultCache.cumulative_lookups": 3,
+          "CACHE.searcher.queryResultCache.cumulative_evictions": 0,
+          "CACHE.searcher.queryResultCache.warmupTime": 0,
+          "CACHE.searcher.queryResultCache.inserts": 1,
+          "CACHE.searcher.queryResultCache.hitratio": 0,
+          "CACHE.searcher.queryResultCache.size": 1,
+          "CACHE.searcher.queryResultCache.cumulative_hitratio": 0.67,
+          "CACHE.searcher.queryResultCache.cumulative_hits": 0,
+          "CACHE.searcher.queryResultCache.hits": 0
+        }
+      },
+      "perSegFilter": {
+        "class": "org.apache.solr.search.LRUCache",
+        "description": "LRU Cache(maxSize=10, initialSize=0, autowarmCount=10, regenerator=org.apache.solr.search.NoOpRegenerator@2d91e661)",
+        "stats": {
+          "CACHE.searcher.perSegFilter.lookups": 357,
+          "CACHE.searcher.perSegFilter.hits": 0,
+          "CACHE.searcher.perSegFilter.hitratio": 0,
+          "CACHE.searcher.perSegFilter.warmupTime": 0,
+          "CACHE.searcher.perSegFilter.cumulative_lookups": 0,
+          "CACHE.searcher.perSegFilter.cumulative_inserts": 0,
+          "CACHE.searcher.perSegFilter.cumulative_hitratio": 0,
+          "CACHE.searcher.perSegFilter.size": 0,
+          "CACHE.searcher.perSegFilter.evictions": 0,
+          "CACHE.searcher.perSegFilter.cumulative_hits": 0,
+          "CACHE.searcher.perSegFilter.cumulative_evictions": 0,
+          "CACHE.searcher.perSegFilter.inserts": 0
+        }
+      },
+      "filterCache": {
+        "class": "org.apache.solr.search.FastLRUCache",
+        "description": "Concurrent LRU Cache(maxSize=512, initialSize=512, minSize=460, acceptableSize=486, cleanupThread=false)",
+        "stats": {
+          "CACHE.searcher.filterCache.hits": 0,
+          "CACHE.searcher.filterCache.cumulative_evictions": 0,
+          "CACHE.searcher.filterCache.cumulative_inserts": 0,
+          "CACHE.searcher.filterCache.size": 0,
+          "CACHE.searcher.filterCache.hitratio": 0,
+          "CACHE.searcher.filterCache.warmupTime": 0,
+          "CACHE.searcher.filterCache.inserts": 0,
+          "CACHE.searcher.filterCache.evictions": 0,
+          "CACHE.searcher.filterCache.cumulative_hitratio": 0,
+          "CACHE.searcher.filterCache.lookups": 135,
+          "CACHE.searcher.filterCache.cumulative_lookups": 0,
+          "CACHE.searcher.filterCache.cumulative_hits": 0
+        }
+      }
+    }
+  ],
+  "responseHeader": {
+    "status": 0,
+    "QTime": 0
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/8.1.1/cores.json
+++ b/mackerel-plugin-solr/lib/stats/8.1.1/cores.json
@@ -1,0 +1,34 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 0
+  },
+  "initFailures": {},
+  "status": {
+    "testcore": {
+      "name": "testcore",
+      "instanceDir": "/var/solr/data/testcore",
+      "dataDir": "/var/solr/data/testcore/data/",
+      "config": "solrconfig.xml",
+      "schema": "managed-schema",
+      "startTime": "2019-08-05T07:31:58.313Z",
+      "uptime": 160866,
+      "index": {
+        "numDocs": 12345,
+        "maxDoc": 0,
+        "deletedDocs": 54321,
+        "indexHeapUsageBytes": 128,
+        "version": 2,
+        "segmentCount": 256,
+        "current": true,
+        "hasDeletions": false,
+        "directory": "org.apache.lucene.store.NRTCachingDirectory:NRTCachingDirectory(MMapDirectory@/var/solr/data/testcore/data/index lockFactory=org.apache.lucene.store.NativeFSLockFactory@44eea421; maxCacheMB=48.0 maxMergeSizeMB=4.0)",
+        "segmentsFile": "segments_1",
+        "segmentsFileSizeInBytes": 69,
+        "userData": {},
+        "sizeInBytes": 512,
+        "size": "69 bytes"
+      }
+    }
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/8.1.1/query.json
+++ b/mackerel-plugin-solr/lib/stats/8.1.1/query.json
@@ -1,0 +1,39 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 0
+  },
+  "solr-mbeans": [
+    "QUERY",
+    {
+      "/select": {
+        "class": "org.apache.solr.handler.component.SearchHandler",
+        "description": "Search using components: ",
+        "stats": {
+          "QUERY./select.errors.count": 222,
+          "QUERY./select.handlerStart": 1564990318671,
+          "QUERY./select.clientErrors.count": 432,
+          "QUERY./select.requestTimes.meanRate": 0.123,
+          "QUERY./select.serverErrors.count": 234,
+          "QUERY./select.timeouts.count": 333,
+          "QUERY./select.totalTime": 0,
+          "QUERY./select.requests": 111
+        }
+      },
+      "/get": {
+        "class": "org.apache.solr.handler.RealTimeGetHandler",
+        "description": "The realtime get handler",
+        "stats": {
+          "QUERY./get.handlerStart": 1564990318575,
+          "QUERY./get.errors.count": 0,
+          "QUERY./get.requests": 0,
+          "QUERY./get.totalTime": 0,
+          "QUERY./get.requestTimes.meanRate": 0,
+          "QUERY./get.clientErrors.count": 0,
+          "QUERY./get.serverErrors.count": 0,
+          "QUERY./get.timeouts.count": 0
+        }
+      }
+    }
+  ]
+}

--- a/mackerel-plugin-solr/lib/stats/8.1.1/replication.json
+++ b/mackerel-plugin-solr/lib/stats/8.1.1/replication.json
@@ -1,0 +1,36 @@
+{
+  "solr-mbeans": [
+    "REPLICATION",
+    {
+      "/replication": {
+        "class": "org.apache.solr.handler.ReplicationHandler",
+        "description": "ReplicationHandler provides replication of index and configuration files from Master to Slaves",
+        "stats": {
+          "REPLICATION./replication.handlerStart": 1564990318571,
+          "REPLICATION./replication.confFilesToReplicate": "",
+          "REPLICATION./replication.indexVersion": "generation=1,version=0",
+          "REPLICATION./replication.indexSize": "69 bytes",
+          "REPLICATION./replication.generation": 1,
+          "REPLICATION./replication.indexPath": "/var/solr/data/testcore/data/index/",
+          "REPLICATION./replication.replicateAfter": [
+            "commit"
+          ],
+          "REPLICATION./replication.isMaster": true,
+          "REPLICATION./replication.clientErrors.count": 54321,
+          "REPLICATION./replication.isSlave": false,
+          "REPLICATION./replication.requests": 11111,
+          "REPLICATION./replication.errors.count": 22222,
+          "REPLICATION./replication.requestTimes.meanRate": 0.12345,
+          "REPLICATION./replication.timeouts.count": 33333,
+          "REPLICATION./replication.serverErrors.count": 12345,
+          "REPLICATION./replication.replicationEnabled": true,
+          "REPLICATION./replication.totalTime": 0
+        }
+      }
+    }
+  ],
+  "responseHeader": {
+    "QTime": 2,
+    "status": 0
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/8.1.1/system.json
+++ b/mackerel-plugin-solr/lib/stats/8.1.1/system.json
@@ -1,0 +1,8 @@
+{
+  "lucene": {
+    "solr-spec-version": "8.1.1",
+    "solr-impl-version": "8.1.1 fcbe46c28cef11bc058779afba09521de1b19bef - ab - 2019-05-22 15:20:01",
+    "lucene-spec-version": "8.1.1",
+    "lucene-impl-version": "8.1.1 fcbe46c28cef11bc058779afba09521de1b19bef - ab - 2019-05-22 15:15:24"
+  }
+}

--- a/mackerel-plugin-solr/lib/stats/8.1.1/update.json
+++ b/mackerel-plugin-solr/lib/stats/8.1.1/update.json
@@ -1,0 +1,67 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 0
+  },
+  "solr-mbeans": [
+    "UPDATE",
+    {
+      "/update/json": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update/json.errors.count": 0,
+          "UPDATE./update/json.requestTimes.meanRate": 0,
+          "UPDATE./update/json.requests": 0,
+          "UPDATE./update/json.clientErrors.count": 0,
+          "UPDATE./update/json.serverErrors.count": 0,
+          "UPDATE./update/json.totalTime": 0,
+          "UPDATE./update/json.handlerStart": 1564990318545,
+          "UPDATE./update/json.timeouts.count": 0
+        }
+      },
+      "/update/json/docs": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update/json/docs.serverErrors.count": 0,
+          "UPDATE./update/json/docs.requests": 0,
+          "UPDATE./update/json/docs.clientErrors.count": 0,
+          "UPDATE./update/json/docs.handlerStart": 1564990318547,
+          "UPDATE./update/json/docs.requestTimes.meanRate": 0,
+          "UPDATE./update/json/docs.timeouts.count": 0,
+          "UPDATE./update/json/docs.errors.count": 0,
+          "UPDATE./update/json/docs.totalTime": 0
+        }
+      },
+      "/update/csv": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update/csv.requestTimes.meanRate": 0,
+          "UPDATE./update/csv.errors.count": 0,
+          "UPDATE./update/csv.serverErrors.count": 0,
+          "UPDATE./update/csv.clientErrors.count": 0,
+          "UPDATE./update/csv.timeouts.count": 0,
+          "UPDATE./update/csv.requests": 0,
+          "UPDATE./update/csv.totalTime": 0,
+          "UPDATE./update/csv.handlerStart": 1564990318546
+        }
+      },
+      "/update": {
+        "class": "org.apache.solr.handler.UpdateRequestHandler",
+        "description": "Add documents using XML (with XSLT), CSV, JSON, or javabin",
+        "stats": {
+          "UPDATE./update.clientErrors.count": 4321,
+          "UPDATE./update.serverErrors.count": 1234,
+          "UPDATE./update.requestTimes.meanRate": 0.1234,
+          "UPDATE./update.timeouts.count": 3333,
+          "UPDATE./update.errors.count": 2222,
+          "UPDATE./update.totalTime": 0,
+          "UPDATE./update.requests": 1111,
+          "UPDATE./update.handlerStart": 1564990318544
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Hi,

We'd like to migrate Apache Solr from `5.x` to `8.x`, however, it seems several metrics keys are changed and removed since `7.x` like follows.

### Graphs

| Label | `5.x` | `6.x` | `7.x` | `8.x` |
| --- | --- | --- | --- | --- |
| Requests | Y | Y | Y | Y |
| Errors | Y | Y | Y | Y |
| Timeouts | Y | Y | Y | Y |
| AvgRequestsPerSecond | Y | Y |  |  |
| 5minRateReqsPerSecond | Y |  |  |  |
| 5minRateRequestsPerSecond |  | Y |  |  |
| 15minRateReqsPerSecond | Y |  |  |  |
| 15minRateRequestsPerSecond |  | Y |  |  |
| AvgTimePerRequest | Y | Y |  |  |
| MedianRequestTime | Y | Y |  |  |
| 75thPcRequestTime | Y | Y |  |  |
| 95thPcRequestTime | Y | Y |  |  |
| 99thPcRequestTime | Y | Y |  |  |
| 999thPcRequestTime | Y | Y |  |  |
| ClientErrors |  |  | Y | Y |
| ServerErrors |  |  | Y | Y |
| RequestTimes |  |  | Y | Y |

### `8.x` response

```
$ curl -s -S 'http://localhost:8983/solr/open_works/admin/mbeans?wt=json&stats=true&cat=QUERY&key=/select' | jq .
{
  "responseHeader": {
    "status": 0,
    "QTime": 0
  },
  "solr-mbeans": [
    "QUERY",
    {
      "/select": {
        "class": "org.apache.solr.handler.component.SearchHandler",
        "description": "Search using components: query,facet,facet_module,mlt,highlight,stats,expand,terms,debug,",
        "stats": {
          "QUERY./select.errors.count": 0,
          "QUERY./select.handlerStart": 1564978925224,
          "QUERY./select.clientErrors.count": 0,
          "QUERY./select.requestTimes.meanRate": 0.015950988833303,
          "QUERY./select.serverErrors.count": 0,
          "QUERY./select.timeouts.count": 0,
          "QUERY./select.totalTime": 9748743578,
          "QUERY./select.requests": 3123
        }
      }
    }
  ]
}
```

### `5.x` response

```
$ curl -s -S 'http://localhost:8983/solr/open_works/admin/mbeans?wt=json&stats=true&cat=QUERYHANDLER&key=/select' | jq .
{
  "responseHeader": {
    "status": 0,
    "QTime": 1
  },
  "solr-mbeans": [
    "QUERYHANDLER",
    {
      "/select": {
        "class": "org.apache.solr.handler.component.SearchHandler",
        "version": "5.2.1",
        "description": "Search using components: ",
        "src": null,
        "stats": {
          "handlerStart": 1564021845004,
          "requests": 0,
          "errors": 0,
          "timeouts": 0,
          "totalTime": 0,
          "avgRequestsPerSecond": 0,
          "5minRateReqsPerSecond": 0,
          "15minRateReqsPerSecond": 0,
          "avgTimePerRequest": 0,
          "medianRequestTime": 0,
          "75thPcRequestTime": 0,
          "95thPcRequestTime": 0,
          "99thPcRequestTime": 0,
          "999thPcRequestTime": 0
        }
      }
    }
  ]
}
```