### PR TITLE
[fluentd] add metric-key-prefix option.

### DIFF
--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -17,21 +17,28 @@ import (
 
 var logger = logging.GetLogger("metrics.plugin.fluentd")
 
-var prefix = "fluentd"
-
 func metricName(names ...string) string {
-	return prefix + "." + strings.Join(names, ".")
+	return strings.Join(names, ".")
 }
 
 // FluentdMetrics plugin for fluentd
 type FluentdMetrics struct {
 	Target          string
+	Prefix          string
 	Tempfile        string
 	pluginType      string
 	pluginIDPattern *regexp.Regexp
 	extendedMetrics []string
 
 	plugins []FluentdPluginMetrics
+}
+
+// MetricKeyPrefix interface for PluginWithPrefix
+func (f FluentdMetrics) MetricKeyPrefix() string {
+	if f.Prefix == "" {
+		f.Prefix = "fluentd"
+	}
+	return f.Prefix
 }
 
 // FluentdPluginMetrics metrics
@@ -118,8 +125,7 @@ func (f *FluentdMetrics) parseStats(body []byte) (map[string]interface{}, error)
 		metrics[metricName("buffer_queue_length", pid)] = float64(p.BufferQueueLength)
 		metrics[metricName("buffer_total_queued_size", pid)] = float64(p.BufferTotalQueuedSize)
 		for _, name := range f.extendedMetrics {
-			key := strings.Join([]string{"fluentd", name, pid}, ".")
-			metrics[key] = p.getExtended(name)
+			metrics[metricName(name, pid)] = p.getExtended(name)
 		}
 	}
 	return metrics, err
@@ -160,22 +166,22 @@ func (f FluentdMetrics) FetchMetrics() (map[string]interface{}, error) {
 }
 
 var defaultGraphs = map[string]mp.Graphs{
-	"fluentd.retry_count": {
-		Label: "Fluentd retry count",
+	"retry_count": {
+		Label: "retry count",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: false},
 		},
 	},
-	"fluentd.buffer_queue_length": {
-		Label: "Fluentd queue length",
+	"buffer_queue_length": {
+		Label: "queue length",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: false},
 		},
 	},
-	"fluentd.buffer_total_queued_size": {
-		Label: "Fluentd buffer total queued size",
+	"buffer_total_queued_size": {
+		Label: "buffer total queued size",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: false},
@@ -184,71 +190,71 @@ var defaultGraphs = map[string]mp.Graphs{
 }
 
 var extendedGraphs = map[string]mp.Graphs{
-	"fluentd.emit_records": {
-		Label: "Fluentd emitted records",
+	"emit_records": {
+		Label: "emitted records",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: true},
 		},
 	},
-	"fluentd.emit_count": {
-		Label: "Fluentd emit calls",
+	"emit_count": {
+		Label: "emit calls",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: true},
 		},
 	},
-	"fluentd.write_count": {
-		Label: "Fluentd write/try_write calls",
+	"write_count": {
+		Label: "write/try_write calls",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: true},
 		},
 	},
-	"fluentd.rollback_count": {
-		Label: "Fluentd rollbacks",
+	"rollback_count": {
+		Label: "rollbacks",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: true},
 		},
 	},
-	"fluentd.slow_flush_count": {
-		Label: "Fluentd slow flushes",
+	"slow_flush_count": {
+		Label: "slow flushes",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: true},
 		},
 	},
-	"fluentd.flush_time_count": {
-		Label: "Fluentd buffer flush time in msec",
+	"flush_time_count": {
+		Label: "buffer flush time in msec",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: true},
 		},
 	},
-	"fluentd.buffer_stage_length": {
-		Label: "Fluentd length of staged buffer chunks",
+	"buffer_stage_length": {
+		Label: "length of staged buffer chunks",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: false},
 		},
 	},
-	"fluentd.buffer_stage_byte_size": {
-		Label: "Fluentd bytesize of staged buffer chunks",
+	"buffer_stage_byte_size": {
+		Label: "bytesize of staged buffer chunks",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: false},
 		},
 	},
-	"fluentd.buffer_queue_byte_size": {
-		Label: "Fluentd bytesize of queued buffer chunks",
+	"buffer_queue_byte_size": {
+		Label: "bytesize of queued buffer chunks",
 		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: false},
 		},
 	},
-	"fluentd.buffer_available_buffer_space_ratios": {
-		Label: "Fluentd available space for buffer",
+	"buffer_available_buffer_space_ratios": {
+		Label: "available space for buffer",
 		Unit:  "percentage",
 		Metrics: []mp.Metrics{
 			{Name: "*", Label: "%1", Diff: false},
@@ -258,15 +264,23 @@ var extendedGraphs = map[string]mp.Graphs{
 
 // GraphDefinition interface for mackerelplugin
 func (f FluentdMetrics) GraphDefinition() map[string]mp.Graphs {
+	labelPrefix := strings.Title(f.Prefix)
 	graphs := make(map[string]mp.Graphs, len(defaultGraphs))
 	for key, g := range defaultGraphs {
-		g := g
-		graphs[key] = g
+		graphs[key] = mp.Graphs{
+			Label:   (labelPrefix + " " + g.Label),
+			Unit:    g.Unit,
+			Metrics: g.Metrics,
+		}
 	}
 	for _, name := range f.extendedMetrics {
 		fullName := metricName(name)
 		if g, ok := extendedGraphs[fullName]; ok {
-			graphs[fullName] = g
+			graphs[fullName] = mp.Graphs{
+				Label:   (labelPrefix + " " + g.Label),
+				Unit:    g.Unit,
+				Metrics: g.Metrics,
+			}
 		}
 	}
 	return graphs
@@ -278,6 +292,7 @@ func Do() {
 	port := flag.String("port", "24220", "fluentd monitor_agent port")
 	pluginType := flag.String("plugin-type", "", "Gets the metric that matches this plugin type")
 	pluginIDPatternString := flag.String("plugin-id-pattern", "", "Gets the metric that matches this plugin id pattern")
+	prefix := flag.String("metric-key-prefix", "fluentd", "Metric key prefix")
 	tempFile := flag.String("tempfile", "", "Temp file name")
 	extendedMetricNames := flag.String("extended_metrics", "", "extended metric names joind with ',' or 'all' (fluentd >= v1.6.0)")
 	flag.Parse()
@@ -296,7 +311,7 @@ func Do() {
 	switch *extendedMetricNames {
 	case "all":
 		for key := range extendedGraphs {
-			extendedMetrics = append(extendedMetrics, strings.TrimPrefix(key, prefix+"."))
+			extendedMetrics = append(extendedMetrics, key)
 		}
 	case "":
 	default:
@@ -311,6 +326,7 @@ func Do() {
 	}
 	f := FluentdMetrics{
 		Target:          fmt.Sprintf("http://%s:%s/api/plugins.json", *host, *port),
+		Prefix:          *prefix,
 		Tempfile:        *tempFile,
 		pluginType:      *pluginType,
 		pluginIDPattern: pluginIDPattern,

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -33,6 +33,8 @@ type FluentdPlugin struct {
 	plugins []FluentdPluginMetrics
 }
 
+type FluentdMetrics = FluentdPlugin
+
 // MetricKeyPrefix interface for PluginWithPrefix
 func (f FluentdPlugin) MetricKeyPrefix() string {
 	if f.Prefix == "" {

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -33,6 +33,7 @@ type FluentdPlugin struct {
 	plugins []FluentdPluginMetrics
 }
 
+// FluentdMetrics is alias for backward compatibility.
 type FluentdMetrics = FluentdPlugin
 
 // MetricKeyPrefix interface for PluginWithPrefix

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -21,8 +21,8 @@ func metricName(names ...string) string {
 	return strings.Join(names, ".")
 }
 
-// FluentdMetrics plugin for fluentd
-type FluentdMetrics struct {
+// FluentdPlugin mackerel plugin for Fluentd
+type FluentdPlugin struct {
 	Target          string
 	Prefix          string
 	Tempfile        string
@@ -34,7 +34,7 @@ type FluentdMetrics struct {
 }
 
 // MetricKeyPrefix interface for PluginWithPrefix
-func (f FluentdMetrics) MetricKeyPrefix() string {
+func (f FluentdPlugin) MetricKeyPrefix() string {
 	if f.Prefix == "" {
 		f.Prefix = "fluentd"
 	}
@@ -110,7 +110,7 @@ func (fpm FluentdPluginMetrics) getNormalizedPluginID() string {
 	return fpm.normalizedPluginID
 }
 
-func (f *FluentdMetrics) parseStats(body []byte) (map[string]interface{}, error) {
+func (f *FluentdPlugin) parseStats(body []byte) (map[string]interface{}, error) {
 	var j FluentMonitorJSON
 	err := json.Unmarshal(body, &j)
 	f.plugins = j.Plugins
@@ -131,7 +131,7 @@ func (f *FluentdMetrics) parseStats(body []byte) (map[string]interface{}, error)
 	return metrics, err
 }
 
-func (f *FluentdMetrics) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
+func (f *FluentdPlugin) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
 	if plugin.PluginCategory != "output" {
 		return true
 	}
@@ -145,7 +145,7 @@ func (f *FluentdMetrics) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
 }
 
 // FetchMetrics interface for mackerelplugin
-func (f FluentdMetrics) FetchMetrics() (map[string]interface{}, error) {
+func (f FluentdPlugin) FetchMetrics() (map[string]interface{}, error) {
 	req, err := http.NewRequest(http.MethodGet, f.Target, nil)
 	if err != nil {
 		return nil, err
@@ -263,7 +263,7 @@ var extendedGraphs = map[string]mp.Graphs{
 }
 
 // GraphDefinition interface for mackerelplugin
-func (f FluentdMetrics) GraphDefinition() map[string]mp.Graphs {
+func (f FluentdPlugin) GraphDefinition() map[string]mp.Graphs {
 	labelPrefix := strings.Title(f.Prefix)
 	graphs := make(map[string]mp.Graphs, len(defaultGraphs))
 	for key, g := range defaultGraphs {
@@ -324,7 +324,7 @@ func Do() {
 			extendedMetrics = append(extendedMetrics, name)
 		}
 	}
-	f := FluentdMetrics{
+	f := FluentdPlugin{
 		Target:          fmt.Sprintf("http://%s:%s/api/plugins.json", *host, *port),
 		Prefix:          *prefix,
 		Tempfile:        *tempFile,

--- a/mackerel-plugin-fluentd/lib/fluentd_test.go
+++ b/mackerel-plugin-fluentd/lib/fluentd_test.go
@@ -49,9 +49,9 @@ func TestParse(t *testing.T) {
 	stat, err := fluentd.parseStats(fluentdStats)
 	assert.Nil(t, err)
 	// Fluentd Stats
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.object_3feb368cfad0"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.object_3feb368cfad0"].(float64), 53)
-	if _, ok := stat["fluentd.buffer_total_queued_size.object_155633c"]; ok {
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.object_3feb368cfad0"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.object_3feb368cfad0"].(float64), 53)
+	if _, ok := stat["buffer_total_queued_size.object_155633c"]; ok {
 		t.Errorf("parseStats: stats of other than the output plugin should not exist")
 	}
 }
@@ -88,13 +88,13 @@ func TestParseExtended(t *testing.T) {
 	stat, err := fluentd.parseStats(fluentdStats)
 	assert.Nil(t, err)
 	// Fluentd Stats
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.object_3feb368cfad0"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.object_3feb368cfad0"].(float64), 53)
-	if _, ok := stat["fluentd.buffer_total_queued_size.object_155633c"]; ok {
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.object_3feb368cfad0"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.object_3feb368cfad0"].(float64), 53)
+	if _, ok := stat["buffer_total_queued_size.object_155633c"]; ok {
 		t.Errorf("parseStats: stats of other than the output plugin should not exist")
 	}
-	assert.EqualValues(t, stat["fluentd.emit_records.object_3feb368cfad0"].(float64), 10)
-	if _, ok := stat["fluentd.emit_count.object_3feb368cfad0"]; ok {
+	assert.EqualValues(t, stat["emit_records.object_3feb368cfad0"].(float64), 10)
+	if _, ok := stat["emit_count.object_3feb368cfad0"]; ok {
 		t.Errorf("parseStats: stats of other than the output plugin should not exist")
 	}
 }
@@ -109,9 +109,9 @@ func TestPluginTypeOption(t *testing.T) {
 	stat, err := fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.out_mackerel"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.out_mackerel"].(float64), 53)
-	if _, ok := stat["fluentd.buffer_total_queued_size.out_file"]; ok {
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.out_mackerel"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.out_mackerel"].(float64), 53)
+	if _, ok := stat["buffer_total_queued_size.out_file"]; ok {
 		t.Errorf("parseStats: stats of plugin that do not match the specified type should not exist")
 	}
 
@@ -120,10 +120,10 @@ func TestPluginTypeOption(t *testing.T) {
 	stat, err = fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.out_mackerel"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.out_mackerel"].(float64), 53)
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.out_file"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.out_file"].(float64), 10940)
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.out_mackerel"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.out_mackerel"].(float64), 53)
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.out_file"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.out_file"].(float64), 10940)
 }
 
 func TestPluginIDPatternOption(t *testing.T) {
@@ -138,9 +138,9 @@ func TestPluginIDPatternOption(t *testing.T) {
 	stat, err := fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.match_plugin_id"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.match_plugin_id"].(float64), 10940)
-	if _, ok := stat["fluentd.buffer_total_queued_size.do_not_match_plugin_id"]; ok {
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.match_plugin_id"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.match_plugin_id"].(float64), 10940)
+	if _, ok := stat["buffer_total_queued_size.do_not_match_plugin_id"]; ok {
 		t.Errorf("parseStats: stats of plugin that do not match the specified id pattern should not exist")
 	}
 
@@ -149,8 +149,8 @@ func TestPluginIDPatternOption(t *testing.T) {
 	stat, err = fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.match_plugin_id"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.match_plugin_id"].(float64), 10940)
-	assert.EqualValues(t, reflect.TypeOf(stat["fluentd.buffer_total_queued_size.do_not_match_plugin_id"]).String(), "float64")
-	assert.EqualValues(t, stat["fluentd.buffer_total_queued_size.do_not_match_plugin_id"].(float64), 53)
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.match_plugin_id"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.match_plugin_id"].(float64), 10940)
+	assert.EqualValues(t, reflect.TypeOf(stat["buffer_total_queued_size.do_not_match_plugin_id"]).String(), "float64")
+	assert.EqualValues(t, stat["buffer_total_queued_size.do_not_match_plugin_id"].(float64), 53)
 }

--- a/mackerel-plugin-fluentd/lib/fluentd_test.go
+++ b/mackerel-plugin-fluentd/lib/fluentd_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGraphDefinition(t *testing.T) {
-	var fluentd FluentdMetrics
+	var fluentd FluentdPlugin
 
 	graphdef := fluentd.GraphDefinition()
 	if len(graphdef) != 3 {
@@ -18,7 +18,7 @@ func TestGraphDefinition(t *testing.T) {
 }
 
 func TestGraphDefinitionExtended(t *testing.T) {
-	var fluentd FluentdMetrics
+	var fluentd FluentdPlugin
 	fluentd.extendedMetrics = []string{"emit_records", "emit_count", "xxx"}
 
 	graphdef := fluentd.GraphDefinition()
@@ -41,7 +41,7 @@ func TestNormalizePluginID(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
-	var fluentd FluentdMetrics
+	var fluentd FluentdPlugin
 	stub := `{"plugins":[{"plugin_id":"object:3feb368cfad0","plugin_category":"output","type":"mackerel","config":{"type":"mackerel","api_key":"aaa","service":"foo","metrics_name":"${[1]}-bar.${out_key}","remove_prefix":"","out_keys":"Latency","localtime":true},"output_plugin":true,"buffer_queue_length":0,"buffer_total_queued_size":53,"retry_count":0},{"plugin_id":"object:155633c","plugin_category":"input","type":"monitor_agent","config":{"type":"monitor_agent","bind":"0.0.0.0","port":"24220"},"output_plugin":false,"retry_count":null}]}`
 
 	fluentdStats := []byte(stub)
@@ -57,7 +57,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestParseExtended(t *testing.T) {
-	var fluentd FluentdMetrics
+	var fluentd FluentdPlugin
 	fluentd.extendedMetrics = []string{"emit_records"}
 	stub := `{
 	  "plugins": [
@@ -105,7 +105,7 @@ func TestPluginTypeOption(t *testing.T) {
 	fluentdStats := []byte(stub)
 
 	// Specify type option
-	var fluentd = FluentdMetrics{pluginType: "mackerel"}
+	var fluentd = FluentdPlugin{pluginType: "mackerel"}
 	stat, err := fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
@@ -116,7 +116,7 @@ func TestPluginTypeOption(t *testing.T) {
 	}
 
 	// Not specify type option
-	fluentd = FluentdMetrics{}
+	fluentd = FluentdPlugin{}
 	stat, err = fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)
@@ -132,7 +132,7 @@ func TestPluginIDPatternOption(t *testing.T) {
 	fluentdStats := []byte(stub)
 
 	// Specify type option
-	var fluentd = FluentdMetrics{
+	var fluentd = FluentdPlugin{
 		pluginIDPattern: regexp.MustCompile("^match"),
 	}
 	stat, err := fluentd.parseStats(fluentdStats)
@@ -145,7 +145,7 @@ func TestPluginIDPatternOption(t *testing.T) {
 	}
 
 	// Not specify type option
-	fluentd = FluentdMetrics{}
+	fluentd = FluentdPlugin{}
 	stat, err = fluentd.parseStats(fluentdStats)
 
 	assert.Nil(t, err)


### PR DESCRIPTION
add metric-key-prefix option of fluentd plugin.

```sh
$ ./mackerel-plugin-fluentd --help 2>&1 | grep prefix
  -metric-key-prefix string
        Metric key prefix (default "fluentd")
```