### PR TITLE
[linux] users メトリックに 0 が投稿されない問題を修正

### DIFF
--- a/mackerel-plugin-linux/lib/linux.go
+++ b/mackerel-plugin-linux/lib/linux.go
@@ -174,7 +174,7 @@ func collectWho(p *map[string]interface{}) error {
 func parseWho(str string, p *map[string]interface{}) error {
 	str = strings.TrimSpace(str)
 	if str == "" {
-		(*p)["users"] = 0
+		(*p)["users"] = float64(0)
 		return nil
 	}
 	line := strings.Split(str, "\n")


### PR DESCRIPTION
ログインしているユーザが 0 の場合に linux.users メトリックに 0 が投稿されない問題の修正です。

ログインしているユーザが 0 の場合 `(*p)["users"] = 0` で 0 を代入していますが、最後にメトリックを出力する以下の処理で int 型に対応しておらずメトリックが投稿されないため、float64 で代入しています。

https://github.com/mackerelio/go-mackerel-plugin-helper/blob/3d9512468e0b00efe5bc2189eead8b4275fd8e9d/mackerel-plugin.go#L87

