### PR TITLE
Enables Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,23 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "01:00"
-    timezone: Asia/Tokyo
-  open-pull-requests-limit: 10
-# TODO when remove rpm-v1, deb-v1 task on Makefile, remove below lines
-- package-ecosystem: gomod
-  directory: "mackerel-plugin-mysql/"
-  schedule:
-    interval: weekly
-    time: "01:00"
-    timezone: Asia/Tokyo
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "01:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+  # TODO when remove rpm-v1, deb-v1 task on Makefile, remove below lines
+  - package-ecosystem: gomod
+    directory: "mackerel-plugin-mysql/"
+    schedule:
+      interval: weekly
+      time: "01:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "01:00"
+      timezone: Asia/Tokyo

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,9 +1,9 @@
-name: 'Create Release PR'
+name: "Create Release PR"
 on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'next release version'
+        description: "next release version"
         required: true
 env:
   GIT_AUTHOR_NAME: mackerelbot
@@ -19,7 +19,7 @@ jobs:
 
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: '5.34'
+          perl-version: "5.34"
 
       - uses: mackerelio/mackerel-create-release-pull-request-action@main
         id: start
@@ -42,4 +42,3 @@ jobs:
           next_version: ${{ steps.start.outputs.nextVersion }}
           branch_name: ${{ steps.start.outputs.branchName }}
           pull_request_infos: ${{ steps.start.outputs.pullRequestInfos }}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ name: test
 on:
   push:
     branches:
-    - master
+      - master
     tags:
-    - v*
+      - v*
   pull_request:
 env:
   DEBIAN_FRONTEND: noninteractive
@@ -28,88 +28,88 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - run: |
-        sudo apt-get update
-        sudo apt-get install -y redis-server
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - run: |
-        make test
-    - run: go test -covermode=atomic -coverprofile=.profile.cov ./...
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-profile: .profile.cov
-        parallel: true
-        flag-name: Go-${{ matrix.os }}-${{ matrix.go }}
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y redis-server
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: |
+          make test
+      - run: go test -covermode=atomic -coverprofile=.profile.cov ./...
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-profile: .profile.cov
+          parallel: true
+          flag-name: Go-${{ matrix.os }}-${{ matrix.go }}
   finish:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
   build:
     needs: [test]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
-    - run: |
-        sudo apt-get update
-        sudo apt-get install -y rpm devscripts debhelper fakeroot crossbuild-essential-arm64
-        mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.19.x
-    - uses: actions/checkout@v2
-    - run: make clean rpm deb
-    - uses: actions/upload-artifact@v2
-      with:
-        name: linux-build-artifacts
-        path: |
-          ~/rpmbuild/RPMS/*/*.rpm
-          packaging/*.deb
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm devscripts debhelper fakeroot crossbuild-essential-arm64
+          mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.19.x
+      - uses: actions/checkout@v2
+      - run: make clean rpm deb
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-build-artifacts
+          path: |
+            ~/rpmbuild/RPMS/*/*.rpm
+            packaging/*.deb
   release:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
-    - uses: actions/download-artifact@v2
-      with:
-        name: linux-build-artifacts
-        path: artifacts/
-    - uses: mackerelio/staging-release-update-action@main
-      if: github.ref == 'refs/heads/master'
-      with:
-        directory: artifacts/
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        tag: staging
-    - uses: mackerelio/create-release-action@main
-      if: startsWith(github.ref, 'refs/tags/v')
-      with:
-        directory: artifacts/
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        tag-prefix: 'refs/tags/v'
-        bump-up-branch-prefix: 'bump-version-'
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        fields: repo,message,commit,action,eventName,ref,workflow,job,took
-        username: mackerel-agent-plugins-release
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.MACKEREL_SLACK_WEBHOOK_URL }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: linux-build-artifacts
+          path: artifacts/
+      - uses: mackerelio/staging-release-update-action@main
+        if: github.ref == 'refs/heads/master'
+        with:
+          directory: artifacts/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: staging
+      - uses: mackerelio/create-release-action@main
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          directory: artifacts/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-prefix: "refs/tags/v"
+          bump-up-branch-prefix: "bump-version-"
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,action,eventName,ref,workflow,job,took
+          username: mackerel-agent-plugins-release
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.MACKEREL_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This repository's workflows look antiquated. Deprecated features and runtimes of Github Actions will soon be unavailable.

So we activate dependabot for GitHub Actions to automate updates.