### PR TITLE
[mackerel-plugin-windows-server-sessions] Remove the dependency for WMIC command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19
 	github.com/urfave/cli v1.22.14
+	github.com/yusufpapurcu/wmi v1.2.4
 	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 )
@@ -52,7 +53,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
-	github.com/go-ole/go-ole v1.2.5 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-sql-driver/mysql v1.7.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,9 @@ github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-ldap/ldap/v3 v3.4.4 h1:qPjipEpt+qDa6SI/h1fzuGWoRUY+qqQ9sOZq67/PYUs=
 github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXgXtJC+aI=
-github.com/go-ole/go-ole v1.2.5 h1:t4MGB5xEDZvXI+0rMjjsfBsD7yAgp/s9ZDkL1JndXwY=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redismock/v9 v9.0.3 h1:mtHQi2l51lCmXIbTRTqb1EiHYe9tL5Yk5oorlSJJqR0=
@@ -200,6 +201,8 @@ github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
+github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.mongodb.org/mongo-driver v1.14.0 h1:P98w8egYRjYe3XDjxhYJagTokP/H6HzlsnojRgZRd80=
 go.mongodb.org/mongo-driver v1.14.0/go.mod h1:Vzb0Mk/pa7e6cWw85R4F/endUC3u0U9jGcNU603k65c=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/mackerel-plugin-windows-server-sessions/README.md
+++ b/mackerel-plugin-windows-server-sessions/README.md
@@ -6,7 +6,7 @@ Windows Server Sessions custom metrics plugin for mackerel-agent.
 ## Usage
 
 ```shell
-mackerel-plugin-windows-server-sessions
+mackerel-plugin-windows-server-sessions [-legacymetricname]
 ```
 
 ## Example of mackerel-agent.conf

--- a/mackerel-plugin-windows-server-sessions/lib/sessions.go
+++ b/mackerel-plugin-windows-server-sessions/lib/sessions.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package mpwindowsserversessions
 
 import (

--- a/mackerel-plugin-windows-server-sessions/lib/sessions_other.go
+++ b/mackerel-plugin-windows-server-sessions/lib/sessions_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package mpwindowsserversessions
+
+// Do the plugin
+func Do() {
+	panic("The mackerel-plugin-windows-server-sessions does not work on non Windows environment, of course.")
+}


### PR DESCRIPTION
WMIC is deprecated as of the 21H1 semi-annual channel release of Windows Server. cf.) https://learn.microsoft.com/en-us/windows/win32/wmisdk/wmic

So, I have updated mackerel-plugin-windows-server-sessions to use a Go library that interact directly with WMI instead of WMIC command.

## test

### before

```console
> WMIC PATH Win32_PerfFormattedData_PerfNet_Server GET ServerSessions /FORMAT:CSV

Node,ServerSessions
EC2AMAZ-BAJQD2D,0
```

```console
> cd mackerel-plugin-windows-server-sessions
> go run ./main
windows.server.sessions.EC2AMAZ-BAJQD2D.count   0       1709118187
```

### after

```console
> go run ./main
windows.server.sessions.EC2AMAZ-BAJQD2D.count   0       1709127711
```