### PR TITLE
Add tar.gz packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,13 +46,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
-      - run: make clean rpm deb
+      - run: make clean rpm deb tar
       - uses: actions/upload-artifact@v4
         with:
           name: linux-build-artifacts
           path: |
             ~/rpmbuild/RPMS/*/*.rpm
             packaging/*.deb
+            packaging/tar/build/*.tar.gz
+
   release:
     needs: build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BINDIR  = build/$(GOOS)/$(GOARCH)
 export GO111MODULE=on
 
 .PHONY: all
-all: testconvention rpm deb
+all: testconvention rpm deb tar
 
 .SECONDEXPANSION:
 $(BINDIR)/mackerel-plugin-%: mackerel-plugin-%/main.go $$(wildcard mackerel-plugin-%/lib/*.go)
@@ -90,9 +90,26 @@ deb-v2-arm:
 	cp build/mackerel-plugin packaging/deb-v2/debian/
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us -aarm64
 
+.PHONY: tar
+tar: tar-x86 tar-arm
+
+.PHONY: tar-x86
+tar-x86:
+	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=amd64
+	mkdir -p packaging/tar/build/mackerel-agent-plugins-$(VERSION)-x86_64
+	cp README.md CHANGELOG.md build/mackerel-plugin packaging/tar/build/mackerel-agent-plugins-$(VERSION)-x86_64/
+	cd packaging/tar && VERSION=$(VERSION) ARCH=x86_64 ./build.sh
+
+.PHONY: tar-arm
+tar-arm:
+	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=arm64
+	mkdir -p packaging/tar/build/mackerel-agent-plugins-$(VERSION)-arm64
+	cp README.md CHANGELOG.md build/mackerel-plugin packaging/tar/build/mackerel-agent-plugins-$(VERSION)-arm64/
+	cd packaging/tar && VERSION=$(VERSION) ARCH=arm64 ./build.sh
+
 .PHONY: clean
 clean:
-	@if [ -d build ]; then rm -rfv build; fi
+	@if [ -d build ]; then rm -rfv build packaging/tar/build; fi
 
 .PHONY: update
 update:

--- a/packaging/tar/build.sh
+++ b/packaging/tar/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+cd build/mackerel-agent-plugins-${VERSION}-${ARCH}
+for i in accesslog apache2 aws-cloudfront aws-dynamodb aws-ec2-cpucredit aws-ec2-ebs aws-elasticache aws-elasticsearch aws-elb aws-kinesis-streams aws-lambda aws-rds aws-s3-requests aws-ses conntrack docker elasticsearch fluentd gostats h2o haproxy inode jmx-jolokia jvm linux mailq memcached mongodb multicore munin mysql nginx openldap php-apc php-fpm php-opcache plack postgres proc-fd rabbitmq redis sidekiq snmp solr squid td-table-count trafficserver twemproxy unicorn uptime uwsgi-vassal varnish; do \
+    ln -s ./mackerel-plugin mackerel-plugin-$i; \
+done
+cd ..
+tar czf mackerel-agent-plugins-${VERSION}-${ARCH}.tar.gz mackerel-agent-plugins-${VERSION}-${ARCH}


### PR DESCRIPTION
Hi. This PR adds support for building tar.gz release packages.

### motivation

We want to use the plain tar.gz packages instead of rpm or deb, similar to the mackerel-agent provided.

### usage

`make tar` builds tar.gz for release packages.
