### PR TITLE
Fix support APCu and PHP7 or later environment.

### DIFF
--- a/mackerel-plugin-php-apc/README.md
+++ b/mackerel-plugin-php-apc/README.md
@@ -3,7 +3,7 @@ mackerel-plugin-php-apc
 
 ## Description
 
-Get PHP APC (Alternative PHP Cache) metrics for Mackerel and Sensu.
+Get PHP APC (Alternative PHP Cache) or APCu (APC User Cache) metrics for Mackerel and Sensu.
 
 ## Usage (for Apache)
 
@@ -36,7 +36,7 @@ Edit your apache config file to access metric from localhost only. For example i
     Allow from 127.0.0.1 ::1
 </Directory>
 ```
- 
+
 And, reload apache configuration.
 
 ```
@@ -68,4 +68,5 @@ Please execute 'mackerel-plugin-php-apc -h' and you can get command line options
 
 ## Author
 
-[Yuichiro Saito](https://github.com/koemu)
+- Original author. [Yuichiro Saito](https://github.com/koemu)
+- Add APCu and PHP>=7 env support. [uzulla](https://github.com/uzulla)

--- a/mackerel-plugin-php-apc/lib/php-apc.php
+++ b/mackerel-plugin-php-apc/lib/php-apc.php
@@ -4,8 +4,8 @@ header("Content-Type: text/plain");
 
 // In PHP7 or later, it is required to use apcu_*. instead of apc_*.
 if(function_exists("apcu_cache_info")){
-    $cache      = apcu_cache_info();
-    $cache_user = apcu_cache_info(true);
+    $cache      = apcu_cache_info(false);
+    $cache_user = $cache;
     $mem        = apcu_sma_info();
 } else {
     $cache      = apc_cache_info();

--- a/mackerel-plugin-php-apc/lib/php-apc.php
+++ b/mackerel-plugin-php-apc/lib/php-apc.php
@@ -2,9 +2,16 @@
 
 header("Content-Type: text/plain");
 
-$cache      = apc_cache_info();
-$cache_user = apc_cache_info('user', 1); 
-$mem        = apc_sma_info();
+// In PHP7 or later, it is required to use apcu_*. instead of apc_*.
+if(function_exists("apcu_cache_info")){
+    $cache      = apcu_cache_info();
+    $cache_user = apcu_cache_info(true);
+    $mem        = apcu_sma_info();
+} else {
+    $cache      = apc_cache_info();
+    $cache_user = apc_cache_info('user', 1);
+    $mem        = apc_sma_info();
+}
 
 $stats = array(
     "memory_segments"       => (int)$mem['num_seg'],


### PR DESCRIPTION
In APCu + PHP>=7 environments, `apc_cache_info` methods are no longer support.
The PR fix it and support APCu extention without shim.

PHP8やPHP7+APCuでは正しく動作しなかったため、修正するPRとなります。
もはやPHP7はEOLですが、それ以降のPHP8+APCuでも本対応が必要です。

Goで書かれた箇所は変更しておらず、APC(APCu)の統計情報を取得するPHPスクリプトのみの修正です。
`apc_*` 関数を `apcu_*` 関数に書き換えています。

> 「APCプラグインなのにAPCuサポートをするのか？」という点は後述します

## 修正内容

### PHP7以降 + APCu環境

本PRのコードで正常に取得できる様子

```
$ curl http://127.0.0.1:1234/mackerel/php-apcu.php // ファイル名は区別のためPRと変更してあります
memory_segments:1
segment_size:33554312
total_memory:33554312
cached_files_count:1
cached_files_size:128
cache_hits:16
cache_misses:7
cache_full_count:0
user_cache_vars_count:1
user_cache_vars_size:128
user_cache_hits:16
user_cache_misses:7
user_cache_full_count:0
```

既存コードで500が返る様子(修正したい問題です)

```
$ curl -v http://127.0.0.1:1234/mackerel/php-apc.php // ファイル名は区別のためPRと変更してあります
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 1234 (#0)
> GET /mackerel/php-apc.php HTTP/1.1
> Host: 127.0.0.1:1234
> User-Agent: curl/7.61.1
> Accept: */*
>
* HTTP 1.0, assume close after body
< HTTP/1.0 500 Internal Server Error
< Date: Fri, 24 Feb 2023 10:30:11 GMT
< Server: Apache
< Content-Length: 0
< Connection: close
< Content-Type: text/plain;charset=UTF-8
<
* Closing connection 0

PHP Fatal error:  Uncaught Error: Call to undefined function apc_cache_info() in /var/www/mackerel/php-apc.php:5
Stack trace:
#0 {main}
thrown in /var/www/mackerel/php-apc.php on line 5
```

### PHP5.6 + APCuでの動作

> PHP5.x+APCu は `apc_cache_info` もサポートしていますので、「こわれていない」という様子です

このPRでの動作の様子

```
$ curl http://127.0.0.1:1234/mackerel/php-apcu.php
memory_segments:1
segment_size:3***6
total_memory:3***6
cached_files_count:4***6
cached_files_size:3***4
cache_hits:3***3
cache_misses:6***8
cache_full_count:0
user_cache_vars_count:4***6
user_cache_vars_size:3***4
user_cache_hits:3***3
user_cache_misses:6***8
user_cache_full_count:0
```

既存の様子

```
$ curl http://127.0.0.1:1234/mackerel/php-apc.php
memory_segments:1
segment_size:3***6
total_memory:3***6
cached_files_count:4***0
cached_files_size:3***4
cache_hits:3***7
cache_misses:6***5
cache_full_count:0
user_cache_vars_count:4***0
user_cache_vars_size:3***4
user_cache_hits:3***7
user_cache_misses:6***5
user_cache_full_count:0
```

都合上、具体的な値は***でマスクしていますが、すべての数字がほぼ同様の内容となっています。
(完全に同タイミングで実行できないのですが、十分に近い数字に見えます)

## test

```
$ go test -v
=== RUN   TestGetPhpApcStatus_1
--- PASS: TestGetPhpApcStatus_1 (0.00s)
=== RUN   TestGetPhpApcMetrics_1
--- PASS: TestGetPhpApcMetrics_1 (0.00s)
PASS
ok  	github.com/mackerelio/mackerel-agent-plugins/mackerel-plugin-php-apc/lib	0.311s
```

(goの箇所は修正しておりませんが…一応)

## 備考

- apcとapcuでプラグインを分割することも検討できますが、apcuはapcからユーザーキャッシュを抜き出したもので、本プラグインが監視したい箇所・機能は同じなので、同一プラグインでサポートする方がよいかと思います。(もはやapcを入れるは少ないだろうからと名称をapcuにすることは良いかもしれませんが)
