### PR TITLE
[plugin-linux] Do not skip diskstat metrics with Linux kernel 4.18+

### DIFF
--- a/mackerel-plugin-linux/lib/linux.go
+++ b/mackerel-plugin-linux/lib/linux.go
@@ -331,7 +331,7 @@ func collectDiskStats(path string, p *map[string]interface{}) error {
 
 func parseDiskStat(name, stat string, p *map[string]interface{}) error {
 	fields := strings.Fields(stat)
-	if len(fields) != 11 {
+	if len(fields) < 11 {
 		return nil
 	}
 

--- a/mackerel-plugin-linux/lib/linux_test.go
+++ b/mackerel-plugin-linux/lib/linux_test.go
@@ -202,6 +202,19 @@ func TestParseDiskStat(t *testing.T) {
 	assert.EqualValues(t, stat[fmt.Sprintf("tswriting_%s", name)], 1648460)
 }
 
+func TestParseDiskStat_NewerKernel(t *testing.T) {
+	name := "testdevice"
+	stub := `   28994        0   304494    16115    10063    42070  1546600    41730        0     3434    55235        0        0        0        0`
+	stat := make(map[string]interface{})
+
+	err := parseDiskStat(name, stub, &stat)
+	assert.Nil(t, err)
+	assert.EqualValues(t, stat[fmt.Sprintf("iotime_%s", name)], 3434)
+	assert.EqualValues(t, stat[fmt.Sprintf("iotime_weighted_%s", name)], 55235)
+	assert.EqualValues(t, stat[fmt.Sprintf("tsreading_%s", name)], 16115)
+	assert.EqualValues(t, stat[fmt.Sprintf("tswriting_%s", name)], 41730)
+}
+
 func TestCollectVirtualDevice(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/mackerel-plugin-linux/lib/linux_test.go
+++ b/mackerel-plugin-linux/lib/linux_test.go
@@ -202,7 +202,7 @@ func TestParseDiskStat(t *testing.T) {
 	assert.EqualValues(t, stat[fmt.Sprintf("tswriting_%s", name)], 1648460)
 }
 
-func TestParseDiskStat_NewerKernel(t *testing.T) {
+func TestParseDiskStat_Kernel4_18(t *testing.T) {
 	name := "testdevice"
 	stub := `   28994        0   304494    16115    10063    42070  1546600    41730        0     3434    55235        0        0        0        0`
 	stat := make(map[string]interface{})


### PR DESCRIPTION
ref: #655

As reported at #655, Linux Kkrnel 4.18+ has 11+ fields in `/sys/block/*/stat` and mackerel-plugin-linux did not consider such cases.

Easiest way to testing with macOS is using Docker for Mac, since its linuxkit has kernel 4.19. (Note that this behavior depends kernel version, not Docker image's Linux distribution version.)

```
[github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-linux]$ docker run --rm -it -v $(PWD):/app debian:buster
root@d97d5092b97e:/# uname -a
Linux d97d5092b97e 4.19.76-linuxkit #1 SMP Tue May 26 11:42:35 UTC 2020 x86_64 GNU/Linux
root@d97d5092b97e:/# /app/mackerel-plugin-linux
2020/07/27 14:14:57 interrupts does not exist at last fetch
2020/07/27 14:14:57 context_switches does not exist at last fetch
2020/07/27 14:14:57 forks does not exist at last fetch
2020/07/27 14:14:57 pswpin does not exist at last fetch
2020/07/27 14:14:57 pswpout does not exist at last fetch
linux.ss.UNCONN	10.000000	1595859297
2020/07/27 14:14:57 iotime_vda does not exist at last fetch
2020/07/27 14:14:57 iotime_weighted_vda does not exist at last fetch
2020/07/27 14:14:57 tsreading_vda does not exist at last fetch
2020/07/27 14:14:57 tswriting_vda does not exist at last fetch
root@d97d5092b97e:/# /app/mackerel-plugin-linux
linux.swap.pswpin	0.000000	1595859302
linux.swap.pswpout	0.000000	1595859302
linux.ss.UNCONN	10.000000	1595859302
linux.disk.elapsed.iotime_vda	24.000000	1595859302
linux.disk.elapsed.iotime_weighted_vda	24.000000	1595859302
linux.disk.rwtime.tsreading_vda	0.000000	1595859302
linux.disk.rwtime.tswriting_vda	48.000000	1595859302
linux.interrupts.interrupts	45684.000000	1595859302
linux.context_switches.context_switches	87708.000000	1595859302
linux.forks.forks	264.000000	1595859302
root@d97d5092b97e:/# cat /sys/block/vda/stat
   28994        0   304494    16115    10616    43123  1559456    41966        0     3479    55383        0        0        0        0
```