### PR TITLE
[mackerel-plugin-snmp] support 32bit counter overflow.

### DIFF
--- a/mackerel-plugin-snmp/README.md
+++ b/mackerel-plugin-snmp/README.md
@@ -7,9 +7,18 @@ SNMP V2c custom metrics plugin for mackerel.io agent.
 can specify multiple metric-definitions in the form of `OID:NAME[:DIFF?][:STACK?]` args.
 
 ```shell
-mackerel-plugin-snmp [-name=<graph-name>] [-unit=<graph-unit>] [-host=<host>] [-community=<snmp-v2c-community>] [-tempfile=<tempfile>] 'OID:NAME[:DIFF?][:STACK?]' ['OID:NAME[:DIFF?][:STACK?]' ...]
+mackerel-plugin-snmp [-name=<graph-name>] [-unit=<graph-unit>] [-host=<host>] [-community=<snmp-v2c-community>] [-tempfile=<tempfile>] 'OID:NAME[:DIFF?][:STACK?]' ['OID:NAME[:DIFF?][:STACK?][:COUNTER?]' ...]
  
 ```
+
+### What is the argument `COUNTER`
+
+If the value is a 32-bit counter, specify uint32.
+
+supported types:
+
+- uint32
+- uint64
 
 ## Example of mackerel-agent.conf
 

--- a/mackerel-plugin-snmp/lib/snmp.go
+++ b/mackerel-plugin-snmp/lib/snmp.go
@@ -118,6 +118,16 @@ func Do() {
 		if len(vals) >= 4 {
 			mpm.Stacked, _ = strconv.ParseBool(vals[3])
 		}
+		if len(vals) >= 5 {
+			switch vals[4] {
+			case "uint64":
+				mpm.Type = "uint64"
+			case "uint32":
+				mpm.Type = "uint32"
+			default:
+				// do nothing
+			}
+		}
 
 		sms = append(sms, SNMPMetrics{OID: vals[0], Metrics: mpm})
 	}


### PR DESCRIPTION
I did it.

It is useful in cases such as ifInOctets `1.3.6.1.2.1.2.2.1.10.(ifIndex)`.