### PR TITLE
packaging: make compression format xz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         parallel-finished: true
   build:
     needs: [test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
     - run: |

--- a/packaging/deb-v2/debian/rules
+++ b/packaging/deb-v2/debian/rules
@@ -6,6 +6,9 @@
 # This variable must be the same as the value of the `Package:` field in the control file.
 package=mackerel-agent-plugins
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/bin

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -5,6 +5,9 @@
 
 package=mackerel-agent-plugins
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/bin


### PR DESCRIPTION
- The plugins packages builds on **ubuntu-latest** label
- Now, **ubuntu-latest** label points to **ubuntu-22.04**
- **ubuntu-22.04** switches to **zst** as default format of deb package

We provides deb packages to many OSes so we should keep **xz** format to compress format of the packages.