### PR TITLE
[jvm] add prefix option

### DIFF
--- a/mackerel-plugin-jvm/README.md
+++ b/mackerel-plugin-jvm/README.md
@@ -26,7 +26,7 @@ user = "SOME_USER_NAME"
 This plugin can retrieve metrics from remote jstatd with rmi protocol by setting `-remote` option.
 In this case, following limitations are applied:
 - jps and jstat commands must be executable localy from this plugin
-- CMS Initiating Occupancy Fraction' metric cannot be retrieved remotely
+- 'CMS Initiating Occupancy Fraction' metric cannot be retrieved remotely
 
 ## About javaname
 

--- a/mackerel-plugin-jvm/README.md
+++ b/mackerel-plugin-jvm/README.md
@@ -6,7 +6,7 @@ JVM(jstat) custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-jvm -javaname=<javaname> [-pidfile=</path/to/pidfile>] [-jstatpath=</path/to/jstat] [-jpspath=/path/to/jps] [-jinfopath=/path/to/jinfo] [-remote=<host:port>]
+mackerel-plugin-jvm -javaname=<javaname> [-pidfile=</path/to/pidfile>] [-jstatpath=</path/to/jstat] [-jpspath=/path/to/jps] [-jinfopath=/path/to/jinfo] [-remote=<host:port>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<prefix>]
 ```
 
 ## Requirements
@@ -26,7 +26,7 @@ user = "SOME_USER_NAME"
 This plugin can retrieve metrics from remote jstatd with rmi protocol by setting `-remote` option.
 In this case, following limitations are applied:
 - jps and jstat commands must be executable localy from this plugin
-- 'CMS Initiating Occupancy Fraction' metric cannot be retrieved remotely
+- CMS Initiating Occupancy Fraction' metric cannot be retrieved remotely
 
 ## About javaname
 
@@ -39,7 +39,7 @@ You can check javaname by jps command.
 ```
 
 Please choose an arbitrary name as `javaname` when you use `pidfile` option.
-It is just used as a prefix of graph label.
+It is used as a prefix of graph label.
 
 ## User to execute this plugin
 
@@ -53,6 +53,7 @@ When the JVM option is enabled, this plugin is no longer able to work because wh
 
 ## References
 
+- [Metric plugins - mackerel-plugin-jvm - Mackerel Docs](https://mackerel.io/docs/entry/plugins/mackerel-plugin-jvm)
 - https://github.com/sensu/sensu-community-plugins/blob/master/plugins/java/jstat-metrics.py
 - http://docs.oracle.com/javase/7/docs/technotes/tools/share/jstat.html
 - https://github.com/kazeburo/jstat2gf

--- a/mackerel-plugin-jvm/README.md
+++ b/mackerel-plugin-jvm/README.md
@@ -38,8 +38,7 @@ You can check javaname by jps command.
 14822 Jps
 ```
 
-Please choose an arbitrary name as `javaname` when you use `pidfile` option.
-It is used as a graph label.
+Please choose an arbitrary name as `javaname` when you use `pidfile` option. It is used as a mertric name and graph label.
 
 ## User to execute this plugin
 

--- a/mackerel-plugin-jvm/README.md
+++ b/mackerel-plugin-jvm/README.md
@@ -6,7 +6,7 @@ JVM(jstat) custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-jvm -javaname=<javaname> [-pidfile=</path/to/pidfile>] [-jstatpath=</path/to/jstat] [-jpspath=/path/to/jps] [-jinfopath=/path/to/jinfo] [-remote=<host:port>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<prefix>]
+mackerel-plugin-jvm -javaname=<javaname> [-pidfile=</path/to/pidfile>] [-jstatpath=</path/to/jstat] [-jpspath=/path/to/jps] [-jinfopath=/path/to/jinfo] [-remote=<host:port>] [-metric-key=<metric key>] [-metric-label=<metric label>]
 ```
 
 ## Requirements
@@ -39,7 +39,7 @@ You can check javaname by jps command.
 ```
 
 Please choose an arbitrary name as `javaname` when you use `pidfile` option.
-It is used as a prefix of graph label.
+It is used as a graph label.
 
 ## User to execute this plugin
 

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -249,14 +249,14 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 		metricLabel = m.JavaName
 	}
 
-	lowerMetricKey := m.MetricKey
-	if lowerMetricKey == "" {
-		lowerMetricKey = m.JavaName
+	javaName := m.MetricKey
+	if javaName == "" {
+		javaName = m.JavaName
 	}
-	lowerMetricKey = strings.ToLower(lowerMetricKey)
+	lowerJavaName := strings.ToLower(javaName)
 
 	return map[string]mp.Graphs{
-		fmt.Sprintf("jvm.%s.gc_events", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.gc_events", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s GC events", metricLabel),
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
@@ -265,7 +265,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CGC", Label: "Concurrent GC event", Diff: true},
 			},
 		},
-		fmt.Sprintf("jvm.%s.gc_time", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.gc_time", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s GC time (sec)", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -274,7 +274,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CGCT", Label: "Concurrent GC time", Diff: true},
 			},
 		},
-		fmt.Sprintf("jvm.%s.gc_time_percentage", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.gc_time_percentage", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s GC time percentage", metricLabel),
 			Unit:  "percentage",
 			Metrics: []mp.Metrics{
@@ -284,7 +284,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CGCT", Label: "Concurrent GC time", Diff: true, Scale: (100.0 / 60)},
 			},
 		},
-		fmt.Sprintf("jvm.%s.new_space", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.new_space", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s New Space memory", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -295,7 +295,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "S1U", Label: "Survivor1 used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.old_space", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.old_space", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s Old Space memory", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -304,7 +304,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "OU", Label: "Old used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.perm_space", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.perm_space", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s Permanent Space", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -313,7 +313,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "PU", Label: "Perm used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.metaspace", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.metaspace", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s Metaspace", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -325,7 +325,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CCSU", Label: "Compressed Class Space Used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.memorySpace", lowerMetricKey): {
+		fmt.Sprintf("jvm.%s.memorySpace", lowerJavaName): {
 			Label: fmt.Sprintf("JVM %s MemorySpace", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -245,7 +245,15 @@ func (m JVMPlugin) FetchMetrics() (map[string]interface{}, error) {
 // GraphDefinition interface for mackerelplugin
 func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 	labelPrefix := m.LabelPrefix
-	lowerJavaName := strings.ToLower(m.Prefix)
+	if labelPrefix == "" {
+		labelPrefix = m.JavaName
+	}
+
+	lowerJavaName := m.Prefix
+	if lowerJavaName == "" {
+		lowerJavaName = m.JavaName
+	}
+	lowerJavaName = strings.ToLower(lowerJavaName)
 
 	return map[string]mp.Graphs{
 		fmt.Sprintf("jvm.%s.gc_events", lowerJavaName): {
@@ -414,16 +422,8 @@ func Do() {
 	}
 
 	jvm.JavaName = *optJavaName
-
 	jvm.Prefix = *optKeyPrefix
-	if jvm.Prefix == "" {
-		jvm.Prefix = jvm.JavaName
-	}
-
 	jvm.LabelPrefix = *optLabelPrefix
-	if jvm.LabelPrefix == "" {
-		jvm.LabelPrefix = jvm.JavaName
-	}
 
 	helper := mp.NewMackerelPlugin(jvm)
 	helper.Tempfile = *optTempfile

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -249,14 +249,14 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 		metricLabel = m.JavaName
 	}
 
-	lowerJavaName := m.MetricKey
-	if lowerJavaName == "" {
-		lowerJavaName = m.JavaName
+	lowerMetricKey := m.MetricKey
+	if lowerMetricKey == "" {
+		lowerMetricKey = m.JavaName
 	}
-	lowerJavaName = strings.ToLower(lowerJavaName)
+	lowerMetricKey = strings.ToLower(lowerMetricKey)
 
 	return map[string]mp.Graphs{
-		fmt.Sprintf("jvm.%s.gc_events", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.gc_events", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s GC events", metricLabel),
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
@@ -265,7 +265,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CGC", Label: "Concurrent GC event", Diff: true},
 			},
 		},
-		fmt.Sprintf("jvm.%s.gc_time", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.gc_time", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s GC time (sec)", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -274,7 +274,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CGCT", Label: "Concurrent GC time", Diff: true},
 			},
 		},
-		fmt.Sprintf("jvm.%s.gc_time_percentage", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.gc_time_percentage", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s GC time percentage", metricLabel),
 			Unit:  "percentage",
 			Metrics: []mp.Metrics{
@@ -284,7 +284,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CGCT", Label: "Concurrent GC time", Diff: true, Scale: (100.0 / 60)},
 			},
 		},
-		fmt.Sprintf("jvm.%s.new_space", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.new_space", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s New Space memory", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -295,7 +295,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "S1U", Label: "Survivor1 used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.old_space", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.old_space", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s Old Space memory", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -304,7 +304,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "OU", Label: "Old used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.perm_space", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.perm_space", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s Permanent Space", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -313,7 +313,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "PU", Label: "Perm used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.metaspace", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.metaspace", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s Metaspace", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
@@ -325,7 +325,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "CCSU", Label: "Compressed Class Space Used", Diff: false, Scale: 1024},
 			},
 		},
-		fmt.Sprintf("jvm.%s.memorySpace", lowerJavaName): {
+		fmt.Sprintf("jvm.%s.memorySpace", lowerMetricKey): {
 			Label: fmt.Sprintf("JVM %s MemorySpace", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{

--- a/mackerel-plugin-jvm/lib/jvm.go
+++ b/mackerel-plugin-jvm/lib/jvm.go
@@ -24,8 +24,8 @@ type JVMPlugin struct {
 	JinfoPath   string
 	JavaName    string
 	Tempfile    string
-	Prefix      string
-	LabelPrefix string
+	MetricKey   string
+	MetricLabel string
 }
 
 // # jps
@@ -244,12 +244,12 @@ func (m JVMPlugin) FetchMetrics() (map[string]interface{}, error) {
 
 // GraphDefinition interface for mackerelplugin
 func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
-	labelPrefix := m.LabelPrefix
-	if labelPrefix == "" {
-		labelPrefix = m.JavaName
+	metricLabel := m.MetricLabel
+	if metricLabel == "" {
+		metricLabel = m.JavaName
 	}
 
-	lowerJavaName := m.Prefix
+	lowerJavaName := m.MetricKey
 	if lowerJavaName == "" {
 		lowerJavaName = m.JavaName
 	}
@@ -257,7 +257,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 
 	return map[string]mp.Graphs{
 		fmt.Sprintf("jvm.%s.gc_events", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s GC events", labelPrefix),
+			Label: fmt.Sprintf("JVM %s GC events", metricLabel),
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
 				{Name: "YGC", Label: "Young GC event", Diff: true},
@@ -266,7 +266,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.gc_time", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s GC time (sec)", labelPrefix),
+			Label: fmt.Sprintf("JVM %s GC time (sec)", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "YGCT", Label: "Young GC time", Diff: true},
@@ -275,7 +275,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.gc_time_percentage", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s GC time percentage", labelPrefix),
+			Label: fmt.Sprintf("JVM %s GC time percentage", metricLabel),
 			Unit:  "percentage",
 			Metrics: []mp.Metrics{
 				// gc_time_percentage is the percentage of gc time to 60 sec.
@@ -285,7 +285,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.new_space", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s New Space memory", labelPrefix),
+			Label: fmt.Sprintf("JVM %s New Space memory", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "NGCMX", Label: "New max", Diff: false, Scale: 1024},
@@ -296,7 +296,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.old_space", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s Old Space memory", labelPrefix),
+			Label: fmt.Sprintf("JVM %s Old Space memory", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "OGCMX", Label: "Old max", Diff: false, Scale: 1024},
@@ -305,7 +305,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.perm_space", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s Permanent Space", labelPrefix),
+			Label: fmt.Sprintf("JVM %s Permanent Space", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "PGCMX", Label: "Perm max", Diff: false, Scale: 1024},
@@ -314,7 +314,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.metaspace", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s Metaspace", labelPrefix),
+			Label: fmt.Sprintf("JVM %s Metaspace", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "MCMX", Label: "Metaspace capacity max", Diff: false, Scale: 1024},
@@ -326,7 +326,7 @@ func (m JVMPlugin) GraphDefinition() map[string]mp.Graphs {
 			},
 		},
 		fmt.Sprintf("jvm.%s.memorySpace", lowerJavaName): {
-			Label: fmt.Sprintf("JVM %s MemorySpace", labelPrefix),
+			Label: fmt.Sprintf("JVM %s MemorySpace", metricLabel),
 			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "oldSpaceRate", Label: "GC Old Memory Space", Diff: false},
@@ -384,8 +384,8 @@ func Do() {
 	optJavaName := flag.String("javaname", "", "Java app name")
 	optPidFile := flag.String("pidfile", "", "pidfile path")
 	optTempfile := flag.String("tempfile", "", "Temp file name")
-	optKeyPrefix := flag.String("metric-key-prefix", "", "Metric key prefix")
-	optLabelPrefix := flag.String("metric-label-prefix", "", "Metric label prefix")
+	optMetricKey := flag.String("metric-key", "", "Specifying the Name field in the Graph Definition")
+	optMetricLabel := flag.String("metric-label", "", "Specifying the Label field in the Graph Definition")
 	flag.Parse()
 
 	var jvm JVMPlugin
@@ -422,8 +422,8 @@ func Do() {
 	}
 
 	jvm.JavaName = *optJavaName
-	jvm.Prefix = *optKeyPrefix
-	jvm.LabelPrefix = *optLabelPrefix
+	jvm.MetricKey = *optMetricKey
+	jvm.MetricLabel = *optMetricLabel
 
 	helper := mp.NewMackerelPlugin(jvm)
 	helper.Tempfile = *optTempfile

--- a/mackerel-plugin-jvm/lib/jvm_test.go
+++ b/mackerel-plugin-jvm/lib/jvm_test.go
@@ -124,8 +124,8 @@ func TestGraphDefinition(t *testing.T) {
 		{
 			plugin: JVMPlugin{
 				JavaName:    "Tomcat",
-				Prefix:      "foo.bar",
-				LabelPrefix: "Hoge Fuga",
+				MetricKey:   "foo.bar",
+				MetricLabel: "Hoge Fuga",
 			},
 			expectedKey:   "jvm.foo.bar.gc_events",
 			expectedLabel: "JVM Hoge Fuga GC events",
@@ -133,15 +133,15 @@ func TestGraphDefinition(t *testing.T) {
 		{
 			plugin: JVMPlugin{
 				JavaName:    "Tomcat",
-				LabelPrefix: "Hoge Fuga",
+				MetricLabel: "Hoge Fuga",
 			},
 			expectedKey:   "jvm.tomcat.gc_events",
 			expectedLabel: "JVM Hoge Fuga GC events",
 		},
 		{
 			plugin: JVMPlugin{
-				JavaName: "Tomcat",
-				Prefix:   "foo.bar",
+				JavaName:  "Tomcat",
+				MetricKey: "foo.bar",
 			},
 			expectedKey:   "jvm.foo.bar.gc_events",
 			expectedLabel: "JVM Tomcat GC events",

--- a/mackerel-plugin-jvm/lib/jvm_test.go
+++ b/mackerel-plugin-jvm/lib/jvm_test.go
@@ -107,3 +107,56 @@ func TestFetchMetrics(t *testing.T) {
 		t.Errorf("fetchMetrics('-gc') = %v; want %v", actual, expected)
 	}
 }
+
+func TestGraphDefinition(t *testing.T) {
+	tests := []struct {
+		plugin        JVMPlugin
+		expectedKey   string
+		expectedLabel string
+	}{
+		{
+			plugin: JVMPlugin{
+				JavaName: "Tomcat",
+			},
+			expectedKey:   "jvm.tomcat.gc_events",
+			expectedLabel: "JVM Tomcat GC events",
+		},
+		{
+			plugin: JVMPlugin{
+				JavaName:    "Tomcat",
+				Prefix:      "foo.bar",
+				LabelPrefix: "Hoge Fuga",
+			},
+			expectedKey:   "jvm.foo.bar.gc_events",
+			expectedLabel: "JVM Hoge Fuga GC events",
+		},
+		{
+			plugin: JVMPlugin{
+				JavaName:    "Tomcat",
+				LabelPrefix: "Hoge Fuga",
+			},
+			expectedKey:   "jvm.tomcat.gc_events",
+			expectedLabel: "JVM Hoge Fuga GC events",
+		},
+		{
+			plugin: JVMPlugin{
+				JavaName: "Tomcat",
+				Prefix:   "foo.bar",
+			},
+			expectedKey:   "jvm.foo.bar.gc_events",
+			expectedLabel: "JVM Tomcat GC events",
+		},
+	}
+
+	for _, tt := range tests {
+		graphDefs := tt.plugin.GraphDefinition()
+
+		metric, ok := graphDefs[tt.expectedKey]
+		if !ok {
+			t.Errorf("expected to have key %s but not found", tt.expectedKey)
+		}
+		if metric.Label != tt.expectedLabel {
+			t.Errorf("expected to have label %s but got: %s", tt.expectedLabel, metric.Label)
+		}
+	}
+}


### PR DESCRIPTION
The mackerel-plugin-jvm monitors the application specified in --javaname, but there is an issue that it can only monitor one of the applications if there are multiple applications with the same name. I would like to solve this issue by making it possible to use --metric-key-prefix and --metric-label-prefix.

```
# /usr/local/bin/mackerel-plugin-jvm -javaname Bootstrap -metric-key-prefix tomcat-ex -metric-label-prefix tomcat-ex --pidfile /usr/local/src/tomcat-ex/temp/tomcat.pid
jvm.tomcat-ex.new_space.NGCMX	1025507328.000000	1731999116
jvm.tomcat-ex.new_space.NGC	35651584.000000	1731999116
jvm.tomcat-ex.new_space.EU	18874368.000000	1731999116
jvm.tomcat-ex.new_space.S0U	0.000000	1731999116
jvm.tomcat-ex.new_space.S1U	4194304.000000	1731999116
jvm.tomcat-ex.old_space.OGCMX	1025507328.000000	1731999116
jvm.tomcat-ex.old_space.OGC	31457280.000000	1731999116
jvm.tomcat-ex.old_space.OU	5605888.000000	1731999116
jvm.tomcat-ex.metaspace.MCMX	1140850688.000000	1731999116
jvm.tomcat-ex.metaspace.MCMN	0.000000	1731999116
jvm.tomcat-ex.metaspace.MC	13369344.000000	1731999116
jvm.tomcat-ex.metaspace.MU	13096038.400000	1731999116
jvm.tomcat-ex.metaspace.CCSC	1507328.000000	1731999116
jvm.tomcat-ex.metaspace.CCSU	1363046.400000	1731999116
jvm.tomcat-ex.memorySpace.oldSpaceRate	17.820638	1731999116
jvm.tomcat-ex.memorySpace.newSpaceRate	64.705882	1731999116
jvm.tomcat-ex.gc_events.YGC	0.000000	1731999116
jvm.tomcat-ex.gc_events.FGC	0.000000	1731999116
jvm.tomcat-ex.gc_events.CGC	0.000000	1731999116
jvm.tomcat-ex.gc_time.YGCT	0.000000	1731999116
jvm.tomcat-ex.gc_time.FGCT	0.000000	1731999116
jvm.tomcat-ex.gc_time.CGCT	0.000000	1731999116
jvm.tomcat-ex.gc_time_percentage.YGCT	0.000000	1731999116
jvm.tomcat-ex.gc_time_percentage.FGCT	0.000000	1731999116
jvm.tomcat-ex.gc_time_percentage.CGCT	0.000000	1731999116
```

```
# MACKEREL_AGENT_PLUGIN_META=1 /usr/local/bin/mackerel-plugin-jvm -javaname Bootstrap -metric-key-prefix tomcat-ex -metric-label-prefix tomcat-ex --pidfile /usr/local/src/tomcat-ex/temp/tomcat.pid | grep -v "mackerel-agent-plugin" | jq
{
  "graphs": {
    "jvm.tomcat-ex.gc_events": {
      "label": "JVM tomcat-ex GC events",
      "unit": "integer",
      "metrics": [
        {
          "name": "YGC",
          "label": "Young GC event",
          "stacked": false
        },
        {
          "name": "FGC",
          "label": "Full GC event",
          "stacked": false
        },
        {
          "name": "CGC",
          "label": "Concurrent GC event",
          "stacked": false
        }
      ]
    },
```

- https://mackerel.io/orgs/masarasi-org/hosts/5edmqp8NvZ3/-/graphs/custom.jvm.tomcat.memorySpace.*#period=30m
- https://mackerel.io/orgs/masarasi-org/hosts/5edmqp8NvZ3/-/graphs/custom.jvm.tomcat-ex.memorySpace.*#period=30m