### PR TITLE
[plugin-mysql] fix panic when parsing aio stats

### DIFF
--- a/mackerel-plugin-mysql/lib/mysql.go
+++ b/mackerel-plugin-mysql/lib/mysql.go
@@ -793,10 +793,11 @@ func calculateAio(s string) (int, error) {
 		}
 		return total, nil
 	}
-	if n := len(v); v[n-1] == ',' {
-		v = v[:n-1]
+	v = strings.TrimSpace(strings.TrimRight(v, ","))
+	if v == "" {
+		return 0, nil
 	}
-	return strconv.Atoi(strings.TrimSpace(v))
+	return strconv.Atoi(v)
 }
 
 func parseInnodbStatus(str string, trxIDHexFormat bool, p map[string]float64) {

--- a/mackerel-plugin-mysql/lib/mysql_test.go
+++ b/mackerel-plugin-mysql/lib/mysql_test.go
@@ -1272,6 +1272,8 @@ func TestParseAio(t *testing.T) {
 		{"Pending normal aio reads: 10 [4, 6] ", 10, 0},
 		{"Pending normal aio reads: 10, aio writes: 20,", 10, 20},
 		{"Pending normal aio reads: 10", 10, 0},
+		{"Pending normal aio reads:, aio writes: [1, 3, 5, 7],", 0, 16},
+		{"Pending normal aio reads:, aio writes:,", 0, 0},
 	}
 
 	for _, tt := range pattern {


### PR DESCRIPTION
Amazon Aurora could return aio statistics like below:

```
Pending normal aio reads:, aio writes: [0, 0, 0, 0] ,
```

That statistics is missing values of reads so plugin-mysql panics when parsing aio line.