### PR TITLE
[mongodb] add metric-key-prefix option

### DIFF
--- a/mackerel-plugin-mongodb/lib/mongodb.go
+++ b/mackerel-plugin-mongodb/lib/mongodb.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/go-version"
 	mp "github.com/mackerelio/go-mackerel-plugin-helper"
 	"github.com/mackerelio/golib/logging"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var logger = logging.GetLogger("metrics.plugin.mongodb")
@@ -314,7 +316,7 @@ func (m MongoDBPlugin) MetricKeyPrefix() string {
 }
 
 func (m MongoDBPlugin) LabelPrefix() string {
-	return strings.Title(strings.Replace(m.MetricKeyPrefix(), defaultPrefix, "MongoDB", -1))
+	return cases.Title(language.Und, cases.NoLower).String(strings.Replace(m.MetricKeyPrefix(), defaultPrefix, "MongoDB", -1))
 }
 
 // Do the plugin

--- a/mackerel-plugin-mongodb/lib/mongodb_test.go
+++ b/mackerel-plugin-mongodb/lib/mongodb_test.go
@@ -3,10 +3,11 @@ package mpmongodb
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/globalsign/mgo/bson"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/globalsign/mgo/bson"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGraphDefinition(t *testing.T) {
@@ -191,4 +192,24 @@ func TestParse36(t *testing.T) {
 	// Mongodb Stats
 	assert.EqualValues(t, reflect.TypeOf(stat["opcounters_command"]).String(), "float64")
 	assert.EqualValues(t, stat["opcounters_command"], 457766)
+}
+
+func TestMetricKeyPrefix(t *testing.T) {
+	var m MongoDBPlugin
+	prefix := m.MetricKeyPrefix()
+	assert.Equal(t, "mongodb", prefix)
+
+	m.KeyPrefix = "test"
+	prefix = m.MetricKeyPrefix()
+	assert.Equal(t, "test", prefix)
+}
+
+func TestLabelPrefix(t *testing.T) {
+	var m MongoDBPlugin
+	label := m.LabelPrefix()
+	assert.Equal(t, "MongoDB", label)
+
+	m.KeyPrefix = "test"
+	label = m.LabelPrefix()
+	assert.Equal(t, "Test", label)
 }


### PR DESCRIPTION
The metric-key-prefix option has been added to mackerel-plugin-mongodb to resolve issues that have been inquired to support.

In line with this, the graph labels now also reflect the prefix.