### PR TITLE
[plugin-mailq] mailq/postfix: Fix mail queue count regexp capture when it's `1`

### DIFF
--- a/mackerel-plugin-mailq/lib/fixtures/postqueue
+++ b/mackerel-plugin-mailq/lib/fixtures/postqueue
@@ -5,7 +5,7 @@
 [[ $1 != -p ]] && exit 1
 
 TEST_MAILQ_COUNT=${TEST_MAILQ_COUNT:-0}
-POSTQUEUE_REQUEST_LABEL="Request"
+POSTQUEUE_REQUEST_LABEL="Requests"
 
 if [[ $TEST_MAILQ_COUNT -eq 1 ]]; then
     POSTQUEUE_REQUEST_LABEL="Request"

--- a/mackerel-plugin-mailq/lib/fixtures/postqueue
+++ b/mackerel-plugin-mailq/lib/fixtures/postqueue
@@ -5,6 +5,12 @@
 [[ $1 != -p ]] && exit 1
 
 TEST_MAILQ_COUNT=${TEST_MAILQ_COUNT:-0}
+POSTQUEUE_REQUEST_LABEL="Request"
+
+if [[ $TEST_MAILQ_COUNT -eq 1 ]]; then
+    POSTQUEUE_REQUEST_LABEL="Request"
+fi
+
 if [[ $TEST_MAILQ_COUNT -ne 0 ]]; then
     cat <<EOF
 -Queue ID- --Size-- ----Arrival Time---- -Sender/Recipient-------
@@ -18,7 +24,7 @@ DD0C740001C      274 Thu Mar  3 23:52:37  foobar@example.com
 EOF
     done
     cat <<EOF
--- 15 Kbytes in ${TEST_MAILQ_COUNT} Requests.
+-- 15 Kbytes in ${TEST_MAILQ_COUNT} ${POSTQUEUE_REQUEST_LABEL}.
 EOF
 else
     cat <<EOF

--- a/mackerel-plugin-mailq/lib/main.go
+++ b/mackerel-plugin-mailq/lib/main.go
@@ -28,7 +28,7 @@ var mailqFormats = map[string]mailq{
 		command: "postqueue",
 		args:    []string{"-p"},
 		line:    -1,
-		pattern: `-- \d+ Kbytes in (\d+) Requests\.`,
+		pattern: `-- \d+ Kbytes in (\d+) (?:Request|Requests)\.`,
 	},
 	"qmail": {
 		command: "qmail-qstat",

--- a/mackerel-plugin-mailq/lib/main_test.go
+++ b/mackerel-plugin-mailq/lib/main_test.go
@@ -290,7 +290,9 @@ func TestFetchMetricsPostfix(t *testing.T) {
 	for _, tc := range []struct {
 		mailqCount int
 	}{
-		{mailqCount: 42}, {mailqCount: 0}, {mailqCount: 1},
+		{mailqCount: 42},
+		{mailqCount: 0},
+		{mailqCount: 1}, // #1185
 	} {
 		os.Setenv("TEST_MAILQ_COUNT", strconv.Itoa(tc.mailqCount))
 		defer os.Unsetenv("TEST_MAILQ_COUNT")

--- a/mackerel-plugin-mailq/lib/main_test.go
+++ b/mackerel-plugin-mailq/lib/main_test.go
@@ -5,6 +5,7 @@ package mpmailq
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -286,15 +287,19 @@ func TestFetchMetricsPostfix(t *testing.T) {
 		labelPrefix: "Mailq",
 	}
 
-	{
-		os.Setenv("TEST_MAILQ_COUNT", "42")
+	for _, tc := range []struct {
+		mailqCount int
+	}{
+		{mailqCount: 42}, {mailqCount: 0}, {mailqCount: 1},
+	} {
+		os.Setenv("TEST_MAILQ_COUNT", strconv.Itoa(tc.mailqCount))
 		defer os.Unsetenv("TEST_MAILQ_COUNT")
 
 		metrics, err := plugin.FetchMetrics()
 		if err != nil {
 			t.Errorf("Error %s", err.Error())
 		}
-		if metrics["count"].(uint64) != 42 {
+		if metrics["count"].(uint64) != uint64(tc.mailqCount) {
 			t.Errorf("Incorrect value: %d", metrics["count"].(uint64))
 		}
 	}

--- a/mackerel-plugin-mailq/lib/main_test.go
+++ b/mackerel-plugin-mailq/lib/main_test.go
@@ -172,6 +172,25 @@ DD0C740001C      274 Thu Mar  3 23:52:37  foobar@example.com
 		}
 	}
 
+	// #1185
+	{
+		output := `-Queue ID- --Size-- ----Arrival Time---- -Sender/Recipient-------
+DD0C740001C      274 Thu Mar  3 23:52:37  foobar@example.com
+          (connect to mail.invalid[192.0.2.100]:25: Connection timed out)
+                                         nyao@mail.invalid
+
+-- 1 Kbytes in 1 Request.
+`
+
+		count, err := mailq.parse(strings.NewReader(output))
+		if err != nil {
+			t.Errorf("Error in parseMailq: %s", err.Error())
+		}
+		if count != 1 {
+			t.Errorf("Incorrect parse result %d", count)
+		}
+	}
+
 	{
 		output := `Mail queue is empty
 `


### PR DESCRIPTION
Fixes #1185 

This PR fixes the mail queue count regexp capture for Postfix when there's only 1 item in the mail queue.

**Note/Update**: The tests in the package modified are passing as I've tested them locally.