### PR TITLE
[plugin-docker] (Breaking) drop 'File' method support

### DIFF
--- a/mackerel-plugin-docker/lib/docker.go
+++ b/mackerel-plugin-docker/lib/docker.go
@@ -1,15 +1,12 @@
 package mpdocker
 
 import (
-	"bytes"
 	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -79,53 +76,18 @@ var graphdef = map[string]mp.Graphs{
 // DockerPlugin mackerel plugin for docker
 type DockerPlugin struct {
 	Host             string
-	DockerCommand    string
 	Tempfile         string
 	Method           string
 	NameFormat       string
 	Label            string
-	pathBuilder      *pathBuilder
 	lastMetricValues mp.MetricValues
 	UseCPUPercentage bool
-}
-
-func getFile(path string) (string, error) {
-	cmd := exec.Command("cat", path)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	if err != nil {
-		return "", err
-	}
-	return out.String(), nil
-}
-
-func exists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return true, err
 }
 
 var normalizeMetricRe = regexp.MustCompile(`[^-a-zA-Z0-9_]`)
 
 func normalizeMetricName(str string) string {
 	return normalizeMetricRe.ReplaceAllString(str, "_")
-}
-
-func (m DockerPlugin) getDockerPs() (string, error) {
-	cmd := exec.Command(m.DockerCommand, "--host", m.Host, "ps", "--no-trunc")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	if err != nil {
-		return "", err
-	}
-	return out.String(), nil
 }
 
 func (m DockerPlugin) listContainer() ([]docker.APIContainers, error) {
@@ -137,154 +99,22 @@ func (m DockerPlugin) listContainer() ([]docker.APIContainers, error) {
 	return containers, nil
 }
 
-func findPrefixPath() (string, error) {
-	pathCandidate := []string{"/host/cgroup", "/cgroup", "/host/sys/fs/cgroup", "/sys/fs/cgroup"}
-	for _, path := range pathCandidate {
-		result, err := exists(path)
-		if err != nil {
-			return "", err
-		}
-		if result {
-			return path, nil
-		}
-	}
-	return "", errors.New("no prefix path is found")
-}
-
-type pathBuilder struct {
-	prefix   string
-	pathType pathType
-}
-
-type pathType uint8
-
-const (
-	pathUnknown pathType = iota
-	pathDocker
-	pathDockerShort
-	pathLxc
-	pathSlice
-)
-
-func newPathBuilder() (*pathBuilder, error) {
-	prefixPath, err := findPrefixPath()
-	if err != nil {
-		return nil, err
-	}
-	pathT, err := guessPathType(prefixPath)
-	if err != nil {
-		return nil, err
-	}
-	return &pathBuilder{
-		prefix:   prefixPath,
-		pathType: pathT,
-	}, nil
-}
-
-func (pb *pathBuilder) build(id, metric, postfix string) string {
-	switch pb.pathType {
-	case pathDockerShort:
-		return fmt.Sprintf("%s/docker/%s/%s.%s", pb.prefix, id, metric, postfix)
-	case pathDocker:
-		return fmt.Sprintf("%s/%s/docker/%s/%s.%s", pb.prefix, metric, id, metric, postfix)
-	case pathLxc:
-		return fmt.Sprintf("%s/%s/lxc/%s/%s.%s", pb.prefix, metric, id, metric, postfix)
-	case pathSlice:
-		return fmt.Sprintf("%s/%s/system.slice/docker-%s.scope/%s.%s", pb.prefix, metric, id, metric, postfix)
-	default:
-		return ""
-	}
-}
-
-func guessPathType(prefix string) (pathType, error) {
-	if ok, err := exists(prefix + "/memory/system.slice/"); ok && err == nil {
-		return pathSlice, nil
-	}
-	if ok, err := exists(prefix + "/memory/docker/"); ok && err == nil {
-		return pathDocker, nil
-	}
-	if ok, err := exists(prefix + "/memory/lxc/"); ok && err == nil {
-		return pathLxc, nil
-	}
-	if ok, err := exists(prefix + "/docker/"); ok && err == nil {
-		return pathDockerShort, nil
-	}
-	return pathUnknown, fmt.Errorf("can't resolve runtime metrics path")
-}
-
-func guessMethod(docker string) (string, error) {
-	cmd := exec.Command(docker, "version")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	if err != nil {
-		return "", err
-	}
-
-	re := regexp.MustCompile(`Server API version: ([0-9]+)(?:\.([0-9]+))?`)
-	res := re.FindAllStringSubmatch(out.String(), 1)
-
-	// Recent docker does not provide server api version info in the form,
-	// But in case it's apparently newer than 1.17.
-	if len(res) < 1 || len(res[0]) < 2 {
-		// log.Printf("Use API because of failing to recognize version")
-		return "API", nil
-	}
-
-	majorVer, err := strconv.Atoi(res[0][1])
-	if err != nil {
-		log.Printf("Use API because of failing to recognize version")
-		return "API", nil
-	}
-
-	minorVer, err := strconv.Atoi(res[0][2])
-	if err != nil {
-		log.Printf("Use API because of failing to recognize version")
-		return "API", nil
-	}
-
-	if majorVer == 1 && minorVer < 17 {
-		//log.Printf("Use File for fetching Metrics")
-		return "File", nil
-	}
-	return "API", nil
-}
-
 // FetchMetrics interface for mackerel plugin
 func (m DockerPlugin) FetchMetrics() (map[string]interface{}, error) {
 	var stats map[string]interface{}
 
-	if m.Method == "API" {
-		containers, err := m.listContainer()
-		if err != nil {
-			return nil, err
-		}
-		stats, err = m.FetchMetricsWithAPI(containers)
+	if m.Method == "File" {
+		return nil, errors.New("no longer supported")
+	}
+	containers, err := m.listContainer()
+	if err != nil {
+		return nil, err
+	}
+	stats, err = m.FetchMetricsWithAPI(containers)
 
-		if m.UseCPUPercentage {
-			if time.Now().Sub(m.lastMetricValues.Timestamp) <= 5*time.Minute {
-				addCPUPercentageStats(&stats, m.lastMetricValues.Values)
-			}
-		}
-	} else {
-		dockerStats := map[string][]string{}
-		data, err := m.getDockerPs()
-		if err != nil {
-			return nil, err
-		}
-		lines := strings.Split(data, "\n")
-		for n, line := range lines {
-			if n == 0 {
-				continue
-			}
-			fields := strings.Fields(line)
-			if len(fields) > 3 {
-				dockerStats[fields[0]] = []string{fields[1], fields[len(fields)-2]}
-			}
-		}
-		stats, err = m.FetchMetricsWithFile(&dockerStats)
-		if err != nil {
-			return nil, err
+	if m.UseCPUPercentage {
+		if time.Now().Sub(m.lastMetricValues.Timestamp) <= 5*time.Minute {
+			addCPUPercentageStats(&stats, m.lastMetricValues.Values)
 		}
 	}
 
@@ -428,62 +258,6 @@ func addCPUPercentageStats(stats *map[string]interface{}, lastStat map[string]in
 	}
 }
 
-// FetchMetricsWithFile use cgroup stats files to fetch metrics
-func (m DockerPlugin) FetchMetricsWithFile(dockerStats *map[string][]string) (map[string]interface{}, error) {
-	pb := m.pathBuilder
-
-	metrics := map[string][]string{
-		"cpuacct": {"user", "system"},
-		"memory":  {"cache", "rss"},
-	}
-
-	res := map[string]interface{}{}
-	for id, name := range *dockerStats {
-		for metric, stats := range metrics {
-			if ok, err := exists(pb.build(id, metric, "stat")); !ok || err != nil {
-				continue
-			}
-			data, err := getFile(pb.build(id, metric, "stat"))
-			if err != nil {
-				return nil, err
-			}
-			for _, stat := range stats {
-				re := regexp.MustCompile(stat + " (\\d+)")
-				m := re.FindStringSubmatch(data)
-				if m != nil {
-					res[fmt.Sprintf("docker.%s.%s_%s.%s", metric, normalizeMetricName(name[0]), id[0:6], stat)] = m[1]
-				}
-			}
-		}
-
-		// blkio statistics
-		for _, blkioType := range []string{"io_queued", "io_serviced", "io_service_bytes"} {
-			if ok, err := exists(pb.build(id, "blkio", blkioType)); !ok || err != nil {
-				continue
-			}
-			data, err := getFile(pb.build(id, "blkio", blkioType))
-			if err != nil {
-				return nil, err
-			}
-			for _, stat := range []string{"Read", "Write", "Sync", "Async"} {
-				re := regexp.MustCompile(stat + " (\\d+)")
-				matchs := re.FindAllStringSubmatch(data, -1)
-				v := 0.0
-				for _, m := range matchs {
-					if m != nil {
-						ret, _ := strconv.ParseFloat(m[1], 64)
-						v += ret
-					}
-				}
-				res[fmt.Sprintf("docker.blkio.%s.%s_%s.%s", blkioType, normalizeMetricName(name[0]), id[0:6], strings.ToLower(stat))] = v
-			}
-		}
-
-	}
-
-	return res, nil
-}
-
 // GraphDefinition interface for mackerel plugin
 func (m DockerPlugin) GraphDefinition() map[string]mp.Graphs {
 	return graphdef
@@ -498,8 +272,8 @@ func Do() {
 	}
 
 	optHost := flag.String("host", "unix:///var/run/docker.sock", "Host for socket")
-	optCommand := flag.String("command", "docker", "Command path to docker")
-	optMethod := flag.String("method", "", "Specify the method to collect stats, 'API' or 'File'. If not specified, an appropriate method is chosen.")
+	_ = flag.String("command", "docker", "Command path to docker") // backward compatibility
+	optMethod := flag.String("method", "", "Specify the method to collect stats, 'API' or 'File'. If not specified, an appropriate method is chosen.(deprecated)")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	optNameFormat := flag.String("name-format", "name_id", "Set the name format from "+strings.Join(candidateNameFormat, ", "))
 	optLabel := flag.String("label", "", "Use the value of the key as name in case that name-format is label.")
@@ -508,13 +282,7 @@ func Do() {
 
 	var docker DockerPlugin
 
-	docker.Host = fmt.Sprintf("%s", *optHost)
-	docker.DockerCommand = *optCommand
-	_, err := exec.LookPath(docker.DockerCommand)
-	if err != nil {
-		log.Fatalf("Docker command is not found: %s", docker.DockerCommand)
-	}
-
+	docker.Host = *optHost
 	docker.NameFormat = *optNameFormat
 	docker.Label = *optLabel
 	if !setCandidateNameFormat[docker.NameFormat] {
@@ -524,37 +292,22 @@ func Do() {
 		log.Fatalf("Label flag should be set when name flag is 'label'.")
 	}
 
-	if *optMethod == "" {
-		docker.Method, err = guessMethod(docker.DockerCommand)
-		if err != nil {
-			log.Fatalf("Fail to guess stats method: %s", err.Error())
-		}
-	} else {
-		if *optMethod != "API" && *optMethod != "File" {
-			log.Fatalf("Method should be 'API', 'File' or an empty string.")
-		}
-		docker.Method = *optMethod
+	switch *optMethod {
+	case "", "API":
+		docker.Method = "API"
+	case "File":
+		log.Fatalf("'File' method is no longer supported")
+	default:
+		log.Fatalf("Method should be 'API', 'File' or an empty string.")
 	}
 
-	if docker.Method == "File" {
-		pb, err := newPathBuilder()
-		if err != nil {
-			log.Fatalf("failed to resolve docker metrics path: %s. It may be no Docker containers exists.", err)
-		}
-		docker.pathBuilder = pb
-	}
-
-	if *optCPUFormat == "percentage" {
-		if docker.Method == "File" {
-			log.Fatalf("'--cpu-format percentage' is not supported with File method.")
-		}
+	switch *optCPUFormat {
+	case "percentage":
 		docker.UseCPUPercentage = true
-	} else if *optCPUFormat == "usage" {
+	case "usage":
 		docker.UseCPUPercentage = false
-	} else {
-		if docker.Method == "API" {
-			docker.UseCPUPercentage = true
-		}
+	default:
+		docker.UseCPUPercentage = true
 	}
 
 	helper := mp.NewMackerelPlugin(docker)


### PR DESCRIPTION
In the past, Docker 1.5.x or earlier didn't have APIs to retrieve metrics so *plugin-docker* was read any metrics from files.
Today, that behavior still be supported if `-method File` option are passed to *plugin-docker* command.

However I think we could stop to support that option because Docker 1.6 had been released in 2015 and it is already marked as EOL.

This PR deletes `-method File` related codes and makes to print a message and exit if `-method File` is passed.