### PR TITLE
git commit, version from runtime/debug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
           sudo apt-get install -y rpm devscripts debhelper fakeroot crossbuild-essential-arm64 build-essential
           mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: 1.24.x

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ _testmain.go
 *.exe
 *.test
 mackerel-plugin-*/mackerel-plugin-*
+
+packaging/*.deb

--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,14 @@ deb-v2-x86:
 	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=amd64
 	cp build/mackerel-plugin packaging/deb-v2/debian/
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us
+	git clean -f -d ./packaging
 
 .PHONY: deb-v2-arm
 deb-v2-arm:
 	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=arm64
 	cp build/mackerel-plugin packaging/deb-v2/debian/
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us -aarm64
+	git clean -f -d ./packaging
 
 .PHONY: tar
 tar: tar-x86 tar-arm

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ tar: tar-x86 tar-arm
 
 .PHONY: tar-x86
 tar-x86:
+	git clean -f -d ./packaging
 	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=amd64
 	mkdir -p packaging/tar/build/mackerel-agent-plugins-$(VERSION)-x86_64
 	cp README.md CHANGELOG.md build/mackerel-plugin packaging/tar/build/mackerel-agent-plugins-$(VERSION)-x86_64/
@@ -103,6 +104,7 @@ tar-x86:
 
 .PHONY: tar-arm
 tar-arm:
+	git clean -f -d ./packaging
 	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=arm64
 	mkdir -p packaging/tar/build/mackerel-agent-plugins-$(VERSION)-arm64
 	cp README.md CHANGELOG.md build/mackerel-plugin packaging/tar/build/mackerel-agent-plugins-$(VERSION)-arm64/

--- a/Makefile
+++ b/Makefile
@@ -79,17 +79,17 @@ deb: deb-v2-x86 deb-v2-arm
 
 .PHONY: deb-v2-x86
 deb-v2-x86:
+	git clean -f -d ./packaging
 	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=amd64
 	cp build/mackerel-plugin packaging/deb-v2/debian/
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us
-	git clean -f -d ./packaging
 
 .PHONY: deb-v2-arm
 deb-v2-arm:
+	git clean -f -d ./packaging
 	$(MAKE) build/mackerel-plugin GOOS=linux GOARCH=arm64
 	cp build/mackerel-plugin packaging/deb-v2/debian/
 	cd packaging/deb-v2 && debuild --no-tgz-check -rfakeroot -uc -us -aarm64
-	git clean -f -d ./packaging
 
 .PHONY: tar
 tar: tar-x86 tar-arm

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 VERSION = 0.88.1
 VERBOSE_FLAG = $(if $(VERBOSE),-verbose)
-CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 
 GOOS   ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -24,7 +23,7 @@ build:
 
 build/mackerel-plugin: $(patsubst %,depends_on,$(GOOS)$(GOARCH))
 	mkdir -p build
-	CGO_ENABLED=0 go build -ldflags="-s -w -X main.gitcommit=$(CURRENT_REVISION)" \
+	CGO_ENABLED=0 go build -ldflags="-s -w" \
 	  -o build/mackerel-plugin
 
 .PHONY: depends_on

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -61,6 +61,7 @@ func run(args []string) int {
 	return exitOK
 }
 
+// nolint
 const version = "0.88.1"
 
 func fromVCS() (version, rev string) {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
@@ -62,9 +63,25 @@ func run(args []string) int {
 
 const version = "0.88.1"
 
-var gitcommit string
+func fromVCS() (version, rev string) {
+	version = "unknown"
+	rev = "unknown"
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	version = info.Main.Version
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			rev = s.Value
+			return
+		}
+	}
+	return
+}
 
 func printHelp() {
+	version, gitcommit := fromVCS()
 	fmt.Printf(`mackerel-plugin %s (rev %s) [%s %s %s]
 
 Usage: mackerel-plugin <plugin> [<args>]


### PR DESCRIPTION
- Go 1.24 or above, can read package version from [BuildInfo](https://pkg.go.dev/runtime/debug#BuildInfo)
- also can use vcs.revision
- therefore we can remove build option `-X main.gitcommit`