### PR TITLE
Replacing the version update process

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,51 @@
+name: 'Create Release PR'
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'next release version'
+        required: true
+env:
+  GIT_AUTHOR_NAME: mackerelbot
+  GIT_AUTHOR_EMAIL: mackerelbot@users.noreply.github.com
+  GIT_COMMITTER_NAME: mackerelbot
+  GIT_COMMITTER_EMAIL: mackerelbot@users.noreply.github.com
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.34'
+
+      - uses: mackerelio/mackerel-create-release-pull-request-action@main
+        id: start
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          next_version: ${{ github.event.inputs.release_version }}
+          package_name: mackerel-agent-plugins
+          version_go_file_path: mackerel-plugin.go
+
+      - run: |
+          CURRENT=${{ steps.start.outputs.currentVersion }}
+          NEXT=${{ steps.start.outputs.nextVersion }}
+          mv packaging/mackerel-agent-plugins_$CURRENT.orig.tar.gz packaging/mackerel-agent-plugins_$NEXT.orig.tar.gz
+
+      - run: |
+          cpanm -qn Path::Tiny
+          perl tool/update-docs.pl
+
+      - uses: mackerelio/mackerel-create-release-pull-request-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          finished: "true"
+          package_name: mackerel-agent-plugins
+          next_version: ${{ steps.start.outputs.nextVersion }}
+          branch_name: ${{ steps.start.outputs.branchName }}
+          pull_request_infos: ${{ steps.start.outputs.pullRequestInfos }}
+        # TODO: remove below lines. when completed test.
+        env:
+          RUNNER_DEBUG: 1

--- a/tool/update-docs.pl
+++ b/tool/update-docs.pl
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+
+use 5.014;
+use strict;
+use warnings;
+use utf8;
+
+use File::Copy qw/move/;
+use JSON::PP qw/decode_json/;
+use Path::Tiny qw/path/;
+
+my $PLUGIN_PREFIX = 'mackerel-plugin-';
+my $PACKAGE_NAME = 'mackerel-agent-plugins';
+
+# refer Mackerel::ReleaseUtils
+sub replace {
+    my ($glob, $code) = @_;
+    for my $file (glob $glob) {
+        my $content = $code->(path($file)->slurp_utf8, $file);
+        $content .= "\n" if $content !~ /\n\z/ms;
+
+        my $f = path($file);
+        # for keeping permission
+        $f->append_utf8({truncate => 1}, $content);
+    }
+}
+
+sub retrieve_plugins {
+    # exclude plugins which has been moved to other repositories
+    sort map {s/^$PLUGIN_PREFIX//; $_} grep { -e "$_/lib" } <$PLUGIN_PREFIX*>;
+}
+
+sub update_readme {
+    my @plugins = @_;
+
+    my $doc_links = '';
+    for my $plug (@plugins) {
+        $doc_links .= "* [$PLUGIN_PREFIX$plug](./$PLUGIN_PREFIX$plug/README.md)\n"
+    }
+    replace 'README.md' => sub {
+        my $readme = shift;
+        my $plu_reg = qr/$PLUGIN_PREFIX[-0-9a-zA-Z_]+/;
+        $readme =~ s!(?:\* \[$plu_reg\]\(\./$plu_reg/README\.md\)\n)+!$doc_links!ms;
+        $readme;
+    };
+}
+
+sub update_packaging_specs {
+    my @plugins = @_;
+    my $for_in = 'for i in ' . join(' ', @plugins) . '; do';
+
+    my $replace_sub = sub {
+        my $content = shift;
+        $content =~ s/for i in.*?;\s*do/$for_in/ms;
+        $content;
+    };
+    replace $_, $replace_sub for ("packaging/rpm/$PACKAGE_NAME*.spec", "packaging/deb*/debian/rules");
+
+    path('packaging/deb/debian/source/include-binaries')->spew(join("\n", map { "debian/$PLUGIN_PREFIX$_" } @plugins) . "\n");
+}
+
+sub load_packaging_confg {
+    decode_json path('packaging/config.json')->slurp;
+}
+
+sub main {
+    my @plugins = retrieve_plugins;
+    update_readme(@plugins);
+    my $config = load_packaging_confg;
+    update_packaging_specs(@{ $config->{plugins} });
+}
+
+main();


### PR DESCRIPTION
We are using [Mackerel::ReleaseUtils](https://metacpan.org/pod/Mackerel::ReleaseUtils) in the version update process and want to replace it.
In this pull request, I'm writing the code to try the replacement.

This GitHub Action does not actually work, but runs in "dry-run" mode.