### PR TITLE
fix build on current working directory.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
     time: "01:00"
     timezone: Asia/Tokyo
   open-pull-requests-limit: 10
+# TODO when remove rpm-v1, deb-v1 task on Makefile, remove below lines
+- package-ecosystem: gomod
+  directory: "mackerel-plugin-mysql/"
+  schedule:
+    interval: weekly
+    time: "01:00"
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 10

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: testconvention rpm deb
 .SECONDEXPANSION:
 $(BINDIR)/mackerel-plugin-%: mackerel-plugin-%/main.go $$(wildcard mackerel-plugin-%/lib/*.go)
 	@if [ ! -d $(BINDIR) ]; then mkdir -p $(BINDIR); fi
-	CGO_ENABLED=0 go build -ldflags="-s -w" -o $@ ./`basename $@`
+	cd `basename $@` && CGO_ENABLED=0 go build -ldflags="-s -w" -o ../$@
 
 .PHONY: build
 build:


### PR DESCRIPTION
- This repository has multiple go.mod files.
- mackerel-plugin-mysql has an independent go.mod
- rpm-v1, deb-v1 task on Makefile creates individual compiled binaries.