### PR TITLE
[nit] added comments for duplicate graphdefs.

### DIFF
--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -68,6 +68,7 @@ func (m *MySQLPlugin) defaultGraphdef() map[string]mp.Graphs {
 				{Name: "Com_replace_select", Label: "Replace Select", Diff: true, Stacked: true},
 				{Name: "Com_load", Label: "Load", Diff: true, Stacked: true},
 				{Name: "Com_set_option", Label: "Set Option", Diff: true, Stacked: true},
+				// Duplicate definitions in the past.
 				{Name: "Qcache_hits", Label: "Query Cache Hits", Diff: true, Stacked: false},
 				{Name: "Questions", Label: "Questions", Diff: true, Stacked: false},
 			},
@@ -88,6 +89,7 @@ func (m *MySQLPlugin) defaultGraphdef() map[string]mp.Graphs {
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
 				{Name: "thread_cache_size", Label: "Cache Size", Diff: false, Stacked: false},
+				// Duplicate definitions in the past.
 				{Name: "Threads_connected", Label: "Connected", Diff: false, Stacked: false},
 				{Name: "Threads_running", Label: "Running", Diff: false, Stacked: false},
 				{Name: "Threads_created", Label: "Created", Diff: true, Stacked: false},

--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -68,7 +68,7 @@ func (m *MySQLPlugin) defaultGraphdef() map[string]mp.Graphs {
 				{Name: "Com_replace_select", Label: "Replace Select", Diff: true, Stacked: true},
 				{Name: "Com_load", Label: "Load", Diff: true, Stacked: true},
 				{Name: "Com_set_option", Label: "Set Option", Diff: true, Stacked: true},
-				// Duplicate of Qcache_hits but remains for compatibility reason
+				// Duplicate of query_cache.Qcache_hits but remains for compatibility reason
 				{Name: "Qcache_hits", Label: "Query Cache Hits", Diff: true, Stacked: false},
 				{Name: "Questions", Label: "Questions", Diff: true, Stacked: false},
 			},
@@ -89,7 +89,7 @@ func (m *MySQLPlugin) defaultGraphdef() map[string]mp.Graphs {
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
 				{Name: "thread_cache_size", Label: "Cache Size", Diff: false, Stacked: false},
-				// Duplicate of Threads_connected but remains for compatibility reason
+				// Duplicate of connections.Threads_connected but remains for compatibility reason
 				{Name: "Threads_connected", Label: "Connected", Diff: false, Stacked: false},
 				{Name: "Threads_running", Label: "Running", Diff: false, Stacked: false},
 				{Name: "Threads_created", Label: "Created", Diff: true, Stacked: false},

--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -68,7 +68,7 @@ func (m *MySQLPlugin) defaultGraphdef() map[string]mp.Graphs {
 				{Name: "Com_replace_select", Label: "Replace Select", Diff: true, Stacked: true},
 				{Name: "Com_load", Label: "Load", Diff: true, Stacked: true},
 				{Name: "Com_set_option", Label: "Set Option", Diff: true, Stacked: true},
-				// Duplicate definitions in the past.
+				// Duplicate of Qcache_hits but remains for compatibility reason
 				{Name: "Qcache_hits", Label: "Query Cache Hits", Diff: true, Stacked: false},
 				{Name: "Questions", Label: "Questions", Diff: true, Stacked: false},
 			},
@@ -89,7 +89,7 @@ func (m *MySQLPlugin) defaultGraphdef() map[string]mp.Graphs {
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
 				{Name: "thread_cache_size", Label: "Cache Size", Diff: false, Stacked: false},
-				// Duplicate definitions in the past.
+				// Duplicate of Threads_connected but remains for compatibility reason
 				{Name: "Threads_connected", Label: "Connected", Diff: false, Stacked: false},
 				{Name: "Threads_running", Label: "Running", Diff: false, Stacked: false},
 				{Name: "Threads_created", Label: "Created", Diff: true, Stacked: false},

--- a/mackerel-plugin-mysql/lib/mysql_test.go
+++ b/mackerel-plugin-mysql/lib/mysql_test.go
@@ -1285,7 +1285,8 @@ func TestMetricNamesShouldUniqueAndConst(t *testing.T) {
 	keys := make(map[string]string) // metricName: graphDefName
 	for name, g := range defs {
 		for _, v := range g.Metrics {
-			// TODO(lufia): bug?
+			// The following two definitions have been added in duplicate in the past.
+			// They cannot be removed to ensure compatibility.
 			if v.Name == "Threads_connected" {
 				if name != "connections" && name != "threads" {
 					t.Errorf(`%q are duplicated in "connections", "threads" and %q`, v.Name, name)

--- a/mackerel-plugin-mysql/lib/mysql_test.go
+++ b/mackerel-plugin-mysql/lib/mysql_test.go
@@ -1285,8 +1285,6 @@ func TestMetricNamesShouldUniqueAndConst(t *testing.T) {
 	keys := make(map[string]string) // metricName: graphDefName
 	for name, g := range defs {
 		for _, v := range g.Metrics {
-			// The following two definitions have been added in duplicate in the past.
-			// They cannot be removed to ensure compatibility.
 			if v.Name == "Threads_connected" {
 				if name != "connections" && name != "threads" {
 					t.Errorf(`%q are duplicated in "connections", "threads" and %q`, v.Name, name)


### PR DESCRIPTION
some definitions have been added in duplicate in the past. They cannot be removed to ensure compatibility.

I have been added comments for clarity understand.