### PR TITLE
Fixed Docker CPU Percentage's unusual spike when restarting containers

### DIFF
--- a/mackerel-plugin-docker/lib/docker.go
+++ b/mackerel-plugin-docker/lib/docker.go
@@ -270,19 +270,30 @@ func addCPUPercentageStats(stats *map[string]interface{}, lastStat map[string]in
 		currentUserUsage, ok1 := (*stats)[internalCPUStatPrefix+name+".user"]
 		prevUserUsage, ok2 := lastStat[internalCPUStatPrefix+name+".user"]
 		if ok1 && ok2 {
-			userUsage := float64(currentUserUsage.(uint64) - uint64(prevUserUsage.(float64)))
-			if userUsage >= 0 {
-				(*stats)["docker.cpuacct_percentage."+name+".user"] = userUsage / hostUsage * 100.0 * float64(cpuNumsInt)
+			currentUserUsageUInt := currentUserUsage.(uint64)
+			prevUserUsageUInt := uint64(prevUserUsage.(float64))
+			var userUsage float64
+			if currentUserUsageUInt >= prevUserUsageUInt {
+				userUsage = float64(currentUserUsage.(uint64) - uint64(prevUserUsage.(float64)))
+			} else {
+				// counter has been reset
+				userUsage = float64(currentUserUsageUInt)
 			}
+			(*stats)["docker.cpuacct_percentage."+name+".user"] = userUsage / hostUsage * 100.0 * float64(cpuNumsInt)
 		}
 
 		currentSystemUsage, ok1 := (*stats)[internalCPUStatPrefix+name+".system"]
 		prevSystemUsage, ok2 := lastStat[internalCPUStatPrefix+name+".system"]
 		if ok1 && ok2 {
-			systemUsage := float64(currentSystemUsage.(uint64) - uint64(prevSystemUsage.(float64)))
-			if systemUsage >= 0 {
-				(*stats)["docker.cpuacct_percentage."+name+".system"] = systemUsage / hostUsage * 100.0 * float64(cpuNumsInt)
+			currentSystemUsageUInt := currentSystemUsage.(uint64)
+			prevSystemUsageUInt := uint64(prevSystemUsage.(float64))
+			var systemUsage float64
+			if currentSystemUsageUInt >= prevSystemUsageUInt {
+				systemUsage = float64(currentSystemUsageUInt - prevSystemUsageUInt)
+			} else {
+				systemUsage = float64(currentSystemUsageUInt)
 			}
+			(*stats)["docker.cpuacct_percentage."+name+".system"] = systemUsage / hostUsage * 100.0 * float64(cpuNumsInt)
 		}
 	}
 }

--- a/mackerel-plugin-docker/lib/docker_test.go
+++ b/mackerel-plugin-docker/lib/docker_test.go
@@ -99,6 +99,10 @@ func TestAddCPUPercentageStats(t *testing.T) {
 		"docker._internal.cpuacct.containerD.host":       uint64(100000),
 		"docker._internal.cpuacct.containerD.user":       uint64(3000),
 		"docker._internal.cpuacct.containerD.system":     uint64(2000),
+		"docker._internal.cpuacct.containerF.user":       uint64(3000), // it has been reset
+		"docker._internal.cpuacct.containerF.system":     uint64(1000), // it has been reset
+		"docker._internal.cpuacct.containerF.host":       uint64(100000100000),
+		"docker._internal.cpuacct.containerF.onlineCPUs": int(2),
 	}
 	oldStats := map[string]interface{}{
 		"docker._internal.cpuacct.containerA.host":   float64(90000),
@@ -111,6 +115,9 @@ func TestAddCPUPercentageStats(t *testing.T) {
 		"docker._internal.cpuacct.containerE.host":   float64(100000),
 		"docker._internal.cpuacct.containerE.user":   float64(3000),
 		"docker._internal.cpuacct.containerE.system": float64(2000),
+		"docker._internal.cpuacct.containerF.user":   float64(40000000000),
+		"docker._internal.cpuacct.containerF.system": float64(20000000000),
+		"docker._internal.cpuacct.containerF.host":   float64(100000000000),
 	}
 	addCPUPercentageStats(&stats, oldStats)
 
@@ -134,5 +141,11 @@ func TestAddCPUPercentageStats(t *testing.T) {
 
 	if _, ok := stats["docker.cpuacct_percentage.containerE.user"]; ok {
 		t.Errorf("docker.cpuacct_percentage.containerE.user should not be calculated")
+	}
+
+	if stat, ok := stats["docker.cpuacct_percentage.containerF.user"]; !ok {
+		t.Errorf("docker.cpuacct_percentage.containerF.user should be calculated")
+	} else if stat != float64(6.0) {
+		t.Errorf("docker.cpuacct_percentage.containerF.user should be %f, but %f", float64(6.0), stat)
 	}
 }

--- a/mackerel-plugin-docker/lib/docker_test.go
+++ b/mackerel-plugin-docker/lib/docker_test.go
@@ -124,7 +124,7 @@ func TestAddCPUPercentageStats(t *testing.T) {
 	if stat, ok := stats["docker.cpuacct_percentage.containerA.user"]; !ok {
 		t.Errorf("docker.cpuacct_percentage.containerA.user should be calculated")
 	} else if stat != float64(40.0) {
-		t.Errorf("docker.cpuacct_percentage.containerA.user should be %f, but %f", stat, float64(40.0))
+		t.Errorf("docker.cpuacct_percentage.containerA.user should be %f, but %f", float64(40.0), stat)
 	}
 
 	if _, ok := stats["docker.cpuacct_percentage.containerC.user"]; ok {


### PR DESCRIPTION
`docker.cpuacct_percentage.*.{user,system}` metrics observed after restarting a docker container appear to be an unusually high spike.

<img width="650" alt="スクリーンショット 2023-08-17 22 00 32" src="https://github.com/mackerelio/mackerel-agent-plugins/assets/32762324/6fa0dcf8-45cc-4a4a-aa7a-bc36c63e44dc">

This problem is due to the fact that the comparison of two uint values is made by subtraction.

https://github.com/mackerelio/mackerel-agent-plugins/blob/cbd69a9fe7e468d1fe193e5cffbde2f3cdc2a5ce/mackerel-plugin-docker/lib/docker.go#L273-L276

This pull request enables to correctly detect that counters have been reset and also set metrics to moderate values in that case.

## operational test

### before

You can see that `docker.cpuacct_percentage.hoge_2e3173.{user,system}` metrics have huge values after executing `docker restart` command.

```console
$ ./build/darwin/arm64/mackerel-plugin-docker
docker.memory.hoge_2e3173.cache	11956224	1692718764
docker.memory.hoge_2e3173.rss	3805184	1692718764
$ ./build/darwin/arm64/mackerel-plugin-docker
docker.cpuacct_percentage.hoge_2e3173.user	2.154874	1692718768
docker.cpuacct_percentage.hoge_2e3173.system	1.628945	1692718768
docker.memory.hoge_2e3173.cache	11956224	1692718768
docker.memory.hoge_2e3173.rss	3805184	1692718768
$ docker restart 2e31732280a7
2e31732280a7
$ ./build/darwin/arm64/mackerel-plugin-docker
docker.cpuacct_percentage.hoge_2e3173.user	246614225174.769592	1692718776
docker.cpuacct_percentage.hoge_2e3173.system	246614225285.428925	1692718776
docker.memory.hoge_2e3173.cache	11923456	1692718776
docker.memory.hoge_2e3173.rss	3735552	1692718776
```

### after

```console
$ ./build/darwin/arm64/mackerel-plugin-docker
docker.memory.hoge_2e3173.cache	11956224	1692717626
docker.memory.hoge_2e3173.rss	3829760	1692717626
$ ./build/darwin/arm64/mackerel-plugin-docker
docker.cpuacct_percentage.hoge_2e3173.user	3.126744	1692717634
docker.cpuacct_percentage.hoge_2e3173.system	2.455736	1692717634
docker.memory.hoge_2e3173.cache	11956224	1692717634
docker.memory.hoge_2e3173.rss	3829760	1692717634
$ docker restart 2e31732280a7
2e31732280a7
$ ./build/darwin/arm64/mackerel-plugin-docker
docker.memory.hoge_2e3173.cache	11923456	1692717644
docker.memory.hoge_2e3173.rss	3710976	1692717644
docker.cpuacct_percentage.hoge_2e3173.user	1.112812	1692717644
docker.cpuacct_percentage.hoge_2e3173.system	1.229388	1692717644
```