### PR TITLE
migrate from goamz,go-ses to aws-sdk-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/alouca/gologger v0.0.0-20120904114645-7d4b7291de9c // indirect
 	github.com/alouca/gosnmp v0.0.0-20170620005048-04d83944c9ab
 	github.com/aws/aws-sdk-go v1.36.28
-	github.com/crowdmob/goamz v0.0.0-20150128194925-3a06871fe9fc
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5
 	github.com/fsouza/go-dockerclient v1.7.0
 	github.com/fukata/golang-stats-api-handler v1.0.0
@@ -44,10 +43,8 @@ require (
 	github.com/mattn/go-treasuredata v0.0.0-20170920030233-31758907cfc4
 	github.com/michaelklishin/rabbit-hole v1.5.0
 	github.com/montanaflynn/stats v0.6.4
-	github.com/naokibtn/go-ses v0.0.0-20150122091825-74908b78cc76
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/soh335/go-test-redisserver v0.1.0
-	github.com/sourcegraph/go-ses v0.0.0-20160405160939-6bd8d17cf7c1 // indirect
 	github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crowdmob/goamz v0.0.0-20150128194925-3a06871fe9fc h1:Gn/roShKxUNtNYEEH+ZeGxMJ+RsCBZdIdb8pKOesTaA=
-github.com/crowdmob/goamz v0.0.0-20150128194925-3a06871fe9fc/go.mod h1:4zrXGiIhmCfgVUO6nJpSa9QVXylPKBYkLa179m59HzE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -247,8 +245,6 @@ github.com/montanaflynn/stats v0.6.4 h1:ZaPgdYrxEyFUovAKlUKInQHcDhwvjq7HtjwREE7y
 github.com/montanaflynn/stats v0.6.4/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/naokibtn/go-ses v0.0.0-20150122091825-74908b78cc76 h1:Aw10fkuaR9de/8f3GN6MNwhogl3YvwbJMKRzxMjCgZM=
-github.com/naokibtn/go-ses v0.0.0-20150122091825-74908b78cc76/go.mod h1:eHYeovSTyOIK+kWt4G7ANVFiuyqQLCfDBPq70qhyz6Y=
 github.com/nwaples/rardecode v1.0.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/octokit/go-octokit v0.4.1-0.20160312003706-812e91dfbd64/go.mod h1:2u3khcAsOOTW3hlaM3dbJxDdvwHMDGQsC5m7edPSLkg=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -285,8 +281,6 @@ github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/soh335/go-test-redisserver v0.1.0 h1:FZYs/CVmUFP1uHVq7avxU+HpRoFIv2JWzhdV/g2Hyk4=
 github.com/soh335/go-test-redisserver v0.1.0/go.mod h1:vofbm8mr+As7DkCPPNA9Jy/KOA6bBl50xd0VUkisMzY=
-github.com/sourcegraph/go-ses v0.0.0-20160405160939-6bd8d17cf7c1 h1:2Ndulo7XO8FH6BqX62+FG9Hvl1uOBwDSrE6BAkTNHtA=
-github.com/sourcegraph/go-ses v0.0.0-20160405160939-6bd8d17cf7c1/go.mod h1:7pQ21TK+WkdBIwDfMovYhmNyGeBduRj3S089GgpNQ3g=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/mackerel-plugin-aws-ses/README.md
+++ b/mackerel-plugin-aws-ses/README.md
@@ -6,9 +6,9 @@ AWS SES custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-ses -endpoint=<SES Endpoint URL> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-ses -region=<SES Region> [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
-* SES Endpoint URL should be like "https://email.#{AWS_REGION}.amazonaws.com" (starting with "https://"). see "API (HTTPS) endpoint" column of http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html
+* You may omit region parameter if you're running this plugin on an EC2 instance running in same region with the target SES
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`
 
 ## AWS Policy
@@ -17,5 +17,5 @@ the credential provided manually or fetched automatically by IAM Role should hav
 ## Example of mackerel-agent.conf
 ```
 [plugin.metrics.aws-ses]
-command = "/path/to/mackerel-plugin-aws-ses -endpoint=https://email.us-west-2.amazonaws.com"
+command = "/path/to/mackerel-plugin-aws-ses -region=us-west-2"
 ```

--- a/mackerel-plugin-aws-ses/lib/aws-ses.go
+++ b/mackerel-plugin-aws-ses/lib/aws-ses.go
@@ -63,7 +63,7 @@ func (p SESPlugin) FetchMetrics() (map[string]float64, error) {
 		config = config.WithCredentials(credentials.NewStaticCredentials(p.AccessKeyID, p.SecretAccessKey, ""))
 	}
 	if p.Region != "" && p.Endpoint != "" {
-		return nil, errors.New("--region and --endpoint are exclusive.")
+		return nil, errors.New("--region and --endpoint are exclusive")
 	}
 	if p.Region != "" {
 		config = config.WithRegion(p.Region)
@@ -76,7 +76,7 @@ func (p SESPlugin) FetchMetrics() (map[string]float64, error) {
 		}
 		hosts := strings.Split(u.Host, ".")
 		if len(hosts) != 4 && hosts[2] == "amazonaws" {
-			return nil, errors.New("--endpoint is invalid.")
+			return nil, errors.New("--endpoint is invalid")
 		}
 		config = config.WithRegion(hosts[1])
 	}

--- a/mackerel-plugin-aws-ses/lib/aws-ses.go
+++ b/mackerel-plugin-aws-ses/lib/aws-ses.go
@@ -68,7 +68,7 @@ func (p SESPlugin) FetchMetrics() (map[string]float64, error) {
 	if p.Region != "" {
 		config = config.WithRegion(p.Region)
 	}
-    // for backward compatibility
+	// for backward compatibility
 	if p.Endpoint != "" {
 		u, err := url.Parse(p.Endpoint)
 		if err != nil {

--- a/mackerel-plugin-aws-ses/lib/aws-ses.go
+++ b/mackerel-plugin-aws-ses/lib/aws-ses.go
@@ -91,16 +91,18 @@ func (p SESPlugin) FetchMetrics() (map[string]float64, error) {
 
 		datapoints := result.SendDataPoints
 
-		for _, dp := range datapoints {
-			if latest.Timestamp.Before(*dp.Timestamp) {
-				latest = dp
+		if len(datapoints) > 0 {
+			for _, dp := range datapoints {
+				if latest.Timestamp.Before(*dp.Timestamp) {
+					latest = dp
+				}
 			}
-		}
 
-		stat["Complaints"] = float64(*latest.Complaints)
-		stat["DeliveryAttempts"] = float64(*latest.DeliveryAttempts)
-		stat["Bounces"] = float64(*latest.Bounces)
-		stat["Rejects"] = float64(*latest.Rejects)
+			stat["Complaints"] = float64(*latest.Complaints)
+			stat["DeliveryAttempts"] = float64(*latest.DeliveryAttempts)
+			stat["Bounces"] = float64(*latest.Bounces)
+			stat["Rejects"] = float64(*latest.Rejects)
+		}
 	}
 
 	return stat, nil

--- a/mackerel-plugin-aws-ses/lib/aws-ses.go
+++ b/mackerel-plugin-aws-ses/lib/aws-ses.go
@@ -68,6 +68,7 @@ func (p SESPlugin) FetchMetrics() (map[string]float64, error) {
 	if p.Region != "" {
 		config = config.WithRegion(p.Region)
 	}
+    // for backward compatibility
 	if p.Endpoint != "" {
 		u, err := url.Parse(p.Endpoint)
 		if err != nil {

--- a/mackerel-plugin-aws-ses/lib/aws-ses_test.go
+++ b/mackerel-plugin-aws-ses/lib/aws-ses_test.go
@@ -1,0 +1,21 @@
+package mpawsses
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepare_Region(t *testing.T) {
+	var p SESPlugin
+	p.Region = "us-west-2"
+	p.prepare()
+	assert.Equal(t, "us-west-2", *p.Svc.Config.Region, "Specified region is used")
+}
+
+func TestPrepare_Endpoint(t *testing.T) {
+	var p SESPlugin
+	p.Endpoint = "https://email.us-west-2.amazonaws.com"
+	p.prepare()
+	assert.Equal(t, "us-west-2", *p.Svc.Config.Region, "Convert from Endpoint to Specified Region")
+}


### PR DESCRIPTION
- migrate from goamz, go-ses to aws-sdk-go
- `--endpoint`, is changed to the deprecated
- `--region` took the place of  `--endpoint`