### PR TITLE
[plugin-sidekiq] add queue latency metric

### DIFF
--- a/mackerel-plugin-sidekiq/README.md
+++ b/mackerel-plugin-sidekiq/README.md
@@ -21,6 +21,25 @@ mackerel-plugin-sidekiq [-host=<host>] [-port=<port>] [-password=<password>] [-d
 command = "/path/to/mackerel-plugin-sidekiq"
 ```
 
+## Graphs and Metrics
+
+### Sidekiq processed and failed count (sidekiq.ProcessedANDFailed)
+
+* processed (sidekiq.ProcessedANDFailed.processed)
+* failed (sidekiq.ProcessedANDFailed.failed)
+
+### Sidekiq stats (sidekiq.Stats)
+
+* busy (sidekiq.Stats.busy)
+* enqueued (sidekiq.Stats.enqueued)
+* scheduled (sidekiq.Stats.scheduled)
+* retry (sidekiq.Stats.retry)
+* dead (sidekiq.Stats.dead)
+
+### sidekiq queue latency (sidekiq.QueueLatency)
+
+* Latency sec (sidekiq.QueueLatency.#)
+
 ## Author
 
 [littlekbt](https://github.com/littlekbt)

--- a/mackerel-plugin-sidekiq/lib/sidekiq.go
+++ b/mackerel-plugin-sidekiq/lib/sidekiq.go
@@ -224,7 +224,7 @@ func (sp SidekiqPlugin) getQueueLatency() map[string]interface{} {
 			fmt.Fprintf(os.Stderr, "json parse error")
 			continue
 		}
-		now := float64(time.Now().UnixMicro()) / 1000 / 1000
+		now := float64(time.Now().Unix())
 		if enqueuedAt, ok := job["enqueued_at"]; ok {
 			enqueuedAt := enqueuedAt.(float64)
 			thence = enqueuedAt

--- a/mackerel-plugin-sidekiq/lib/sidekiq_test.go
+++ b/mackerel-plugin-sidekiq/lib/sidekiq_test.go
@@ -9,7 +9,7 @@ func TestGraphDefinition(t *testing.T) {
 
 	graphdef := sp.GraphDefinition()
 
-	expect := 2
+	expect := 3
 
 	if len(graphdef) != expect {
 		t.Errorf("GraphDefinition(): %d should be %d", len(graphdef), expect)


### PR DESCRIPTION
Measures the difference between when the oldest job was pushed into the queue and the current time as latency.
ref: https://github.com/mperham/sidekiq/wiki/Monitoring#monitoring-queue-latency

I refered the following code for implementation.
https://github.com/mperham/sidekiq/blob/46f4c6bd9ee0b2f5502a1dc0d03414989ad65063/lib/sidekiq/api.rb#L240-L254