### PR TITLE
[accesslog] use Seek to skip the log

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.16.x"]
+        go: ["1.16.x", "1.15.x"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ yum install mackerel-agent-plugins
 apt-get install mackerel-agent-plugins
 ```
 
+### Go
+
+**mackerel-agent-plugins** supports two newer versions of Go.
+
+```shell
+go install github.com/mackerelio/mackerel-agent-plugins/...
+```
+
 Caution
 =======
 

--- a/mackerel-plugin-accesslog/lib/accesslog.go
+++ b/mackerel-plugin-accesslog/lib/accesslog.go
@@ -97,7 +97,14 @@ func (p *AccesslogPlugin) getPosPath() string {
 	)
 }
 
-func (p *AccesslogPlugin) getReadSeekCloser() (io.ReadSeekCloser, bool, error) {
+// We'd like to better to use io.ReadSeekCloser interface if we can drop support for Go 1.15.
+type readSeekCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
+func (p *AccesslogPlugin) getReadSeekCloser() (readSeekCloser, bool, error) {
 	if p.noPosFile {
 		f, err := os.Open(p.file)
 		return f, true, err

--- a/mackerel-plugin-accesslog/lib/accesslog.go
+++ b/mackerel-plugin-accesslog/lib/accesslog.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -98,30 +97,30 @@ func (p *AccesslogPlugin) getPosPath() string {
 	)
 }
 
-func (p *AccesslogPlugin) getReadCloser() (io.ReadCloser, bool, error) {
+func (p *AccesslogPlugin) getReadSeekCloser() (io.ReadSeekCloser, bool, error) {
 	if p.noPosFile {
-		rc, err := os.Open(p.file)
-		return rc, true, err
+		f, err := os.Open(p.file)
+		return f, true, err
 	}
 	posfile := p.getPosPath()
 	fi, err := os.Stat(posfile)
 	// don't output any metrics when the pos file doesn't exist or is too old
 	takeMetrics := err == nil && fi.ModTime().After(time.Now().Add(-2*time.Minute))
-	rc, err := postailer.Open(p.file, posfile)
-	return rc, takeMetrics, err
+	f, err := postailer.Open(p.file, posfile)
+	return f, takeMetrics, err
 }
 
 // FetchMetrics interface for mackerelplugin
 func (p *AccesslogPlugin) FetchMetrics() (map[string]float64, error) {
-	rc, takeMetrics, err := p.getReadCloser()
+	f, takeMetrics, err := p.getReadSeekCloser()
 	if err != nil {
 		return nil, err
 	}
-	defer rc.Close()
+	defer f.Close()
 
 	if !takeMetrics {
 		// discard existing contents to seek position
-		_, err := ioutil.ReadAll(rc)
+		_, err := f.Seek(0, io.SeekEnd)
 		return map[string]float64{}, err
 	}
 
@@ -131,7 +130,7 @@ func (p *AccesslogPlugin) FetchMetrics() (map[string]float64, error) {
 		ret[k] = 0
 	}
 	var reqtimes []float64
-	r := bufio.NewReader(rc)
+	r := bufio.NewReader(f)
 	for {
 		var (
 			l   *axslogparser.Log

--- a/mackerel-plugin-accesslog/lib/accesslog_test.go
+++ b/mackerel-plugin-accesslog/lib/accesslog_test.go
@@ -1,6 +1,9 @@
 package mpaccesslog
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -172,5 +175,39 @@ func TestFetchMetricsWithCustomParser(t *testing.T) {
 	}
 	if !reflect.DeepEqual(out, expected) {
 		t.Errorf("out:  %#v\n want: %#v", out, expected)
+	}
+}
+
+func TestSkipLogOnceIfNoPos(t *testing.T) {
+	dir := t.TempDir()
+	posFile := filepath.Join(dir, "plugin-accesslog.test.pos")
+	p := &AccesslogPlugin{
+		file:    "testdata/sample-ltsv.tsv",
+		posFile: posFile,
+	}
+	out, err := p.FetchMetrics()
+	if err != nil {
+		t.Errorf("error should be nil but: %+v", err)
+		return
+	}
+	if n := len(out); n != 0 {
+		t.Errorf("got %d metrics; but want 0", n)
+	}
+
+	// see https://github.com/Songmu/postailer/blob/master/postailer.go#L27-L30
+	var pos struct {
+		Pos int64 `json:"pos"`
+	}
+	b, err := os.ReadFile(posFile)
+	if err != nil {
+		t.Errorf("ReadFile(%s): %v", posFile, err)
+		return
+	}
+	if err := json.Unmarshal(b, &pos); err != nil {
+		t.Fatal(err)
+	}
+	var want int64 = 1247
+	if pos.Pos != want {
+		t.Errorf("saved position = %d; want %d", pos.Pos, want)
 	}
 }

--- a/mackerel-plugin-accesslog/lib/accesslog_test.go
+++ b/mackerel-plugin-accesslog/lib/accesslog_test.go
@@ -2,7 +2,7 @@ package mpaccesslog
 
 import (
 	"encoding/json"
-	"os"
+	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -198,7 +198,7 @@ func TestSkipLogOnceIfNoPos(t *testing.T) {
 	var pos struct {
 		Pos int64 `json:"pos"`
 	}
-	b, err := os.ReadFile(posFile)
+	b, err := ioutil.ReadFile(posFile)
 	if err != nil {
 		t.Errorf("ReadFile(%s): %v", posFile, err)
 		return

--- a/test.bash
+++ b/test.bash
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # install dependencies
-go install github.com/lufia/graphitemetrictest/cmd/graphite-metric-test@latest || exit
+#go install github.com/lufia/graphitemetrictest/cmd/graphite-metric-test@latest || exit
+go get github.com/lufia/graphitemetrictest/cmd/graphite-metric-test || exit
 
 # prepare tests
 for f in mackerel-plugin-*/test.sh


### PR DESCRIPTION
It is not good to use ioutil.ReadAll to skip all logs.

ioutil.ReadAll reads all bytes into memory, so if the access log is large then the plugin might be OOM crash.