### PR TITLE
[sidekiq] add option for redis-namespace

### DIFF
--- a/mackerel-plugin-sidekiq/README.md
+++ b/mackerel-plugin-sidekiq/README.md
@@ -1,7 +1,7 @@
 mackerel-plugin-sidekiq
 ====
 
-## Overview  
+## Overview
 Sidekiq custom metrics plugin for mackerel.io agent.
 
 ## Description
@@ -11,7 +11,7 @@ This plugin makes two graphs: one shows processed job diff and failed job diff, 
 ## Usage
 
 ```
-mackerel-plugin-sidekiq [-host=<host>] [-port=<port>] [-password=<password>] [-db=<db>] [-tempfile=<template file path>]
+mackerel-plugin-sidekiq [-host=<host>] [-port=<port>] [-password=<password>] [-db=<db>] [-tempfile=<template file path>] [-redis-namespace=<redis namespace>]
 ```
 
 ### Example of mackerel-agent.conf


### PR DESCRIPTION
Our rails applications use sidekiq with redis-namespace gem.
I installed mackerel-plugin-sidekiq, but I couldn't gather any metrics.

So I added option for redis-namespace.
