### PR TITLE
[plugin-docker] fix CPU/Memory metrics on Docker hosts uses cgroup2

### DIFF
--- a/mackerel-plugin-docker/lib/docker.go
+++ b/mackerel-plugin-docker/lib/docker.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 )
 
@@ -362,13 +362,32 @@ func (m DockerPlugin) parseStats(stats *map[string]interface{}, name string, res
 		(*stats)[internalCPUStatPrefix+name+".user"] = (*result).CPUStats.CPUUsage.UsageInUsermode
 		(*stats)[internalCPUStatPrefix+name+".system"] = (*result).CPUStats.CPUUsage.UsageInKernelmode
 		(*stats)[internalCPUStatPrefix+name+".host"] = (*result).CPUStats.SystemCPUUsage
-		(*stats)[internalCPUStatPrefix+name+".onlineCPUs"] = len((*result).CPUStats.CPUUsage.PercpuUsage)
+
+		onlineCPUs := int((*result).CPUStats.OnlineCPUs)
+		// if either `CPUStats.OnlineCPUs` or `PerCPUStats.OnlineCPUs` is zero,
+		// use the length of CPUUsage.PerCPUUsage for onlineCPUs
+		// ref. https://docs.docker.com/engine/api/v1.41/#operation/ContainerStats
+		if onlineCPUs == 0 || (*result).PreCPUStats.OnlineCPUs == 0 {
+			onlineCPUs = len((*result).CPUStats.CPUUsage.PercpuUsage)
+		}
+		(*stats)[internalCPUStatPrefix+name+".onlineCPUs"] = onlineCPUs
 	} else {
 		(*stats)["docker.cpuacct."+name+".user"] = (*result).CPUStats.CPUUsage.UsageInUsermode
 		(*stats)["docker.cpuacct."+name+".system"] = (*result).CPUStats.CPUUsage.UsageInKernelmode
 	}
-	(*stats)["docker.memory."+name+".cache"] = (*result).MemoryStats.Stats.TotalCache
-	(*stats)["docker.memory."+name+".rss"] = (*result).MemoryStats.Stats.TotalRss
+
+	totalRss := (*result).MemoryStats.Stats.TotalRss
+	if totalRss == 0 {
+		// use `anon` and `file` for RSS and Cache usage on cgroup2 host
+		// ref. https://github.com/google/cadvisor/blob/a9858972e75642c2b1914c8d5428e33e6392c08a/container/libcontainer/handler.go#L799-L800
+		(*stats)["docker.memory."+name+".rss"] = (*result).MemoryStats.Stats.Anon
+		(*stats)["docker.memory."+name+".cache"] = (*result).MemoryStats.Stats.File
+
+	} else {
+		// use `total_rss` and `total_cache` for RSS and Cache usage on cgroup host
+		(*stats)["docker.memory."+name+".rss"] = totalRss
+		(*stats)["docker.memory."+name+".cache"] = (*result).MemoryStats.Stats.TotalCache
+	}
 
 	fields := []string{"read", "write", "sync", "async"}
 	for _, field := range fields {

--- a/mackerel-plugin-docker/lib/docker_test.go
+++ b/mackerel-plugin-docker/lib/docker_test.go
@@ -3,7 +3,7 @@ package mpdocker
 import (
 	"testing"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 func TestNormalizeMetricName(t *testing.T) {


### PR DESCRIPTION
Fix #885

# Overview

Fix the issue `mackerel-plugin-docker` always outputs zero value CPU/Memory metrics for Docker host with cgroup v2.
(The issue filed in https://github.com/mackerelio/mackerel-agent-plugins/issues/885)
In particular, make the following metrics proper value on cgroupv2 host.

- `docker.cpuacct_percentage.<container_name>.user`
- `docker.cpuacct_percentage.<container_name>.system`
- `docker.memory.<container_name>.cache`
- `docker.memory.<container_name>.rss`

It is because the output of Docker Stats API on cgroupv2 host differs from the one on cgroup host.

> On a cgroup v2 host, the following fields are not set
>
> blkio_stats: all fields other than io_service_bytes_recursive
> cpu_stats: cpu_usage.percpu_usage
> memory_stats: max_usage and failcnt Also, memory_stats.stats fields are incompatible with cgroup v1.

(cf. https://docs.docker.com/engine/api/v1.41/#operation/ContainerStats)

The this PR fix usage of Docker Stats API result to consider cgroupv2 hosts.

# Testing

The following log is to confirm the patched binary outputs CPU/Memory usage properly. 
It executes `mackerel-plugin-docker` twice on the host with Docker daemon uses cgroup2.

```
ruins@thor:~/src/github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker$ ./mackerel-plugin-docker
docker.memory.mackerel_a34df2.cache     16384   1654677395
docker.memory.mackerel_a34df2.rss       6270976 1654677395
ruins@thor:~/src/github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker$ ./mackerel-plugin-docker
docker.cpuacct_percentage.mackerel_a34df2.user  0.010311        1654677398
docker.cpuacct_percentage.mackerel_a34df2.system        0.002042        1654677398
docker.memory.mackerel_a34df2.cache     16384   1654677398
docker.memory.mackerel_a34df2.rss       6270976 1654677398
```

<details>
<summary>Detail of test environment</summary>

```
ruins@thor:~/src/github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker$ uname -r
5.15.0-33-generic
ruins@thor:~/src/github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker$ cat /etc/issue
Ubuntu 22.04 LTS \n \l
ruins@thor:~/src/github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-docker$ docker info
Client:
 Context:    default
 Debug Mode: false

Server:
 Containers: 10
  Running: 1
  Paused: 0
  Stopped: 9
 Images: 60
 Server Version: 20.10.12
 Storage Driver: overlay2
  Backing Filesystem: xfs
  Supports d_type: true
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version:
 runc version:
 init version:
 Security Options:
  apparmor
  seccomp
   Profile: default
  cgroupns
 Kernel Version: 5.15.0-33-generic
 Operating System: Ubuntu 22.04 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 24
 Total Memory: 62.73GiB
 Name: thor
 ID: BXOG:D3MJ:Q5FT:43V3:U55A:DHWI:ZSOB:7BJ2:ZE4T:6VZN:5SI4:YRQO
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Username: ruins
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
 ```

</details>