### PR TITLE
added TLS support on mackerel-plugin-redis

### DIFF
--- a/mackerel-plugin-redis/README.md
+++ b/mackerel-plugin-redis/README.md
@@ -6,7 +6,7 @@ Redis custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-redis [-host=<hostname>] [-port=<port>] [-password=<password>] [-socket=<unix socket>] [-timeout=<time>] [-metric-key-prefix=<prefix>] [-config-command=<CONFIG command name>]
+mackerel-plugin-redis [-host=<hostname>] [-port=<port>] [-password=<password>] [-socket=<unix socket>] [-timeout=<time>] [-metric-key-prefix=<prefix>] [-config-command=<CONFIG command name>] [-tls] [-tls-skip-verify]
 ```
 
 ## Example of mackerel-agent.conf


### PR DESCRIPTION
our customers needed TLS support at Redis datastore on some managed cloud services.