### PR TITLE
[varnish] Added backend_reuse and backend_recycle metrics

### DIFF
--- a/mackerel-plugin-varnish/lib/varnish.go
+++ b/mackerel-plugin-varnish/lib/varnish.go
@@ -27,6 +27,8 @@ var graphdef = map[string]mp.Graphs{
 			{Name: "backend_req", Label: "Requests", Diff: true},
 			{Name: "backend_conn", Label: "Conn success", Diff: true},
 			{Name: "backend_fail", Label: "Conn fail", Diff: true},
+			{Name: "backend_reuse", Label: "Conn reuse", Diff: true},
+			{Name: "backend_recycle", Label: "Conn recycle", Diff: true},
 		},
 	},
 	"varnish.objects": {
@@ -124,6 +126,10 @@ func (m VarnishPlugin) FetchMetrics() (map[string]interface{}, error) {
 			stat["backend_conn"] = tmpv
 		case "MAIN.backend_fail":
 			stat["backend_fail"] = tmpv
+		case "MAIN.backend_reuse":
+			stat["backend_reuse"] = tmpv
+		case "MAIN.backend_recycle":
+			stat["backend_recycle"] = tmpv
 		case "MAIN.n_object":
 			stat["n_object"] = tmpv
 		case "MAIN.n_objectcore":


### PR DESCRIPTION
If varnish persists communication with the upstream, the values of backend_reuse and backend_recycle also change.

- [Reusing backend connections to increase performance](https://www.fastly.com/blog/reusing-backend-connections-increase-performance)
  - > What you're looking for is for backend_reuse to not be zero, and ideally to be an order of magnitude, or more, higher than backend_conn. 
- [Enormous amount of connections stuck in CLOSE_WAIT state with Varnish](https://stackoverflow.com/questions/27247756/enormous-amount-of-connections-stuck-in-close-wait-state-with-varnish)
  - > And finally, check the output of varnishstat -1 |grep backend to see if varnish is able to reuse backend connections (backend_reuse) and if it has noticed that they are closed (backend_toolate). The values should be so backend_reuse + backend_toolate ≅ backend_recycle.