### PR TITLE
[mysql] adapt for mysql5.7's InnoDB SEMAPHORES metrics

### DIFF
--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -834,6 +834,12 @@ func parseInnodbStatus(str string, trxIDHexFormat bool, p map[string]float64) {
 			increaseMap(p, "os_waits", record[7])
 			continue
 		}
+		if strings.HasPrefix(line, "RW-sx spins") {
+			// 5.7
+			increaseMap(p, "spin_waits", record[2])
+			increaseMap(p, "os_waits", record[7])
+			continue
+		}
 		if strings.Contains(line, "seconds the semaphore:") {
 			increaseMap(p, "innodb_sem_waits", "1")
 			wait, err := atof(record[9])

--- a/mackerel-plugin-mysql/lib/mysql_test.go
+++ b/mackerel-plugin-mysql/lib/mysql_test.go
@@ -714,7 +714,7 @@ OS WAIT ARRAY INFO: reservation count 63
 OS WAIT ARRAY INFO: signal count 111
 RW-shared spins 0, rounds 85, OS waits 22
 RW-excl spins 0, rounds 4705, OS waits 17
-RW-sx spins 0, rounds 0, OS waits 0
+RW-sx spins 70, rounds 70, OS waits 70
 Spin rounds per wait: 85.00 RW-shared, 4705.00 RW-excl, 0.00 RW-sx
 ------------
 TRANSACTIONS
@@ -871,9 +871,9 @@ END OF INNODB MONITOR OUTPUT
 	stat := make(map[string]float64)
 	parseInnodbStatus(stub, false, stat)
 	// Innodb Semaphores
-	assert.EqualValues(t, stat["spin_waits"], 0)
+	assert.EqualValues(t, stat["spin_waits"], 70)
 	assert.EqualValues(t, stat["spin_rounds"], 0) // empty
-	assert.EqualValues(t, stat["os_waits"], 39)
+	assert.EqualValues(t, stat["os_waits"], 109)
 	assert.EqualValues(t, stat["innodb_sem_wait"], 0)         // empty
 	assert.EqualValues(t, stat["innodb_sem_wait_time_ms"], 0) // empty
 	// Innodb Transactions


### PR DESCRIPTION
## why

Starting with mysql5.7, the metric for "RW-sx" is displayed. I want to observe this.

## how

- Added according to examples such as "RW-shared".

## check

- Correct the test and make sure it passes.

### unchecked

- I have not confirmed the behavior in MySQL8.0.

## FYI

- Starting with mysql5.7.8, The "Mutex spin waits" line is no longer displayed.
  - https://github.com/mysql/mysql-server/commit/3574d439c1cf7ad39a5077d5d3c7ff5ad835a882
  - https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-8.html