### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         go build -o mackerel-plugin-windows-server-sessions/mackerel-plugin-windows-server-sessions.exe ./mackerel-plugin-windows-server-sessions
   build:
     needs: [test, integration-test-linux]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - run: |


### PR DESCRIPTION
The CI for the master branch is failing due to the absence of the `build-essential:native` package, as seen in [this run](https://github.com/mackerelio/mackerel-agent-plugins/actions/runs/12500547540/job/34876951429). It appears that the cause is the change to Ubuntu 24.04, as the runner is specified to use ubuntu-latest in GHA.
This pull request specifies the runner to use ubuntu-22.04.