### PR TITLE
Fix: Input 'job-number' has been deprecated with message: use flag-name instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-profile: .profile.cov
         parallel: true
-        flag-name: Go-${{ matrix.go }}
+        flag-name: Go-${{ matrix.os }}-${{ matrix.go }}
   build:
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-profile: .profile.cov
         parallel: true
-        job-number: ${{ strategy.job-index }}
+        flag-name: Go-${{ matrix.go }}
   build:
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
shogo82148/actions-goveralls now deplicates `job-number` input ( https://github.com/shogo82148/actions-goveralls/commit/883ba99002413b1b1a998431af467d00628c3f46 ). It say "Input 'job-number' has been deprecated with message: use flag-name instead".

Example notification : https://github.com/mackerelio/mackerel-agent-plugins/actions/runs/2165034703 <img width="641" alt="スクリーンショット 2022-04-14 13 10 01" src="https://user-images.githubusercontent.com/452772/163312079-0a532c26-a4c8-401b-aa7c-47c4ee4ee2ee.png">

```yaml
  job-number:
    description: "job number (DEPRECATED)"
    required: false
    default: '${{ strategy.job-index }}'
    deprecationMessage: "use flag-name instead"
```

```yaml
  flag-name:
    description: 'Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.'
    required: false
    default: '${{ strategy.job-index }}'
```

Result is shown at the below of this pull request like this.
<img width="853" alt="スクリーンショット 2022-04-14 13 07 18" src="https://user-images.githubusercontent.com/452772/163311871-22d5dcaf-f984-434e-8c59-a082d084f6b9.png">
