### PR TITLE
The graph definition for mackerel-plugin-squid was broken.

### DIFF
--- a/mackerel-plugin-squid/lib/squid.go
+++ b/mackerel-plugin-squid/lib/squid.go
@@ -58,7 +58,7 @@ var graphdef = map[string]mp.Graphs{
 	},
 	"squid.memory_account_for": {
 		Label: "Squid Memory accounted for",
-		Unit:  "interger",
+		Unit:  "integer",
 		Metrics: []mp.Metrics{
 			{Name: "memory_poll_alloc", Label: "memPoolAlloc calls", Diff: true},
 			{Name: "memory_poll_free", Label: "memPoolFree calls", Diff: true},


### PR DESCRIPTION
## Why

When using mackerel-plugin-squid, the following error is output and the graph definition registration fails.
```
mackerel-agent[2399783]: 2025/06/27 09:42:57 agent.go:124: ERROR <agent> Failed to create graphdefs: API request failed: Invalid Parameter: obj[6].unit validate.error.unexpected.value.
```

## How

https://github.com/mackerelio/mackerel-agent-plugins/blob/1d93bfe9c97e5a2aa9a9c59123921b277bda10ca/mackerel-plugin-squid/lib/squid.go#L61
The correct term here is “integer.”

## operation check

I compared the output when `MACKEREL_AGENT_PLUGIN_META=1` and confirmed that it became an `integer`.
```
diff <(MACKEREL_AGENT_PLUGIN_META=1 mackerel-plugin-squid | tail -n +2 | jq .) <(MACKEREL_AGENT_PLUGIN_META=1 ./mackerel-plugin-squid |  tail -n +2 | jq .)
89c89
<       "unit": "interger",
---
>       "unit": "integer",
```

We built mackerel-plugin-squid with this fix incorporated and confirmed that the error no longer appears.



