### PR TITLE
[fluentd] add workers option.

### DIFF
--- a/mackerel-plugin-fluentd/README.md
+++ b/mackerel-plugin-fluentd/README.md
@@ -31,6 +31,21 @@ port 24220
 
 See https://docs.fluentd.org/input/monitor_agent in details.
 
+If you have specified the `workers` parameter in fluentd's `<system>` directive, you can use the `-workers` option.
+
+```
+<system>
+  workers 3
+</system>
+
+<source>
+  @type monitor_agent
+  port 24230 # worker0: 24230, worker1: 24231, worker2: 24232
+</source>
+```
+
+See https://docs.fluentd.org/input/monitor_agent#multi-process-environment in details.
+
 ## License
 
 Released under the MIT license

--- a/mackerel-plugin-fluentd/README.md
+++ b/mackerel-plugin-fluentd/README.md
@@ -6,7 +6,7 @@ Fluentd (http://www.fluentd.org/) custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-fluentd [-host=<host>] [-port=<port>] [-tempfile=<tempfile>] [-plugin-type=<plugin-type>] [-plugin-id-pattern=<plugin-id-pattern>]
+mackerel-plugin-fluentd [-host=<host>] [-port=<port>] [-tempfile=<tempfile>] [-plugin-type=<plugin-type>] [-plugin-id-pattern=<plugin-id-pattern>] [-workers=<workers>]
 ```
 
 ## Example of mackerel-agent.conf

--- a/mackerel-plugin-fluentd/README.md
+++ b/mackerel-plugin-fluentd/README.md
@@ -29,7 +29,7 @@ port 24220
 </source>
 ```
 
-See http://docs.fluentd.org/articles/monitoring in details.
+See https://docs.fluentd.org/input/monitor_agent in details.
 
 ## License
 

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -173,7 +173,10 @@ func (f *FluentdPlugin) fetchFluentdMetrics(host string, port int) (map[string]i
 
 // FetchMetrics interface for mackerelplugin
 func (f FluentdPlugin) FetchMetrics() (map[string]interface{}, error) {
-	port, _ := strconv.Atoi(f.Port)
+	port, err := strconv.Atoi(f.Port)
+	if err != nil {
+		return nil, err
+	}
 	if f.Workers > 1 {
 		metrics := make(map[string]interface{})
 		for workerNumber := 0; workerNumber < int(f.Workers); workerNumber++ {

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -302,6 +302,9 @@ func (f FluentdPlugin) GraphDefinition() map[string]mp.Graphs {
 	labelPrefix := strings.Title(f.Prefix)
 	graphs := make(map[string]mp.Graphs, len(defaultGraphs))
 	for key, g := range defaultGraphs {
+		if f.Workers > 1 {
+			key = metricName(key, "#")
+		}
 		graphs[key] = mp.Graphs{
 			Label:   (labelPrefix + " " + g.Label),
 			Unit:    g.Unit,
@@ -309,9 +312,11 @@ func (f FluentdPlugin) GraphDefinition() map[string]mp.Graphs {
 		}
 	}
 	for _, name := range f.extendedMetrics {
-		fullName := metricName(name)
-		if g, ok := extendedGraphs[fullName]; ok {
-			graphs[fullName] = mp.Graphs{
+		if g, ok := extendedGraphs[name]; ok {
+			if f.Workers > 1 {
+				name = metricName(name, "#")
+			}
+			graphs[name] = mp.Graphs{
 				Label:   (labelPrefix + " " + g.Label),
 				Unit:    g.Unit,
 				Metrics: g.Metrics,

--- a/mackerel-plugin-fluentd/lib/fluentd.go
+++ b/mackerel-plugin-fluentd/lib/fluentd.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
@@ -23,12 +24,14 @@ func metricName(names ...string) string {
 
 // FluentdPlugin mackerel plugin for Fluentd
 type FluentdPlugin struct {
-	Target          string
+	Host            string
+	Port            string
 	Prefix          string
 	Tempfile        string
 	pluginType      string
 	pluginIDPattern *regexp.Regexp
 	extendedMetrics []string
+	Workers         uint
 
 	plugins []FluentdPluginMetrics
 }
@@ -147,9 +150,9 @@ func (f *FluentdPlugin) nonTargetPlugin(plugin FluentdPluginMetrics) bool {
 	return false
 }
 
-// FetchMetrics interface for mackerelplugin
-func (f FluentdPlugin) FetchMetrics() (map[string]interface{}, error) {
-	req, err := http.NewRequest(http.MethodGet, f.Target, nil)
+func (f *FluentdPlugin) fetchFluentdMetrics(host string, port int) (map[string]interface{}, error) {
+	target := fmt.Sprintf("http://%s:%d/api/plugins.json", host, port)
+	req, err := http.NewRequest(http.MethodGet, target, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -166,6 +169,35 @@ func (f FluentdPlugin) FetchMetrics() (map[string]interface{}, error) {
 	}
 
 	return f.parseStats(body)
+}
+
+// FetchMetrics interface for mackerelplugin
+func (f FluentdPlugin) FetchMetrics() (map[string]interface{}, error) {
+	port, _ := strconv.Atoi(f.Port)
+	if f.Workers > 1 {
+		metrics := make(map[string]interface{})
+		for workerNumber := 0; workerNumber < int(f.Workers); workerNumber++ {
+			m, e := f.fetchFluentdMetrics(f.Host, port+workerNumber)
+			if e != nil {
+				continue
+			}
+
+			workerName := fmt.Sprintf("worker%d", workerNumber)
+			for k, v := range m {
+				ks := strings.Split(k, ".")
+				ks, last := ks[:len(ks)-1], ks[len(ks)-1]
+				ks = append(ks, workerName)
+				ks = append(ks, last)
+				metrics[strings.Join(ks, ".")] = v
+			}
+		}
+		if len(metrics) == 0 {
+			err := fmt.Errorf("failed to connect to fluentd's monitor_agent")
+			return metrics, err
+		}
+		return metrics, nil
+	}
+	return f.fetchFluentdMetrics(f.Host, port)
 }
 
 var defaultGraphs = map[string]mp.Graphs{
@@ -298,6 +330,7 @@ func Do() {
 	prefix := flag.String("metric-key-prefix", "fluentd", "Metric key prefix")
 	tempFile := flag.String("tempfile", "", "Temp file name")
 	extendedMetricNames := flag.String("extended_metrics", "", "extended metric names joind with ',' or 'all' (fluentd >= v1.6.0)")
+	workers := flag.Uint("workers", 1, "specifying the number of Fluentd's multi-process workers")
 	flag.Parse()
 
 	var pluginIDPattern *regexp.Regexp
@@ -328,12 +361,14 @@ func Do() {
 		}
 	}
 	f := FluentdPlugin{
-		Target:          fmt.Sprintf("http://%s:%s/api/plugins.json", *host, *port),
+		Host:            *host,
+		Port:            *port,
 		Prefix:          *prefix,
 		Tempfile:        *tempFile,
 		pluginType:      *pluginType,
 		pluginIDPattern: pluginIDPattern,
 		extendedMetrics: extendedMetrics,
+		Workers:         *workers,
 	}
 
 	helper := mp.NewMackerelPlugin(f)

--- a/mackerel-plugin-fluentd/lib/fluentd_test.go
+++ b/mackerel-plugin-fluentd/lib/fluentd_test.go
@@ -27,6 +27,17 @@ func TestGraphDefinitionExtended(t *testing.T) {
 	}
 }
 
+func TestGraphDefinitionMultiWorkers(t *testing.T) {
+	var fluentd FluentdPlugin
+	fluentd.Workers = 2
+
+	graphdef := fluentd.GraphDefinition()
+	for key := range graphdef {
+		last := key[len(key)-1]
+		assert.EqualValues(t, last, "#")
+	}
+}
+
 func TestNormalizePluginID(t *testing.T) {
 	testSets := [][]string{
 		{"foo/bar", "foo_bar"},


### PR DESCRIPTION
add workers option of fluentd plugin.
workers option supports fetching metrics for multi process workers.

refs.

- [Multi Process Workers - Fluentd]( https://docs.fluentd.org/deployment/multi-process-workers )
- [monitor_agent - Fluentd]( https://docs.fluentd.org/input/monitor_agent#multi-process-environment )