### PR TITLE
[fluentd] add metric-key-prefix option.

### DIFF
--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -14,8 +14,8 @@ import (
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 )
 
-// FluentdMetrics plugin for fluentd
-type FluentdMetrics struct {
+// FluentdPlugin mackerel plugin
+type FluentdPlugin struct {
 	Target          string
 	Prefix          string
 	Tempfile        string
@@ -26,7 +26,7 @@ type FluentdMetrics struct {
 }
 
 // MetricKeyPrefix interface for PluginWithPrefix
-func (f FluentdMetrics) MetricKeyPrefix() string {
+func (f FluentdPlugin) MetricKeyPrefix() string {
 	if f.Prefix == "" {
 		f.Prefix = "fluentd"
 	}
@@ -63,7 +63,7 @@ func (fpm FluentdPluginMetrics) getNormalizedPluginID() string {
 	return fpm.normalizedPluginID
 }
 
-func (f *FluentdMetrics) parseStats(body []byte) (map[string]interface{}, error) {
+func (f *FluentdPlugin) parseStats(body []byte) (map[string]interface{}, error) {
 	var j FluentMonitorJSON
 	err := json.Unmarshal(body, &j)
 	f.plugins = j.Plugins
@@ -81,7 +81,7 @@ func (f *FluentdMetrics) parseStats(body []byte) (map[string]interface{}, error)
 	return metrics, err
 }
 
-func (f *FluentdMetrics) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
+func (f *FluentdPlugin) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
 	if plugin.PluginCategory != "output" {
 		return true
 	}
@@ -95,7 +95,7 @@ func (f *FluentdMetrics) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
 }
 
 // FetchMetrics interface for mackerelplugin
-func (f FluentdMetrics) FetchMetrics() (map[string]interface{}, error) {
+func (f FluentdPlugin) FetchMetrics() (map[string]interface{}, error) {
 	req, err := http.NewRequest(http.MethodGet, f.Target, nil)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (f FluentdMetrics) FetchMetrics() (map[string]interface{}, error) {
 }
 
 // GraphDefinition interface for mackerelplugin
-func (f FluentdMetrics) GraphDefinition() map[string]mp.Graphs {
+func (f FluentdPlugin) GraphDefinition() map[string]mp.Graphs {
 	labelPrefix := strings.Title(f.Prefix)
 
 	return map[string]mp.Graphs{
@@ -164,7 +164,7 @@ func Do() {
 		}
 	}
 
-	f := FluentdMetrics{
+	f := FluentdPlugin{
 		Target:          fmt.Sprintf("http://%s:%s/api/plugins.json", *host, *port),
 		Prefix:          *prefix,
 		Tempfile:        *tempFile,

--- a/mackerel-plugin-fluentd/lib/fluentd_test.go
+++ b/mackerel-plugin-fluentd/lib/fluentd_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGraphDefinition(t *testing.T) {
-	var fluentd FluentdMetrics
+	var fluentd FluentdPlugin
 
 	graphdef := fluentd.GraphDefinition()
 	if len(graphdef) != 3 {
@@ -31,7 +31,7 @@ func TestNormalizePluginID(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
-	var fluentd FluentdMetrics
+	var fluentd FluentdPlugin
 	stub := `{"plugins":[{"plugin_id":"object:3feb368cfad0","plugin_category":"output","type":"mackerel","config":{"type":"mackerel","api_key":"aaa","service":"foo","metrics_name":"${[1]}-bar.${out_key}","remove_prefix":"","out_keys":"Latency","localtime":true},"output_plugin":true,"buffer_queue_length":0,"buffer_total_queued_size":53,"retry_count":0},{"plugin_id":"object:155633c","plugin_category":"input","type":"monitor_agent","config":{"type":"monitor_agent","bind":"0.0.0.0","port":"24220"},"output_plugin":false,"retry_count":null}]}`
 
 	fluentdStats := []byte(stub)
@@ -52,7 +52,7 @@ func TestPluginTypeOption(t *testing.T) {
 	fluentdStats := []byte(stub)
 
 	// Specify type option
-	var fluentd = FluentdMetrics{pluginType: "mackerel"}
+	var fluentd = FluentdPlugin{pluginType: "mackerel"}
 	stat, err := fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
@@ -63,7 +63,7 @@ func TestPluginTypeOption(t *testing.T) {
 	}
 
 	// Not specify type option
-	fluentd = FluentdMetrics{}
+	fluentd = FluentdPlugin{}
 	stat, err = fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
@@ -79,7 +79,7 @@ func TestPluginIDPatternOption(t *testing.T) {
 	fluentdStats := []byte(stub)
 
 	// Specify type option
-	var fluentd = FluentdMetrics{
+	var fluentd = FluentdPlugin{
 		pluginIDPattern: regexp.MustCompile("^match"),
 	}
 	stat, err := fluentd.parseStats(fluentdStats)
@@ -92,7 +92,7 @@ func TestPluginIDPatternOption(t *testing.T) {
 	}
 
 	// Not specify type option
-	fluentd = FluentdMetrics{}
+	fluentd = FluentdPlugin{}
 	stat, err = fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
add metric-key-prefix option of fluentd plugin.

```sh
$ ./mackerel-plugin-fluentd --help 2>&1 | grep prefix
  -metric-key-prefix string
        Metric key prefix (default "fluentd")
```