### PR TITLE
update go version -> 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,22 @@ env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
   lint:
-    uses: mackerelio/workflows/.github/workflows/go-lint.yml@main
+    uses: mackerelio/workflows/.github/workflows/go-lint.yml@v1.1.0
     with:
       os-versions: '["ubuntu-latest", "windows-latest"]'
   test:
-    uses: mackerelio/workflows/.github/workflows/go-test.yml@main
+    uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.1.0
     with:
       os-versions: '["ubuntu-latest", "windows-latest"]'
   integration-test-linux:
-    uses: mackerelio/workflows/.github/workflows/setup-go-matrix.yml@main
+    uses: mackerelio/workflows/.github/workflows/setup-go-matrix.yml@v1.1.0
     with:
       os-versions: '["ubuntu-latest"]'
       run: |
         make testconvention
         ./test.bash
   integration-test-windows:
-    uses: mackerelio/workflows/.github/workflows/setup-go-matrix.yml@main
+    uses: mackerelio/workflows/.github/workflows/setup-go-matrix.yml@v1.1.0
     with:
       os-versions: '["windows-latest"]'
       run: |
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
       - run: make clean rpm deb
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I updated go toolchain

- build: go 1.22
- test: go 1.21, 1.22 (workflows)
  - ref https://github.com/mackerelio/workflows/blob/4ff6e7b3422ff5f9d078848d32b1a48850ad3f8d/.github/workflows/go-test.yml#L15
- lint: go 1.22