### PR TITLE
Fix timeout/error labels of mackerel-plugin-twemproxy

### DIFF
--- a/mackerel-plugin-twemproxy/lib/twemproxy.go
+++ b/mackerel-plugin-twemproxy/lib/twemproxy.go
@@ -46,8 +46,8 @@ func (p TwemproxyPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "total_pool_client_error", Label: "Pool Client Error", Diff: true},
 				{Name: "total_pool_server_ejects", Label: "Pool Server Ejects", Diff: true},
 				{Name: "total_pool_forward_error", Label: "Pool Forward Error", Diff: true},
-				{Name: "total_server_timeout", Label: "Server Error", Diff: true},
-				{Name: "total_server_error", Label: "Server Timeout", Diff: true},
+				{Name: "total_server_timeout", Label: "Server Timeout", Diff: true},
+				{Name: "total_server_error", Label: "Server Error", Diff: true},
 			},
 		},
 		"pool_error.#": {


### PR DESCRIPTION
In mackerel-plugin-twemproxy, `Server Timeout` and `Server Error` are reversed in the display label and value set.
This patch trys to fix it.
