### PR TITLE
add STRING number support

### DIFF
--- a/mackerel-plugin-snmp/lib/snmp.go
+++ b/mackerel-plugin-snmp/lib/snmp.go
@@ -52,6 +52,12 @@ func (m SNMPPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 		ret, err := strconv.ParseFloat(fmt.Sprint(resp.Variables[0].Value), 64)
 		if err != nil {
+			// NOTE: Cannot assume strconv.ParseFloat("%s", resp.Variables[0].Value)
+			// first, as resp.Variables[0].Value may be an int class, etc.
+			// Normally, an object values such as INTEGER or Counter are
+			// successfully accepted in the above conversions.
+			// However, STRING object values are passed as byte arrays, so the above
+			// conversion will result in an error.
 			ret, err = strconv.ParseFloat(fmt.Sprintf("%s", resp.Variables[0].Value), 64)
 			if err != nil {
 				log.Println(err)

--- a/mackerel-plugin-snmp/lib/snmp.go
+++ b/mackerel-plugin-snmp/lib/snmp.go
@@ -52,8 +52,11 @@ func (m SNMPPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 		ret, err := strconv.ParseFloat(fmt.Sprint(resp.Variables[0].Value), 64)
 		if err != nil {
-			log.Println(err)
-			continue
+			ret, err = strconv.ParseFloat(fmt.Sprintf("%s", resp.Variables[0].Value), 64)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
 		}
 
 		stat[sm.Metrics.Name] = ret

--- a/mackerel-plugin-snmp/rule.txt
+++ b/mackerel-plugin-snmp/rule.txt
@@ -1,2 +1,3 @@
 snmp.hrSystemNumUsers	>=0
 snmp.hrSystemProcesses	>=0
+snmp.echo	>0

--- a/mackerel-plugin-snmp/test.sh
+++ b/mackerel-plugin-snmp/test.sh
@@ -26,7 +26,7 @@ docker run --name "test-$plugin" -v $(pwd)/testdata/snmpd.conf:/etc/snmp/snmpd.c
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit 1' 1 2 3 15
 sleep 10
 
-$plugin '.1.3.6.1.2.1.25.1.5.0:hrSystemNumUsers:0:0' '.1.3.6.1.2.1.25.1.6.0:hrSystemProcesses:0:0' | graphite-metric-test -f rule.txt
+$plugin '.1.3.6.1.2.1.25.1.5.0:hrSystemNumUsers:0:0' '.1.3.6.1.2.1.25.1.6.0:hrSystemProcesses:0:0' '.1.3.6.1.4.1.8072.1.3.2.3.1.2.4.101.99.104.111:echo:0:0' | graphite-metric-test -f rule.txt
 status=$?
 
 docker stop "test-$plugin"

--- a/mackerel-plugin-snmp/testdata/snmpd.conf
+++ b/mackerel-plugin-snmp/testdata/snmpd.conf
@@ -1,4 +1,7 @@
 view   systemonly  included   .1.3.6.1.2.1.1
 view   systemonly  included   .1.3.6.1.2.1.25.1
+view   systemonly  included   .1.3.6.1.4.1.8072.1.3.2.3.1.2.4
 
 rocommunity public  default    -V systemonly
+
+extend echo /bin/echo '3.14'


### PR DESCRIPTION
I found mackerel-plugin-snmp failed to parse a number of STRING type from SNMP device, like `strconv.ParseFloat: parsing "[51 46 49 52]": invalid syntax`.
For example, original value from SNMP device is '3.14', and `51 46 49 52` seems the byte array of '3.14'.
Because it is usually impossible to change a type on the SNMP device side, the receiver has a responsiblity to accept it.

Here is a patch to support STRING number.

- `parseFloat` again for byte array with forcing String conversion by `fmt.Sprintf('%s'` only if the parsing failed first. `resp.Variables[0].Value` may be vary, so original first `fmt.Sprint(resp.Variables[0].Value)` works well, except a byte array of string.
- To test it, extend command is added. It will back STRING 3.14. `.1.3.6.1.4.1.8072.1.3.2.3.1.2.4.101.99.104.111 = STRING: 3.14`

Result of test.sh
Before:
```
2024/03/29 08:47:18 strconv.ParseFloat: parsing "[51 46 49 52]": invalid syntax
graphite-metric-test: <stdin>: rule snmp.echo[>0] is not matched any metrics
test-mackerel-plugin-snmp
test-mackerel-plugin-snmp
```

After:
```
test-mackerel-plugin-snmp
test-mackerel-plugin-snmp
```
