### PR TITLE
[plugin-redis] avoid to store +Inf

### DIFF
--- a/mackerel-plugin-redis/lib/redis.go
+++ b/mackerel-plugin-redis/lib/redis.go
@@ -165,8 +165,9 @@ func (m RedisPlugin) FetchMetrics() (map[string]interface{}, error) {
 				lagFv, err := strconv.ParseFloat(lagKv[1], 64)
 				if err != nil {
 					logger.Warningf("Failed to parse slaves. %s", err)
+				} else {
+					stat[fmt.Sprintf("%s_lag", key)] = lagFv
 				}
-				stat[fmt.Sprintf("%s_lag", key)] = lagFv
 			} else {
 				_, _, _, offset = kv[0], kv[1], kv[2], kv[3]
 			}
@@ -174,6 +175,7 @@ func (m RedisPlugin) FetchMetrics() (map[string]interface{}, error) {
 			offsetFv, err := strconv.ParseFloat(offsetKv[1], 64)
 			if err != nil {
 				logger.Warningf("Failed to parse slaves. %s", err)
+				continue
 			}
 			stat[fmt.Sprintf("%s_offset_delay", key)] = offsetFv
 			continue
@@ -187,23 +189,26 @@ func (m RedisPlugin) FetchMetrics() (map[string]interface{}, error) {
 			keysFv, err := strconv.ParseFloat(keysKv[1], 64)
 			if err != nil {
 				logger.Warningf("Failed to parse db keys. %s", err)
+			} else {
+				keysStat += keysFv
 			}
-			keysStat += keysFv
 
 			expiresKv := strings.SplitN(expires, "=", 2)
 			expiresFv, err := strconv.ParseFloat(expiresKv[1], 64)
 			if err != nil {
 				logger.Warningf("Failed to parse db expires. %s", err)
+			} else {
+				expiresStat += expiresFv
 			}
-			expiresStat += expiresFv
 
 			continue
 		}
 
-		stat[key], err = strconv.ParseFloat(value, 64)
+		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			continue
 		}
+		stat[key] = v
 	}
 
 	stat["keys"] = keysStat

--- a/mackerel-plugin-redis/test.sh
+++ b/mackerel-plugin-redis/test.sh
@@ -21,7 +21,7 @@ image=redis:6
 port=16379
 
 docker run --name "test-$plugin" -p $port:6379 -d $image --requirepass $REDIS_PASSWORD
-trap 'docker stop test-$plugin; docker rm test-$plugin; exit' 1 2 3 15 EXIT
+trap 'docker stop test-$plugin; docker rm test-$plugin; exit 1' 1 2 3 15
 sleep 10
 
 # to store previous value to calculate a diff of metrics
@@ -29,3 +29,8 @@ $plugin -port $port >/dev/null 2>&1
 sleep 1
 
 $plugin -port $port | graphite-metric-test -f rule.txt
+status=$?
+
+docker stop "test-$plugin"
+docker rm "test-$plugin"
+exit $status


### PR DESCRIPTION
You would be able to look **"saveValues:  json: unsupported value: +Inf"** error  in the result of GitHub Action's output of the first commit of this PR; [756ca59](https://github.com/mackerelio/mackerel-agent-plugins/pull/779/checks?check_run_id=2915016825)
Therefore I fixed it.

see #770