### PR TITLE
[fluentd] add README.md with extended_metrics option

### DIFF
--- a/mackerel-plugin-fluentd/README.md
+++ b/mackerel-plugin-fluentd/README.md
@@ -6,7 +6,7 @@ Fluentd (http://www.fluentd.org/) custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-fluentd [-host=<host>] [-port=<port>] [-tempfile=<tempfile>] [-plugin-type=<plugin-type>] [-plugin-id-pattern=<plugin-id-pattern>] [-workers=<workers>]
+mackerel-plugin-fluentd [-host=<host>] [-port=<port>] [-tempfile=<tempfile>] [-plugin-type=<plugin-type>] [-plugin-id-pattern=<plugin-id-pattern>] [-workers=<workers>] [-extended_metrics=<metric-names>]
 ```
 
 ## Example of mackerel-agent.conf


### PR DESCRIPTION
I found an option that was added in #738 but it is not described in the README.