### PR TITLE
[ci] run tests on the workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ depends_on:
 
 .PHONY: test
 test: testgo lint testconvention
+	./test.bash
 
 .PHONY: testgo
 testgo: testdeps

--- a/mackerel-plugin-accesslog/test.sh
+++ b/mackerel-plugin-accesslog/test.sh
@@ -4,17 +4,21 @@ prog=$(basename $0)
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
 fi
 
+status=0
 for i in lib/testdata/*.*
 do
-	if $plugin -no-posfile $i; then
+	if $plugin -no-posfile $i
+	then
 		echo OK: $i
 	else
+		status=$?
 		echo FAIL: $i
 	fi
 done
+exit $status

--- a/mackerel-plugin-apache2/test.sh
+++ b/mackerel-plugin-apache2/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
@@ -10,7 +10,7 @@ fi
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
@@ -21,9 +21,4 @@ docker run -d --name test-$plugin -p 10080:80 test-$plugin
 trap 'docker stop test-$plugin; docker rm test-$plugin; docker rmi test-$plugin; exit' EXIT
 sleep 10
 
-if $plugin -p 10080 -status_page '/server-status?auto'
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin -p 10080 -status_page '/server-status?auto'

--- a/mackerel-plugin-docker/test.sh
+++ b/mackerel-plugin-docker/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
@@ -10,14 +10,10 @@ fi
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
 fi
 
-if $plugin; then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin

--- a/mackerel-plugin-mongodb/test.sh
+++ b/mackerel-plugin-mongodb/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
@@ -10,7 +10,7 @@ fi
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
@@ -28,9 +28,4 @@ docker run -d \
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10
 
-if $plugin -port $port -username=$user -password $password
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin -port $port -username=$user -password $password

--- a/mackerel-plugin-mysql/test.sh
+++ b/mackerel-plugin-mysql/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
@@ -10,7 +10,7 @@ fi
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
@@ -27,10 +27,14 @@ trap 'docker stop test-$plugin; docker rm test-$plugin; exit' 1 2 3 15 EXIT
 sleep 10
 
 # wait until bootstrap mysqld..
-while (( i++ < 3 )) && ! $plugin -port $port -password $password -enable_extended
+for i in $(seq 3)
 do
+	if $plugin -port $port -password $password -enable_extended
+	then
+		break
+	fi
 	sleep 3
 done
 sleep 1
 #export MACKEREL_PLUGIN_WORKDIR=tmp
-$plugin -port $port -password $password -enable_extended
+exec $plugin -port $port -password $password -enable_extended

--- a/mackerel-plugin-openldap/test.sh
+++ b/mackerel-plugin-openldap/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
@@ -10,7 +10,7 @@ fi
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
@@ -25,9 +25,4 @@ trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10
 
 base_dn='dc=example,dc=org'
-if $plugin -bind "cn=monitor,$base_dn" -pw passpass
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin -bind "cn=monitor,$base_dn" -pw passpass

--- a/mackerel-plugin-postgres/test.sh
+++ b/mackerel-plugin-postgres/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
@@ -10,7 +10,7 @@ fi
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
@@ -25,9 +25,4 @@ docker run -d \
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10
 
-if $plugin -port 15432 -user=$user -password $password
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin -port 15432 -user=$user -password $password

--- a/mackerel-plugin-redis/test.sh
+++ b/mackerel-plugin-redis/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
@@ -10,7 +10,7 @@ fi
 cd $(dirname $0)
 PATH=$(pwd):$PATH
 plugin=$(basename $(pwd))
-if ! which -s $plugin
+if ! which $plugin >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
@@ -21,9 +21,4 @@ docker run --name test-$plugin -p 16379:6379 -d redis:6 --requirepass $REDIS_PAS
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10
 
-if $plugin -port 16379
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin -port 16379

--- a/test.bash
+++ b/test.bash
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# prepare tests
+for f in mackerel-plugin-*/test.sh
+do
+	dir=$(dirname "$f")
+	name=$(basename "$dir")
+	go build -o "$dir/$name" ./"$dir" || exit
+done
+
+# run tests
+declare -A plugins=()
+for f in mackerel-plugin-*/test.sh
+do
+	./"$f" &
+	pid=$!
+	plugins[$pid]="$f"
+	pids="${pids} ${pid}"
+done
+
+# collect the results
+declare -a results=()
+status=0
+for i in $pids
+do
+	if wait "$i"
+	then
+		results+=("OK: ${plugins[$i]}")
+	else
+		results+=("ERR: ${plugins[$i]}")
+		status=1
+	fi
+done
+echo '======'
+for s in "${results[@]}"
+do
+	echo "$s" >&2
+done
+exit $status

--- a/test.bash
+++ b/test.bash
@@ -31,7 +31,7 @@ do
 		status=1
 	fi
 done
-echo '======'
+echo '======' >&2
 for s in "${results[@]}"
 do
 	echo "$s" >&2


### PR DESCRIPTION
I changed workflow to run tests (**&lt;plugin&gt;/test.sh**) for each plugins.

The "make cover test" task ends up with the reports of each tests of the plugin.

```
OK: mackerel-plugin-accesslog/test.sh
OK: mackerel-plugin-apache2/test.sh
OK: mackerel-plugin-docker/test.sh
OK: mackerel-plugin-mongodb/test.sh
OK: mackerel-plugin-mysql/test.sh
OK: mackerel-plugin-openldap/test.sh
OK: mackerel-plugin-postgres/test.sh
OK: mackerel-plugin-redis/test.sh
```