### PR TITLE
ignore diffs of go.mod and go.sum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ testgo: testdeps
 .PHONY: testconvention
 testconvention:
 	prove -r t/
-	go generate ./... && git diff --exit-code || \
+	go generate ./... && git diff --exit-code -- . ':(exclude)go.*' || \
 	  (echo 'please `go generate ./...` and commit them' && false)
 
 .PHONY: testdeps


### PR DESCRIPTION
This PR will modify `make testconvention`.

The PRs created by Dependabot sometimes breaks the CI because the CI processes may update **go.\*** files automatically. ex: #619

`make testconvention` checks whether there is the diffs or not. This behavior purposes in checking to need to run `go generate`. Therefore it is not needed to know that **go.\*** files was changed in CI processes.

This code was tested on #625