### PR TITLE
[plugin-aws-ec2-ebs] fix misuse of period

### DIFF
--- a/mackerel-plugin-aws-ec2-ebs/README.md
+++ b/mackerel-plugin-aws-ec2-ebs/README.md
@@ -20,5 +20,5 @@ the credential provided manually or fetched automatically with IAM Role, should 
 
 ```
 [plugin.metrics.aws-ec2_ebs]
-command = "/path/to/mackerel-plugin-aws-ec2-ebs"
+command = ["/path/to/mackerel-plugin-aws-ec2-ebs"]
 ```


### PR DESCRIPTION
I fixed period-misuse bugs in **mackerel-plugin-aws-ec2-ebs**.

The plugin retrieves recent values of  the metrics each minutes, and then it elects only a most recent value each metrics from them. Thus these metric values are aggregated by a minute.

In addition, some metric's graph definition such as `ec2.ebs.bandwidth.#.read` or `ec2.ebs.throughput.#.read` are designed with per-second units. Thus the plugin should convert these `Sum`ed values to the values avarage per second, like `val / 60`.

https://github.com/mackerelio/mackerel-agent-plugins/blob/1be28e2aed5f8ca05cf8b2ee35717283405c722b/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go#L230-L243

However, in the current implementaton, that formula is wrong.
For instance, *getLastPoint* method returns a metric value and its period that are aggregated each period, but this period is `metricPeriodDefault = 300` (but if not io1).

https://github.com/mackerelio/mackerel-agent-plugins/blob/1be28e2aed5f8ca05cf8b2ee35717283405c722b/mackerel-plugin-aws-ec2-ebs/lib/aws-ec2-ebs.go#L288-L298
