### PR TITLE
[plugin-redis] migrate redis client library to redigo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5
 	github.com/fsouza/go-dockerclient v1.7.2
 	github.com/fukata/golang-stats-api-handler v1.0.0
-	github.com/fzzy/radix v0.5.6
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-ldap/ldap/v3 v3.3.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,13 +82,12 @@ github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DP
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/fhs/go-netrc v1.0.0/go.mod h1:tGgE+SHFQhgo1jg+hG6/uCxBJv5Pnq7pTMjvaEWrOu8=
 github.com/frankban/quicktest v1.6.0/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/go-dockerclient v1.7.2 h1:bBEAcqLTkpq205jooP5RVroUKiVEWgGecHyeZc4OFjo=
 github.com/fsouza/go-dockerclient v1.7.2/go.mod h1:+ugtMCVRwnPfY7d8/baCzZ3uwB0BrG5DB8OzbtxaRz8=
 github.com/fukata/golang-stats-api-handler v1.0.0 h1:N6M25vhs1yAvwGBpFY6oBmMOZeJdcWnvA+wej8pKeko=
 github.com/fukata/golang-stats-api-handler v1.0.0/go.mod h1:1sIi4/rHq6s/ednWMZqTmRq3765qTUSs/c3xF6lj8J8=
-github.com/fzzy/radix v0.5.6 h1:cbj4zksFVtUo5ST6gW5NsUlW6C6x7eAiqajgCe6e2Ys=
-github.com/fzzy/radix v0.5.6/go.mod h1:KhtJfdbo4PD2LEOYO7QCVSIH0pOcZEZ/SpNsXgwQtkk=
 github.com/github/hub v2.11.1+incompatible/go.mod h1:zQrzJEdze2hfWJDgktd/L6sROjAdCThFrzjbxw4keTs=
 github.com/github/hub v2.11.2+incompatible/go.mod h1:zQrzJEdze2hfWJDgktd/L6sROjAdCThFrzjbxw4keTs=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
@@ -328,6 +327,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/mackerel-plugin-redis/lib/redis.go
+++ b/mackerel-plugin-redis/lib/redis.go
@@ -3,6 +3,7 @@ package mpredis
 import (
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"strconv"
@@ -94,7 +95,7 @@ func (m RedisPlugin) MetricKeyPrefix() string {
 // FetchMetrics interface for mackerelplugin
 func (m RedisPlugin) FetchMetrics() (map[string]interface{}, error) {
 	network := "tcp"
-	address := fmt.Sprintf("%s:%s", m.Host, m.Port)
+	address := net.JoinHostPort(m.Host, m.Port)
 	if m.Socket != "" {
 		network = "unix"
 		address = m.Socket
@@ -286,7 +287,7 @@ func (m RedisPlugin) GraphDefinition() map[string]mp.Graphs {
 	}
 
 	network := "tcp"
-	address := fmt.Sprintf("%s:%s", m.Host, m.Port)
+	address := net.JoinHostPort(m.Host, m.Port)
 	if m.Socket != "" {
 		network = "unix"
 		address = m.Socket

--- a/mackerel-plugin-redis/lib/redis.go
+++ b/mackerel-plugin-redis/lib/redis.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fzzy/radix/redis"
+	"github.com/gomodule/redigo/redis"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 	"github.com/mackerelio/golib/logging"
 )
@@ -28,24 +28,18 @@ type RedisPlugin struct {
 	ConfigCommand string
 }
 
-func authenticateByPassword(c *redis.Client, password string) error {
-	if r := c.Cmd("AUTH", password); r.Err != nil {
-		logger.Errorf("Failed to authenticate. %s", r.Err)
-		return r.Err
+func authenticateByPassword(c redis.Conn, password string) error {
+	if _, err := c.Do("AUTH", password); err != nil {
+		logger.Errorf("Failed to authenticate. %s", err)
+		return err
 	}
 	return nil
 }
 
-func (m RedisPlugin) fetchPercentageOfMemory(c *redis.Client, stat map[string]interface{}) error {
-	r := c.Cmd(m.ConfigCommand, "GET", "maxmemory")
-	if r.Err != nil {
-		logger.Errorf("Failed to run `%s GET maxmemory` command. %s", m.ConfigCommand, r.Err)
-		return r.Err
-	}
-
-	res, err := r.Hash()
+func (m RedisPlugin) fetchPercentageOfMemory(c redis.Conn, stat map[string]interface{}) error {
+	res, err := redis.StringMap(c.Do(m.ConfigCommand, "GET", "maxmemory"))
 	if err != nil {
-		logger.Errorf("Failed to fetch maxmemory. %s", err)
+		logger.Errorf("Failed to run `%s GET maxmemory` command. %s", m.ConfigCommand, err)
 		return err
 	}
 
@@ -64,16 +58,10 @@ func (m RedisPlugin) fetchPercentageOfMemory(c *redis.Client, stat map[string]in
 	return nil
 }
 
-func (m RedisPlugin) fetchPercentageOfClients(c *redis.Client, stat map[string]interface{}) error {
-	r := c.Cmd(m.ConfigCommand, "GET", "maxclients")
-	if r.Err != nil {
-		logger.Errorf("Failed to run `%s GET maxclients` command. %s", m.ConfigCommand, r.Err)
-		return r.Err
-	}
-
-	res, err := r.Hash()
+func (m RedisPlugin) fetchPercentageOfClients(c redis.Conn, stat map[string]interface{}) error {
+	res, err := redis.StringMap(c.Do(m.ConfigCommand, "GET", "maxclients"))
 	if err != nil {
-		logger.Errorf("Failed to fetch maxclients. %s", err)
+		logger.Errorf("Failed to run `%s GET maxclients` command. %s", m.ConfigCommand, err)
 		return err
 	}
 
@@ -88,7 +76,7 @@ func (m RedisPlugin) fetchPercentageOfClients(c *redis.Client, stat map[string]i
 	return nil
 }
 
-func (m RedisPlugin) calculateCapacity(c *redis.Client, stat map[string]interface{}) error {
+func (m RedisPlugin) calculateCapacity(c redis.Conn, stat map[string]interface{}) error {
 	if err := m.fetchPercentageOfMemory(c, stat); err != nil {
 		return err
 	}
@@ -106,12 +94,12 @@ func (m RedisPlugin) MetricKeyPrefix() string {
 // FetchMetrics interface for mackerelplugin
 func (m RedisPlugin) FetchMetrics() (map[string]interface{}, error) {
 	network := "tcp"
-	target := fmt.Sprintf("%s:%s", m.Host, m.Port)
+	address := fmt.Sprintf("%s:%s", m.Host, m.Port)
 	if m.Socket != "" {
-		target = m.Socket
 		network = "unix"
+		address = m.Socket
 	}
-	c, err := redis.DialTimeout(network, target, time.Duration(m.Timeout)*time.Second)
+	c, err := redis.Dial(network, address, redis.DialConnectTimeout(time.Duration(m.Timeout)*time.Second))
 	if err != nil {
 		logger.Errorf("Failed to connect redis. %s", err)
 		return nil, err
@@ -124,14 +112,9 @@ func (m RedisPlugin) FetchMetrics() (map[string]interface{}, error) {
 		}
 	}
 
-	r := c.Cmd("info")
-	if r.Err != nil {
-		logger.Errorf("Failed to run info command. %s", r.Err)
-		return nil, r.Err
-	}
-	str, err := r.Str()
+	str, err := redis.String(c.Do("info"))
 	if err != nil {
-		logger.Errorf("Failed to fetch information. %s", err)
+		logger.Errorf("Failed to run info command. %s", err)
 		return nil, err
 	}
 
@@ -303,13 +286,13 @@ func (m RedisPlugin) GraphDefinition() map[string]mp.Graphs {
 	}
 
 	network := "tcp"
-	target := fmt.Sprintf("%s:%s", m.Host, m.Port)
+	address := fmt.Sprintf("%s:%s", m.Host, m.Port)
 	if m.Socket != "" {
-		target = m.Socket
 		network = "unix"
+		address = m.Socket
 	}
 
-	c, err := redis.DialTimeout(network, target, time.Duration(m.Timeout)*time.Second)
+	c, err := redis.Dial(network, address, redis.DialConnectTimeout(time.Duration(m.Timeout)*time.Second))
 	if err != nil {
 		logger.Errorf("Failed to connect redis. %s", err)
 		return nil
@@ -322,14 +305,9 @@ func (m RedisPlugin) GraphDefinition() map[string]mp.Graphs {
 		}
 	}
 
-	r := c.Cmd("info")
-	if r.Err != nil {
-		logger.Errorf("Failed to run info command. %s", r.Err)
-		return nil
-	}
-	str, err := r.Str()
+	str, err := redis.String(c.Do("info"))
 	if err != nil {
-		logger.Errorf("Failed to fetch information. %s", err)
+		logger.Errorf("Failed to run info command. %s", err)
 		return nil
 	}
 


### PR DESCRIPTION
The redis client library `fzzy/radix` seems to be removed, so I migrated the library to `gomodule/redigo`.