### PR TITLE
[solr] Fix several graph definitions

### DIFF
--- a/mackerel-plugin-solr/lib/solr.go
+++ b/mackerel-plugin-solr/lib/solr.go
@@ -267,7 +267,8 @@ func (s SolrPlugin) GraphDefinition() map[string]mp.Graphs {
 				path = escapeSlash(path)
 				metricLabel := strings.Title(path)
 				diff := false
-				if key == "requests" {
+				if key == "requests" || key == "errors" || key == "timeouts" ||
+					key == "clientErrors" || key == "serverErrors" || key == "requestTimes" {
 					diff = true
 				}
 				metrics = append(metrics,


### PR DESCRIPTION
Hello,

I found that several metrics values are cumulative in Apache Solr. So they are needed to specify the option `Diff: true`.