### PR TITLE
Add -tls-skip-verify flag to nginx plugin

### DIFF
--- a/mackerel-plugin-nginx/README.md
+++ b/mackerel-plugin-nginx/README.md
@@ -6,7 +6,7 @@ Nginx custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-nginx [-header=<header>] [-host=<host>] [-path=<path>] [-port=<port>] [-scheme=<'http'|'https'>] [-tempfile=<tempfile>] [-uri=<uri>]
+mackerel-plugin-nginx [-header=<header>] [-host=<host>] [-path=<path>] [-port=<port>] [-scheme=<'http'|'https'>] [-tempfile=<tempfile>] [-tls-skip-verify] [-uri=<uri>]
 ```
 
 ## Requirements

--- a/mackerel-plugin-nginx/lib/nginx.go
+++ b/mackerel-plugin-nginx/lib/nginx.go
@@ -2,6 +2,7 @@ package mpnginx
 
 import (
 	"bufio"
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"io"
@@ -56,8 +57,9 @@ func (s *stringSlice) String() string {
 
 // NginxPlugin mackerel plugin for Nginx
 type NginxPlugin struct {
-	URI    string
-	Header stringSlice
+	URI           string
+	Header        stringSlice
+	TLSSkipVerify bool
 }
 
 // % wget -qO- http://localhost:8080/nginx_status
@@ -91,7 +93,14 @@ func (n NginxPlugin) FetchMetrics() (map[string]any, error) {
 		req.Header.Set("User-Agent", "mackerel-plugin-nginx")
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := http.Client{}
+	if n.TLSSkipVerify {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client.Transport = tr
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -184,6 +193,7 @@ func Do() {
 	optTempfile := flag.String("tempfile", "", "Temp file name")
 	optHeader := &stringSlice{}
 	flag.Var(optHeader, "header", "Set http header (e.g. \"Host: servername\")")
+	optTLSSkipVerify := flag.Bool("tls-skip-verify", false, "Skip TLS certificate verification")
 	flag.Parse()
 
 	var nginx NginxPlugin
@@ -192,6 +202,7 @@ func Do() {
 	} else {
 		nginx.URI = fmt.Sprintf("%s://%s:%s%s", *optScheme, *optHost, *optPort, *optPath)
 	}
+	nginx.TLSSkipVerify = *optTLSSkipVerify
 	nginx.Header = *optHeader
 
 	helper := mp.NewMackerelPlugin(nginx)

--- a/mackerel-plugin-nginx/lib/nginx_test.go
+++ b/mackerel-plugin-nginx/lib/nginx_test.go
@@ -58,7 +58,7 @@ func TestHTTP(t *testing.T) {
 	assert.EqualValues(t, stat["accepts"], 1693613501)
 }
 
-// TestHTTPSInsecure tests that FetchMetrics cannot fetch metrics from HTTPS endpoint when TLS certificate is invalid.
+// TestHTTPSWithInvalidCert tests that FetchMetrics cannot fetch metrics from HTTPS endpoint when TLS certificate is invalid.
 // This is the default behavior of this plugin.
 func TestHTTPSWithInvalidCert(t *testing.T) {
 	sv := httptest.NewTLSServer(

--- a/mackerel-plugin-nginx/lib/nginx_test.go
+++ b/mackerel-plugin-nginx/lib/nginx_test.go
@@ -3,6 +3,8 @@ package mpnginx
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -18,19 +20,78 @@ func TestGraphDefinition(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
-	var nginx NginxPlugin
-	stub := `Active connections: 123
+var responseStub = `Active connections: 123
 server accepts handled requests
  1693613501 1693613501 7996986318
 Reading: 66 Writing: 16 Waiting: 41
 `
 
+func TestParse(t *testing.T) {
+	var nginx NginxPlugin
+	stub := responseStub
 	nginxStats := bytes.NewBufferString(stub)
 
 	stat, err := nginx.parseStats(nginxStats)
 	fmt.Println(stat)
 	assert.Nil(t, err)
+	assert.EqualValues(t, reflect.TypeOf(stat["writing"]).String(), "float64")
+	assert.EqualValues(t, stat["writing"], 16)
+	assert.EqualValues(t, reflect.TypeOf(stat["accepts"]).String(), "float64")
+	assert.EqualValues(t, stat["accepts"], 1693613501)
+}
+
+func TestHTTP(t *testing.T) {
+	sv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, responseStub)
+		}),
+	)
+	defer sv.Close()
+
+	var nginx NginxPlugin
+	nginx.URI = sv.URL
+	stat, err := nginx.FetchMetrics()
+	assert.Nil(t, err)
+	assert.EqualValues(t, reflect.TypeOf(stat["writing"]).String(), "float64")
+	assert.EqualValues(t, stat["writing"], 16)
+	assert.EqualValues(t, reflect.TypeOf(stat["accepts"]).String(), "float64")
+	assert.EqualValues(t, stat["accepts"], 1693613501)
+}
+
+// TestHTTPSInsecure tests that FetchMetrics cannot fetch metrics from HTTPS endpoint when TLS certificate is invalid.
+// This is the default behavior of this plugin.
+func TestHTTPSWithInvalidCert(t *testing.T) {
+	sv := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, responseStub)
+		}),
+	)
+	defer sv.Close()
+
+	var nginx NginxPlugin
+	nginx.URI = sv.URL
+
+	stat, err := nginx.FetchMetrics()
+	assert.NotNil(t, err)
+	assert.Nil(t, stat)
+}
+
+// TestHTTPSInsecure tests that FetchMetrics returns metrics when the server has an invalid TLS certificate.
+func TestHTTPSInsecure(t *testing.T) {
+	sv := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, responseStub)
+		}),
+	)
+	defer sv.Close()
+
+	var nginx NginxPlugin
+	nginx.URI = sv.URL
+	nginx.TLSSkipVerify = true
+
+	stat, err := nginx.FetchMetrics()
+	assert.Nil(t, err)
+	assert.NotNil(t, stat)
 	assert.EqualValues(t, reflect.TypeOf(stat["writing"]).String(), "float64")
 	assert.EqualValues(t, stat["writing"], 16)
 	assert.EqualValues(t, reflect.TypeOf(stat["accepts"]).String(), "float64")


### PR DESCRIPTION
Hi!

When a nginx listens TLS only, mackerel-plugin-nginx fails with https://localhost/nginx_status with "tls: bad certificate".

This flag allows access to https servers with bad certificate.