### PR TITLE
Enables to parse responses which include string and number from Plack.

### DIFF
--- a/mackerel-plugin-plack/lib/plack_test.go
+++ b/mackerel-plugin-plack/lib/plack_test.go
@@ -97,3 +97,19 @@ func TestParseWithInsufficientResponse(t *testing.T) {
 	assert.EqualValues(t, stat["requests"], uint(670))
 	assert.Nil(t, stat["idle_workers"])
 }
+
+func TestParseWithNumberResponse(t *testing.T) {
+	var plack PlackPlugin
+	stub := `
+{"TotalKbytes":36,"IdleWorkers":5,"BusyWorkers":3,"TotalAccesses":670,"stats":[],"Uptime":"1474047568"}
+`
+	plackStats := bytes.NewBufferString(stub)
+
+	stat, err := plack.parseStats(plackStats)
+	fmt.Println(stat)
+	assert.Nil(t, err)
+	assert.EqualValues(t, stat["bytes_sent"], 36)
+	assert.EqualValues(t, stat["busy_workers"], 3)
+	assert.EqualValues(t, stat["idle_workers"], 5)
+	assert.EqualValues(t, stat["requests"], uint(670))
+}


### PR DESCRIPTION
I encountered responses as below from Plack::Middleware::ServerStatus::Lite 0.36 & Perl 5.32.
The responses include xxxKbytes and xxxWorkers values encoded as a JSON number, not a string.

```json
{
  "TotalKbytes": 0,
  "BusyWorkers": 1,
  "stats": [],
  "TotalAccesses": 3,
  "IdleWorkers": 4,
  "Uptime": "1607091099"
}
```

This PR enables to parse numbers and strings both in the responses.