### PR TITLE
[plugin-aws-ec2-ebs] add actions to README need to be allowed in the iam policy

### DIFF
--- a/mackerel-plugin-aws-ec2-ebs/README.md
+++ b/mackerel-plugin-aws-ec2-ebs/README.md
@@ -14,7 +14,12 @@ mackerel-plugin-aws-ec2-ebs [-instance-id=<id>] [-region=<aws-region>] [-access-
 * you can set keys by environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (see https://github.com/aws/aws-sdk-go#configuring-credentials)
 
 ## AWS IAM Policy
-the credential provided manually or fetched automatically with IAM Role, should have the policy that includes an action, `cloudwatch:GetMetricStatistics` and `ec2:DescribeVolumes`
+the credential provided manually or fetched automatically with IAM Role, should have the policy that allows actions below.
+
+* `cloudwatch:GetMetricStatistics`
+* `ec2:DescribeInstanceTypes`
+* `ec2:DescribeInstances`
+* `ec2:DescribeVolumes`
 
 ## Example of mackerel-agent.conf
 


### PR DESCRIPTION
I've been setting up mackerel agent with aws-ec2-ebs plugin according to README, and was faced with insufficient AWS IAM policy attachment.

I've recieved two error messages (several ids are masked) and now it turned out that two essential actions (`ec2:DescribeInstanceTypes` and `ec2:DescribeInstances`) are not mentioned on README for aws-ec2-ebs plugin. So this PR fixes it.

```
Aug 28 07:48:10 ip-10-0-0-100 mackerel-agent[409653]: 2024/08/28 07:48:10 INFO <metrics.plugin> command mackerel-plugin-aws-ec2-ebs outputted to STDERR: "2024/08/28 07:48:10 UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::123456789012:assumed-role/my-role/i-01234567890abcdef is not authorized to perform: ec2:DescribeInstanceTypes because no identity-based policy allows the ec2:DescribeInstanceTypes action\n\tstatus code: 403, request id: c129b45e-410a-4be8-998c-681a127db319\n"
```

```
Aug 28 07:42:00 ip-10-0-0-100 mackerel-agent[408819]: 2024/08/28 07:42:00 INFO <metrics.plugin> command mackerel-plugin-aws-ec2-ebs outputted to STDERR: "2024/08/28 07:42:00 UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::123456789012:assumed-role/my-role/i-01234567890abcdef is not authorized to perform: ec2:DescribeInstances because no identity-based policy allows the ec2:DescribeInstances action\n\tstatus code: 403, request id: 99962773-9682-4b1d-922f-79184f2252a5\n"
```