### PR TITLE
[plugin-postgres] suppress fetchXlogLocation when wal_level != 'logical'

### DIFF
--- a/mackerel-plugin-postgres/lib/postgres.go
+++ b/mackerel-plugin-postgres/lib/postgres.go
@@ -191,15 +191,17 @@ func fetchDatabaseSize(db *sqlx.DB) (map[string]interface{}, error) {
 }
 
 func fetchXlogLocation(db *sqlx.DB, version version) (map[string]interface{}, error) {
-	rows, err := db.Query("SELECT pg_is_in_recovery()")
-	if err != nil {
-		logger.Errorf("Failed to select pg_is_in_recovery. %s", err)
-		return nil, err
-	}
 	var recovery bool
-	for rows.Next() {
-		if err := rows.Scan(&recovery); err != nil {
-			logger.Warningf("Failed to scan %s", err)
+	{
+		rows, err := db.Query("SELECT pg_is_in_recovery()")
+		if err != nil {
+			logger.Errorf("Failed to select pg_is_in_recovery. %s", err)
+			return nil, err
+		}
+		for rows.Next() {
+			if err := rows.Scan(&recovery); err != nil {
+				logger.Warningf("Failed to scan %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
When wal_level is not set to `logical`, suppress  fetchXlogLocation to avoid error.

## Motivation

On AWS RDS Aurora PostgreSQL,
`SELECT pg_is_in_recovery()` returns `f` but wal_level is `replica`

```console
$ psql -U XXX -h XXX.XXX.ap-northeast-1.rds.amazonaws.com -c "SELECT pg_is_in_recovery()"
...
 pg_is_in_recovery
-------------------
 f
(1 row)

$ psql -U XXX -h XXX.XXX.ap-northeast-1.rds.amazonaws.com -c "SELECT setting FROM pg_settings WHERE name = 'wal_level'"
...
 setting
---------
 replica
(1 row)
```

To run `SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), '0/0')` successfully,
wal_level must be `logical`.

```console
$ mackerel-plugin-postgres -hostname XXX.XXX.ap-northeast-1.rds.amazonaws.com -database XXX -user XXX -password XXX
2021/08/17 11:14:02 ERROR <metrics.plugin.postgres> Failed to select pg_wal_lsn_diff. pq: wal_level must be set to 'logical'
2021/08/17 11:14:02 OutputValues:  pq: wal_level must be set to 'logical'
```
