### PR TITLE
[mackerel-plugin-php-fpm] add slow_requests_delta metrics because slow_requests is a counter

### DIFF
--- a/mackerel-plugin-php-fpm/lib/php-fpm.go
+++ b/mackerel-plugin-php-fpm/lib/php-fpm.go
@@ -182,7 +182,8 @@ func (p PhpFpmPlugin) GraphDefinition() map[string]mp.Graphs {
 			Label: p.LabelPrefix + " Slow Requests",
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
-				{Name: "slow_requests", Label: "Slow Requests", Diff: false, Type: "uint64"},
+				{Name: "slow_requests", Label: "Slow Requests Counter", Diff: false, Type: "uint64"},
+				{Name: "slow_requests_delta", Label: "Slow Requests Delta", Diff: true, Type: "uint64"},
 			},
 		},
 	}
@@ -205,6 +206,7 @@ func (p PhpFpmPlugin) FetchMetrics() (map[string]interface{}, error) {
 		"listen_queue_len":     status.ListenQueueLen,
 		"max_listen_queue":     status.MaxListenQueue,
 		"slow_requests":        status.SlowRequests,
+		"slow_requests_delta":  status.SlowRequests,
 	}, nil
 }
 


### PR DESCRIPTION
`slow_requests` metric is counter. cf.) https://www.php.net/manual/en/fpm.status.php#:~:text=The%20total%20number%20of%20requests%20that%20have%20hit%20the%20configured%20request_slowlog_timeout.

In monitoring, we are often more interested in the increment than in the raw slow requests number. So, I added a slow_requests_delta metric that outputs the difference values of slow_requests.

```console
$ sudo ./mackerel-plugin-php-fpm -socket /var/run/php/php-fpm.sock
php-fpm.processes.total_processes	2	1719783877
php-fpm.processes.active_processes	1	1719783877
php-fpm.processes.idle_processes	1	1719783877
php-fpm.max_active_processes.max_active_processes	1	1719783877
php-fpm.max_children_reached.max_children_reached	0	1719783877
php-fpm.queue.listen_queue	0	1719783877
php-fpm.queue.listen_queue_len	0	1719783877
php-fpm.max_listen_queue.max_listen_queue	0	1719783877
php-fpm.slow_requests.slow_requests	0	1719783877
2024/07/01 06:44:37 slow_requests_delta does not exist at last fetch
$ sudo ./mackerel-plugin-php-fpm -socket /var/run/php/php-fpm.sock
php-fpm.max_children_reached.max_children_reached	0	1719783900
php-fpm.queue.listen_queue	0	1719783900
php-fpm.queue.listen_queue_len	0	1719783900
php-fpm.max_listen_queue.max_listen_queue	0	1719783900
php-fpm.slow_requests.slow_requests	0	1719783900
php-fpm.slow_requests.slow_requests_delta	0.000000	1719783900
php-fpm.processes.total_processes	2	1719783900
php-fpm.processes.active_processes	1	1719783900
php-fpm.processes.idle_processes	1	1719783900
php-fpm.max_active_processes.max_active_processes	1	1719783900
```